### PR TITLE
GPU GEMM: rename gemm_ukernel→gemm_warp, gemm_gpu→gemm_kernel + worked examples

### DIFF
--- a/workspace/ceramic/ARCHITECTURE.md
+++ b/workspace/ceramic/ARCHITECTURE.md
@@ -127,6 +127,56 @@ steps 1–5 match CuTe `sgemm_1.cu` statement-by-statement: CTA coordinate,
 tiles, `local_partition` for thread data, `fillWith` to clear the accumulator,
 main loop of `copyFrom` + `gemm`, epilogue `axpby` (CuTe tutorial naming; the ceramic epilogue is `EpiAXPBY`, `src/kernel_gemm_epilogues.nim`).
 
+## GEMM thread organization — who owns what (worked example)
+
+The tensor-core GEMM levels differ in *who owns which state* as much as in what they compute.
+The levels are `gemm_atom`, `gemm_warp`, `gemm_tiled`, `gemm_cta` and `gemm_kernel`, defined in `src/kernel_gemm_gpu.nim`.
+The canonical worked example lives in that module's header.
+This section mirrors it so the partitioning is visible away from the kernel code.
+
+**Config (worked example):**
+- atom: m16n8k8
+- thread layout: (2, 2, 1)
+- tile: (32, 16, 32)
+- CTA: one tile, 128 lanes = 4 warps
+
+The same 32 lanes are the cooperation unit at both `gemm_atom` and `gemm_warp`.
+
+```
+CTA (gemm_cta)            128 lanes = 4 warps, owns the (32, 16) output tile
+  └─ warp (tm, tn) ∈ (2, 2)      [gemm_tiled partition]
+     owns the (16, 8) sub-tile: A rows tm·16..tm·16+16, B rows tn·8..tn·8+8
+     └─ lane l ∈ 0..31           [hardware fragment layouts]
+        owns V values per atom: A: 4, B: 2, C: 4
+```
+
+- `gemm_atom`: one `mma.sync`. The warp's 32 lanes jointly perform
+  one 16×8×8 MMA into their C fragment (16×8 = 128 values = 32 lanes × 4).
+- `gemm_warp`: the same 32 lanes loop kSlice = 0 ..< 4, with RepeatK = tileK/atomK = 32/8.
+  Each iteration issues one warp-wide `mma.sync` into the C fragment.
+  Per lane:
+  - A: (4, 1, 4)
+  - B: (2, 1, 4)
+  - C: (4, 1, 1)
+- The (2, 2, 1) thread layout never splits an atom across lanes:
+  it replicates the atom 2×2 = 4 times across the 4 warps, so the warps together cover the (32, 16) CTA tile.
+
+State/data flow (per CTA tile, one tileK-sized slice of K at a time):
+
+```
+gmem A (32, kView), B (16, kView)
+  ── gemm_cta cp.async ──▶ smem A (32, 32), B (16, 32)
+  ── gemm_tiled gather ──▶ lane registers A (4, 1, 4), B (2, 1, 4)
+  ── gemm_cta zeroes C (4, 1, 1) once, before the K-loop
+  ── gemm_warp 4× mma.sync ──▶ C (4, 1, 1) accumulated
+  ── gemm_cta epilogue ──▶ gmem D (32, 16)
+```
+
+**Terminology:**
+- **lane**: one thread (`threadIdx.x % 32`)
+- **warp**: 32 lanes, the unit that executes `mma.sync`
+- **CTA / threadblock**: the unit scheduled on one SM (`blockIdx`), made of warps
+
 ## Extension points
 
 - **New layout transform.** Add to `src/layouts.nim` (structural transforms) or

--- a/workspace/ceramic/src/kernel_gemm_gpu.nim
+++ b/workspace/ceramic/src/kernel_gemm_gpu.nim
@@ -11,10 +11,10 @@
 ##
 ##   gemm_atom    one Matrix-Multiply-Accumulate (MMA) instruction on a thread's register fragments,
 ##                accumulated in place.
-##   gemm_ukernel loop over atoms
+##   gemm_warp    loop over atoms
 ##   gemm_tiled   partition the shared memory tiles and move data into registers
 ##   gemm_cta     Copy data into shared memory, apply gemm_tiled, apply epilogue, store result into destination
-##   gemm_gpu     the GEMM with a fused epilogue
+##   gemm_kernel  the GEMM with a fused epilogue
 ##
 ## SM80 example in matryoshka-like diagram
 ##   - atom m16n8k8,
@@ -22,6 +22,10 @@
 ##   - tile (32, 16, 32),
 ##   - input (64, 32)
 ##   - grid (2, 2).
+##
+## This is the manual gemm_cta configuration: tile and thread layout are passed explicitly (as in the manual gemm_cta tests).
+## gemm_kernel derives them from the input instead.
+## A (64, 32) input yields thread layout (4, 4, 1), tile (64, 32, 32), grid (1, 1), 512 lanes = 16 warps.
 ##
 ## Fragment shapes:
 ##   a thread's register fragments are arrays, one per operand,
@@ -40,6 +44,48 @@
 ## The axes are register storage, not the GEMM's (M, N, K).
 ## The thread's output stays 2D, RepeatM·atomM × RepeatN·atomN,
 ## and K is the contraction dimension.
+##
+## Thread organization: who owns what (worked example)
+## ---------------------------------------------------
+## Config (worked example):
+##   - atom: m16n8k8
+##   - thread layout: (2, 2, 1)
+##   - tile: (32, 16, 32)
+##   - CTA: one tile, 128 lanes = 4 warps
+## The same 32 lanes are the cooperation unit at both gemm_atom and gemm_warp.
+##
+## Terminology:
+##   lane = one thread (threadIdx.x % 32),
+##   warp = 32 lanes (the unit that executes mma.sync),
+##   CTA = the unit scheduled on one SM (blockIdx).
+##
+##   CTA (gemm_cta)            128 lanes = 4 warps, owns the (32, 16) output tile
+##     └─ warp (tm, tn) ∈ (2, 2)      [gemm_tiled partition]
+##        owns the (16, 8) sub-tile: A rows tm·16..tm·16+16, B rows tn·8..tn·8+8
+##        └─ lane l ∈ 0..31           [hardware fragment layouts]
+##           owns V values per atom: A: 4, B: 2, C: 4
+##
+##   gemm_atom:  one mma.sync. The warp's 32 lanes jointly perform
+##               one 16×8×8 MMA into their C fragment
+##               (16×8 = 128 values = 32 lanes × 4).
+##   gemm_warp:  the same 32 lanes loop kSlice = 0 ..< 4, issuing
+##               one warp-wide mma.sync per k slice
+##               (RepeatK = tileK/atomK = 32/8), accumulating in place.
+##               Per lane:
+##                 A (4, 1, 4)
+##                 B (2, 1, 4)
+##                 C (4, 1, 1)
+##
+##   The (2, 2, 1) thread layout never splits an atom across lanes:
+##   it replicates the atom 2×2 = 4 times across the 4 warps, so the warps together cover the (32, 16) CTA tile.
+##
+## State/data flow (per CTA tile, one tileK-sized slice of K at a time):
+##   gmem A (32, kView), B (16, kView)
+##     ── gemm_cta cp.async ──▶ smem A (32, 32), B (16, 32)
+##     ── gemm_tiled gather ──▶ lane registers A (4, 1, 4), B (2, 1, 4)
+##     ── gemm_cta zeroes C (4, 1, 1) once, before the K-loop
+##     ── gemm_warp 4× mma.sync ──▶ C (4, 1, 1) accumulated
+##     ── gemm_cta epilogue ──▶ gmem D (32, 16)
 ##
 ##   grid: the (64, 32) input, tiled into (2, 2) CTA tiles of (32, 16)
 ##   - mCTA = blockIdx.x, rows
@@ -60,7 +106,7 @@
 ##   The loop over the K dimension iterates the
 ##   ceil(K/tileK) tileK-sized slices of K.
 ##   ┌──────────────────────────────────────────────────────────────┐
-##    CTA: one (32, 16) output tile, tiled into (2, 2) threads
+##    CTA: one (32, 16) output tile, tiled into (2, 2) warps
 ##    data: gmem → smem via cp.async:
 ##            A (32, kView)
 ##            B (16, kView)
@@ -69,17 +115,17 @@
 ##
 ##    (0,0)      (0,1)
 ##      ┌────────┐  ┌────────┐
-##      │ thread │  │ thread │
+##      │ warp   │  │ warp   │
 ##      │ (16, 8)│  │ (16, 8)│
 ##      └────────┘  └────────┘
 ##    (1,0)      (1,1)
 ##      ┌────────┐  ┌────────┐
-##      │ thread │  │ thread │
+##      │ warp   │  │ warp   │
 ##      │ (16, 8)│  │ (16, 8)│
 ##      └────────┘  └────────┘
 ##
 ##   ┌──────────────────────────────────────────────────────────────┐
-##   │  one thread (16, 8)                                          │
+##   │  one warp (16, 8)                                            │
 ##   │  data: per slice of K, fragments copied smem → registers     │
 ##   │         (V, RepeatM, RepeatK) × (V, RepeatN, RepeatK)        │
 ##   │ │ ┌──────────────────────────────────────────────────────┐ │ │
@@ -128,6 +174,14 @@ func gemm_atom*[TD, ShD, StD, TA, ShA, StA, TB, ShB, StB](
     bFrag: TensorView[TB, ShB, StB] or Tensor[TB, ShB, StB]) {.inline.} =
   ## Register-level MMA, in-place accumulate: dFrag += aFrag·bFrag.
   ##
+  ## One mma.sync, executed by the 32 lanes of a warp cooperatively.
+  ##
+  ## Worked example (m16n8k8, (2, 2, 1), tile (32, 16, 32), 128 lanes = 4 warps):
+  ##   each lane runs this call on its own register slice.
+  ##   The warp's 32 lanes together hold the atom's (16, 8) fragments
+  ##   (A: 4 values/lane, B: 2, C: 4), then jointly perform
+  ##   one 16×8×8 MMA into the warp's C fragment.
+  ##
   ## Args:
   ##   mma: the hardware instruction descriptor
   ##   dFrag: mutable register fragment tensor (V, RepeatM, RepeatN), the accumulator (AB).
@@ -140,15 +194,27 @@ func gemm_atom*[TD, ShD, StD, TA, ShA, StA, TB, ShB, StB](
            dFrag, aFrag, bFrag)
 
 # ═════════════════════════════════════════════════════════════════════════
-#  gemm_ukernel(mma, ...): loop over atoms
+#  gemm_warp(mma, ...): loop over atoms
 # ═════════════════════════════════════════════════════════════════════════
 
-func gemm_ukernel*[TD, ShD, StD, TA, ShA, StA, TB, ShB, StB](
+func gemm_warp*[TD, ShD, StD, TA, ShA, StA, TB, ShB, StB](
     mma: static MmaAtom,
     dFrag: var Tensor[TD, ShD, StD],
     aFrag: TensorView[TA, ShA, StA] or Tensor[TA, ShA, StA],
     bFrag: TensorView[TB, ShB, StB] or Tensor[TB, ShB, StB]) {.inline.} =
   ## Loop over atoms, one gemm_atom per k slice, with dFrag += aFrag·bFrag accumulated in place.
+  ##
+  ## Warp-scoped loop: the 32 lanes that cooperate on one gemm_atom run it
+  ## in lockstep, one warp-wide mma.sync per k slice, all accumulating
+  ## into the warp's C fragment.
+  ##
+  ## Worked example (m16n8k8, (2, 2, 1), tile (32, 16, 32), 128 lanes = 4 warps):
+  ##   per lane:
+  ##     A: (4, 1, 4), 16 values
+  ##     B: (2, 1, 4), 8 values
+  ##     C: (4, 1, 1), 4 values
+  ##   kSlices = RepeatK = tileK/atomK = 32/8 = 4.
+  ##   Each warp issues 4 warp-wide mma.syncs, one per k slice of the A/B registers.
   ##
   ## Args:
   ##   mma: the hardware instruction descriptor
@@ -161,19 +227,19 @@ func gemm_ukernel*[TD, ShD, StD, TA, ShA, StA, TB, ShB, StB](
     kSlices = ShA.default[2]
   static:
     doAssert ShA.default[0] === VA,
-      "gemm_ukernel: A fragment width (" & $ShA.default[0] & ") != atom valuesPerThread(opA) (" & $VA & ")"
+      "gemm_warp: A fragment width (" & $ShA.default[0] & ") != atom valuesPerThread(opA) (" & $VA & ")"
     doAssert ShB.default[0] === VB,
-      "gemm_ukernel: B fragment width (" & $ShB.default[0] & ") != atom valuesPerThread(opB) (" & $VB & ")"
+      "gemm_warp: B fragment width (" & $ShB.default[0] & ") != atom valuesPerThread(opB) (" & $VB & ")"
     # TODO: relax the Repeat == 1 restriction when the GEMM generalizes to
     # multi-Repeat fragments.
     doAssert ShA.default[1] === 1,
-      "gemm_ukernel: A RepeatM (" & $ShA.default[1] & ") != 1. A k slice must be exactly one atom A fragment (V, 1)"
+      "gemm_warp: A RepeatM (" & $ShA.default[1] & ") != 1. A k slice must be exactly one atom A fragment (V, 1)"
     doAssert ShB.default[1] === 1,
-      "gemm_ukernel: B RepeatN (" & $ShB.default[1] & ") != 1. B k slice must be exactly one atom B fragment (V, 1)"
+      "gemm_warp: B RepeatN (" & $ShB.default[1] & ") != 1. B k slice must be exactly one atom B fragment (V, 1)"
     doAssert ShB.default[2] === kSlices,
-      "gemm_ukernel: B k dimension (" & $ShB.default[2] & ") != A k dimension (" & $kSlices & "). A and B must agree on the k slice count"
+      "gemm_warp: B k dimension (" & $ShB.default[2] & ") != A k dimension (" & $kSlices & "). A and B must agree on the k slice count"
     doAssert dFrag.layout.cosize().toIntVal() === mma.valuesPerThread(opC),
-        "gemm_ukernel: accumulator size (" & $dFrag.layout.cosize().toIntVal() &
+        "gemm_warp: accumulator size (" & $dFrag.layout.cosize().toIntVal() &
         ") != atom valuesPerThread(opC) (" & $mma.valuesPerThread(opC) & ")"
 
   staticFor kSlice, 0, kSlices.toIntVal():
@@ -204,6 +270,17 @@ func gemm_tiled*[TA, ShA, StA, TB, ShB, StB, TD, ShD, StD](
   ## with the shapes (V, RepeatM, RepeatN)+=(V, RepeatM, RepeatK)·(V, RepeatN, RepeatK):
   ##   - V is the values per thread per atom instruction,
   ##   - RepeatM/N/K the number of atoms per threaf along M, N, K
+  ##
+  ## Worked example (m16n8k8, (2, 2, 1), tile (32, 16, 32), 128 lanes = 4 warps):
+  ##   the CTA's 4 warps cover the (32, 16) output tile (C never lives in smem).
+  ##   Warp (tm, tn) ∈ (2, 2) owns the (16, 8) C sub-tile, reading from smem:
+  ##     A: rows tm·16..tm·16+16
+  ##     B: rows tn·8..tn·8+8
+  ##   Each of its 32 lanes gathers its V values into registers:
+  ##     A: (4, 1, 4)
+  ##     B: (2, 1, 4)
+  ##   It then hands off to gemm_warp.
+  ##   C (4, 1, 1) was pre-zeroed by gemm_cta.
   ##
   ## Args:
   ##   tma: the TiledMma, atom plus (ThrM, ThrN, ThrK) thread tiling
@@ -253,8 +330,8 @@ func gemm_tiled*[TA, ShA, StA, TB, ShB, StB, TD, ShD, StD](
   aFragTile.copyFrom(tAv)
   bFragTile.copyFrom(tBv)
 
-  # the k-slice microkernel: accumulate into dFrag (in/out)
-  gemm_ukernel(tma.atom, dFrag, aFragTile, bFragTile)
+  # gemm_warp: accumulate into dFrag (in/out)
+  gemm_warp(tma.atom, dFrag, aFragTile, bFragTile)
 
 # ═════════════════════════════════════════════════════════════════════════
 #  gemm_cta(tma, D, A, B, M, N, K, epi, TileShape, mCTA, nCTA, threadIdx)
@@ -274,13 +351,21 @@ func gemm_cta*[TA, ShA, StA, TB, ShB, StB, TD, ShD, StD, Epi](
   ## One tile per Cooperative Thread Array (CTA) in the grid,
   ## one tileK-sized slice of K prepared in smem per loop iteration.
   ##
+  ## Worked example (m16n8k8, (2, 2, 1), tile (32, 16, 32), 128 lanes = 4 warps):
+  ##   the CTA owns the (32, 16) output tile.
+  ##   Per tileK slice of K it stages the smem tiles via cp.async:
+  ##     A: (32, 32)
+  ##     B: (16, 32)
+  ##   The 4 warps compute the tile through gemm_tiled + gemm_warp,
+  ##   and the epilogue stores the (32, 16) D tile.
+  ##
   ##   A: (M, kView) ── local_tile((tileM, tileK), (mCTA, kCTA)) ──▶ (tileM, tileK)
   ##      ── cp.async, 16-byte chunks per thread ──▶ smem ── partition_A ──▶ aFrag (V, RepeatM, RepeatK)
   ##   B: (N, kView) ── local_tile((tileN, tileK), (nCTA, kCTA)) ──▶ (tileN, tileK)
   ##      ── cp.async, 16-byte chunks per thread ──▶ smem ── partition_B ──▶ bFrag (V, RepeatN, RepeatK)
   ##                                                                                 │
   ##                                                                                 ▼
-  ##                  gemm_ukernel: one gemm_atom per k slice,
+  ##                  gemm_warp: one gemm_atom per k slice,
   ##                  dFrag (V, RepeatM, RepeatN) += aFrag(_, _, kSlice)·bFrag(_, _, kSlice),
   ##                  per-slice fragments (V, RepeatM, 1) and (V, RepeatN, 1)
   ##                                                                                 ▲
@@ -429,7 +514,7 @@ func gemm_cta*[TA, ShA, StA, TB, ShB, StB, TD, ShD, StD, Epi](
 #  The dtype policy: atom → thread layout → tile
 # ═════════════════════════════════════════════════════════════════════════
 #
-#  gemm_gpu computes its tma config internally.
+#  gemm_kernel computes its tma config internally.
 #  The host and the device run the same policy: the same atom, thread layout and tile.
 #  TODO: refactor this whole section: the dtype mapping is a naive first cut.
 
@@ -473,21 +558,36 @@ template tile_shape*(tma: static TiledMma; tileK: static int): auto =
   (M: tma.thrM * tma.atom.mnk.m, N: tma.thrN * tma.atom.mnk.n, K: tileK)
 
 # ═════════════════════════════════════════════════════════════════════════
-#  gemm_gpu(D, A, B, epi)
+#  gemm_kernel(D, A, B, epi)
 # ═════════════════════════════════════════════════════════════════════════
 
-proc gemm_gpu*[TA, ShA, StA, TB, ShB, StB, TC, ShC, StC, Epi](
+proc gemm_kernel*[TA, ShA, StA, TB, ShB, StB, TC, ShC, StC, Epi](
     D: var (TensorView[TC, ShC, StC] or Tensor[TC, ShC, StC]),
     A: TensorView[TA, ShA, StA] or Tensor[TA, ShA, StA],
     B: TensorView[TB, ShB, StB] or Tensor[TB, ShB, StB],
     epi: Epi) =
   ## Computes D = f(A·B), with f an epilogue.
   ##
+  ## Worked example (m16n8k8, tile (32, 16, 32)):
+  ##   gemm_kernel derives the thread layout, tile and grid from the input,
+  ##   then partitions D per thread (partition_C) and shards the epilogue.
+  ##   For a (32, 16) input:
+  ##     thread layout: (2, 2, 1)
+  ##     tile: (32, 16, 32)
+  ##     grid: 1×1
+  ##     CTA: 128 lanes = 4 warps
+  ##   Each CTA computes the (32, 16) output tile via gemm_cta.
+  ##   For a (64, 32) input:
+  ##     thread layout: (4, 4, 1)
+  ##     tile: (64, 32, 32)
+  ##     grid: 1×1
+  ##     CTA: 512 lanes = 16 warps
+  ##
   ## Example: C += α·AB + β·C is implemented via
   ##   let pA = make_view(A, (M, K), (1, M))
   ##   let pB = make_view(B, (N, K), (1, N))
   ##   var pC = make_view(C, (M, N), (1, M))
-  ##   gemm_gpu(pC, pA, pB, initEpiAXPBY(alpha, beta, pC))
+  ##   gemm_kernel(pC, pA, pB, initEpiAXPBY(alpha, beta, pC))
   ##
   ## Args:
   ##   D: the (M, N) destination view, written by the epilogue
@@ -500,9 +600,9 @@ proc gemm_gpu*[TA, ShA, StA, TB, ShB, StB, TC, ShC, StC, Epi](
   ## At the moment: 32-bit operands (TF32) with float32 accumulation.
   static:
     doAssert sizeof(TA) == 4 and sizeof(TB) == 4,
-      "gemm_gpu: at the moment, 32-bit operands only (the SM80 TF32 atom)"
+      "gemm_kernel: at the moment, 32-bit operands only (the SM80 TF32 atom)"
     doAssert TC is float32,
-      "gemm_gpu: at the moment, float32 accumulation only"
+      "gemm_kernel: at the moment, float32 accumulation only"
   const
     M = toIntVal(ShA.default[0])
     K = toIntVal(ShA.default[1])
@@ -517,8 +617,8 @@ proc gemm_gpu*[TA, ShA, StA, TB, ShB, StB, TC, ShC, StC, Epi](
     (tileM, tileN, tileK) = tile_shape(tma, defaultTileK)
   static:
     doAssert M mod tileM == 0 and N mod tileN == 0,
-      "gemm_gpu: the input (" & $M & ", " & $N & ") is not a multiple of the tile (" &
-      $tileM & ", " & $tileN & "). At the moment, ragged tiles are not expressible through gemm_gpu"
+      "gemm_kernel: the input (" & $M & ", " & $N & ") is not a multiple of the tile (" &
+      $tileM & ", " & $tileN & "). At the moment, ragged tiles are not expressible through gemm_kernel"
   let mCTA = int(blockIdx.x)
   let nCTA = int(blockIdx.y)
   let thr = tma.get_slice(int(threadIdx.x))

--- a/workspace/ceramic/tests/gemm/gemm_test_lib.nim
+++ b/workspace/ceramic/tests/gemm/gemm_test_lib.nim
@@ -117,7 +117,7 @@ proc gemm_tf32_ref*(C: var openArray[float32];
 #
 # Kernel-name conventions (the test files' cuda/opencl blocks must name them so):
 #   microtile: mmaMicrotileKernel / mmaMicrotileExplicitKernel (one module)
-#   ukernel:   gemmUkernelKernel
+#   warp:      gemmWarpKernel
 #   tiled:     gemmTiledKernel
 #
 # ═════════════════════════════════════════════════════════════════════════
@@ -164,8 +164,8 @@ proc testMicrotile*[E](engine: var E; atom: static MmaAtom; label: string) =
 
   echo "  OK: m16n8k8 tf32 microtile matches reference within 1e-4 (tf32-exact fixture, ", label, " atom, 16 trials, in-place + explicit)"
 
-proc testUkernel*[E](engine: var E; atom: static MmaAtom; label: string) =
-  ## k-loop microkernel: C(M×N) = A(M, 2·K)·B(N, 2·K), two k slices,
+proc testWarp*[E](engine: var E; atom: static MmaAtom; label: string) =
+  ## gemm_warp k-loop: C(M×N) = A(M, 2·K)·B(N, 2·K), two k slices,
   ## 16 trials vs the tf32 reference.
   const
     M = atom.mnk.m
@@ -179,7 +179,7 @@ proc testUkernel*[E](engine: var E; atom: static MmaAtom; label: string) =
     var refC = newSeq[float32](M * N)
     refC.gemm_tf32_ref(A, B, M, N, Ktotal, 0.0'f32)
     var gpuC = newSeq[float32](M * N)
-    engine.run<<(1, toIntVal(atom.threadCount(opA)))>>("gemmUkernelKernel", gpuC, (A, B))
+    engine.run<<(1, toIntVal(atom.threadCount(opA)))>>("gemmWarpKernel", gpuC, (A, B))
     allClose(gpuC, refC, M, N, "trial " & $trial)
 
   echo "  OK: m16n8k8 tf32 gemm_warp matches reference within 1e-4 (tf32-exact fixture, ", label, " atom, 2 k slices, 16 trials)"
@@ -634,7 +634,7 @@ proc testGemmCtaDynamic*[E](engine: var E; tiled: static TiledMma;
 #  (blockIdx.x/y), and the per-thread epilogue shard internally.
 #  Launched over a 2D grid.
 
-proc testGemmGpu*[E](engine: var E; tiled: static TiledMma; label: string) =
+proc testGemmKernel*[E](engine: var E; tiled: static TiledMma; label: string) =
   ## gemm_kernel with EpiAXPBY (1, 0): C(32×32) = A(32×32)·B(32×32) over a 1×1 CTA grid,
   ## 16 trials, bit-exact vs the tf32 reference.
   ## C is NaN-prefilled, a spurious C read fails.
@@ -659,12 +659,12 @@ proc testGemmGpu*[E](engine: var E; tiled: static TiledMma; label: string) =
     var gpuC = newSeq[float32](M * N)
     for i in 0 ..< M * N:
       gpuC[i] = 0x7FC00000'f32    # NaN sentinel, a spurious C read fails
-    engine.run<<((M div TILE_M, N div TILE_N), blockSize)>>("gemmGpuKernel", gpuC,
+    engine.run<<((M div TILE_M, N div TILE_N), blockSize)>>("gemmKernelAXPBY", gpuC,
                (A_gpu, B_gpu, alpha, beta))
     allClose(gpuC, C_ref, M, N, "gemm_kernel trial " & $trial)
   echo "  OK: gemm_kernel M=32 N=32 K=32 matches reference within 1e-4 (tf32-exact fixture, ", label, " atom, 1x1 CTA grid, 256 threads, 16 trials, (1,0), NaN C)"
 
-proc testGemmGpuBeta*[E](engine: var E; tiled: static TiledMma; label: string) =
+proc testGemmKernelBeta*[E](engine: var E; tiled: static TiledMma; label: string) =
   ## gemm_kernel with EpiAXPBY (α, β) = (1, 1): C(32×32) = A(32×32)·B(32×32)
   ## over a 1×1 CTA grid, C_init pre-loaded from the fixture domain, verify
   ## D = α·AB + β·C_init elementwise.
@@ -690,12 +690,12 @@ proc testGemmGpuBeta*[E](engine: var E; tiled: static TiledMma; label: string) =
     for i in 0 ..< M * N:
       C_ref[i] = alpha * acc[i] + beta * C_init[i]
     var gpuC = C_init
-    engine.run<<((M div TILE_M, N div TILE_N), blockSize)>>("gemmGpuKernel", gpuC,
+    engine.run<<((M div TILE_M, N div TILE_N), blockSize)>>("gemmKernelAXPBY", gpuC,
                (A_gpu, B_gpu, alpha, beta))
     allClose(gpuC, C_ref, M, N, "gemm_kernel beta trial " & $trial)
   echo "  OK: gemm_kernel (1,1) matches reference within 1e-4 (tf32-exact fixture, ", label, " atom, 1x1 CTA grid, C pre-loaded, 16 trials)"
 
-proc testGemmGpuK64*[E](engine: var E; tiled: static TiledMma; label: string) =
+proc testGemmKernelK64*[E](engine: var E; tiled: static TiledMma; label: string) =
   ## gemm_kernel with K = 64: two tileK-sized slices of K (depth 32),
   ## accumulated into one fragment, one epilogue pass, over a 1×1 CTA grid.
   const
@@ -719,12 +719,12 @@ proc testGemmGpuK64*[E](engine: var E; tiled: static TiledMma; label: string) =
     var gpuC = newSeq[float32](M * N)
     for i in 0 ..< M * N:
       gpuC[i] = 0x7FC00000'f32
-    engine.run<<((M div TILE_M, N div TILE_N), blockSize)>>("gemmGpuK64Kernel", gpuC,
+    engine.run<<((M div TILE_M, N div TILE_N), blockSize)>>("gemmKernelK64", gpuC,
                (A_gpu, B_gpu, alpha, beta))
     allClose(gpuC, C_ref, M, N, "gemm_kernel K=64 trial " & $trial)
   echo "  OK: gemm_kernel M=32 N=32 K=64 (2 k-tiles, tileK=32) matches reference within 1e-4 (tf32-exact fixture, ", label, " atom, 1x1 CTA grid, 256 threads, 16 trials, (1,0), NaN C)"
 
-proc testGemmGpuIdentity*[E](engine: var E; tiled: static TiledMma; label: string) =
+proc testGemmKernelIdentity*[E](engine: var E; tiled: static TiledMma; label: string) =
   ## gemm_kernel with EpiIdentity: D = AB over a 1×1 CTA grid.
   ## D is NaN-prefilled, a dropped store leaves NaN and fails the check.
   const
@@ -746,12 +746,12 @@ proc testGemmGpuIdentity*[E](engine: var E; tiled: static TiledMma; label: strin
     var gpuC = newSeq[float32](M * N)
     for i in 0 ..< M * N:
       gpuC[i] = 0x7FC00000'f32
-    engine.run<<((M div TILE_M, N div TILE_N), blockSize)>>("gemmGpuIdentityKernel", gpuC,
+    engine.run<<((M div TILE_M, N div TILE_N), blockSize)>>("gemmKernelIdentity", gpuC,
                (A_gpu, B_gpu))
     allClose(gpuC, C_ref, M, N, "gemm_kernel identity trial " & $trial)
   echo "  OK: gemm_kernel identity (EpiIdentity, D = AB) matches reference within 1e-4 (tf32-exact fixture, ", label, " atom, 1x1 CTA grid, 256 threads, 16 trials, NaN D)"
 
-proc testGemmGpuReLU*[E](engine: var E; tiled: static TiledMma; label: string) =
+proc testGemmKernelReLU*[E](engine: var E; tiled: static TiledMma; label: string) =
   ## gemm_kernel with EpiReLU: D = max(0, AB) over a 1×1 CTA grid.
   ## Fixture domain -15..15 makes AB span negative values.
   const
@@ -773,12 +773,12 @@ proc testGemmGpuReLU*[E](engine: var E; tiled: static TiledMma; label: string) =
     var gpuC = newSeq[float32](M * N)
     for i in 0 ..< M * N:
       gpuC[i] = 0x7FC00000'f32
-    engine.run<<((M div TILE_M, N div TILE_N), blockSize)>>("gemmGpuReLUKernel", gpuC,
+    engine.run<<((M div TILE_M, N div TILE_N), blockSize)>>("gemmKernelReLU", gpuC,
                (A_gpu, B_gpu))
     allClose(gpuC, C_ref, M, N, "gemm_kernel relu trial " & $trial)
   echo "  OK: gemm_kernel relu (EpiReLU, D = max(0, AB)) matches reference within 1e-4 (tf32-exact fixture, ", label, " atom, 1x1 CTA grid, 256 threads, 16 trials, NaN D)"
 
-proc testGemmGpuBias*[E](engine: var E; tiled: static TiledMma; label: string) =
+proc testGemmKernelBias*[E](engine: var E; tiled: static TiledMma; label: string) =
   ## gemm_kernel with EpiAddBias: D = AB + bias over a 1×1 CTA grid.
   ## Bias is a (N,) column vector (stride-0 rows in the op's input view),
   ## sharded onto the thread's fragment.
@@ -804,7 +804,7 @@ proc testGemmGpuBias*[E](engine: var E; tiled: static TiledMma; label: string) =
     var gpuC = newSeq[float32](M * N)
     for i in 0 ..< M * N:
       gpuC[i] = 0x7FC00000'f32
-    engine.run<<((M div TILE_M, N div TILE_N), blockSize)>>("gemmGpuBiasKernel", gpuC,
+    engine.run<<((M div TILE_M, N div TILE_N), blockSize)>>("gemmKernelBias", gpuC,
                (A_gpu, B_gpu, bias))
     allClose(gpuC, C_ref, M, N, "gemm_kernel bias trial " & $trial)
   echo "  OK: gemm_kernel bias (EpiAddBias, D = AB + bias) matches reference within 1e-4 (tf32-exact fixture, ", label, " atom, 1x1 CTA grid, 256 threads, 16 trials, column broadcast, NaN D)"

--- a/workspace/ceramic/tests/gemm/gemm_test_lib.nim
+++ b/workspace/ceramic/tests/gemm/gemm_test_lib.nim
@@ -182,7 +182,7 @@ proc testUkernel*[E](engine: var E; atom: static MmaAtom; label: string) =
     engine.run<<(1, toIntVal(atom.threadCount(opA)))>>("gemmUkernelKernel", gpuC, (A, B))
     allClose(gpuC, refC, M, N, "trial " & $trial)
 
-  echo "  OK: m16n8k8 tf32 gemm_ukernel matches reference within 1e-4 (tf32-exact fixture, ", label, " atom, 2 k slices, 16 trials)"
+  echo "  OK: m16n8k8 tf32 gemm_warp matches reference within 1e-4 (tf32-exact fixture, ", label, " atom, 2 k slices, 16 trials)"
 
 proc testTiled*[E](engine: var E; tiled: static TiledMma; label: string) =
   ## Tiled GEMM on the (2,2,1)-tiled atom: 1×1 grid, K = TILE_K = 16,
@@ -626,15 +626,16 @@ proc testGemmCtaDynamic*[E](engine: var E; tiled: static TiledMma;
     " CTA grid, 16 trials, K-pad + pad region verified NaN)"
 
 # ═════════════════════════════════════════════════════════════════════════
-#  gemm_gpu tests
+#  gemm_kernel tests
 # ═════════════════════════════════════════════════════════════════════════
 #
-#  gemm_gpu kernels build the input views over the raw buffers and derive
-#  the tma policy, the CTA position (blockIdx.x/y), and the per-thread
-#  epilogue shard internally. Launched over a 2D grid.
+#  The test kernels build the input views over the raw buffers and hand them
+#  to gemm_kernel, which derives the tma policy, the CTA position
+#  (blockIdx.x/y), and the per-thread epilogue shard internally.
+#  Launched over a 2D grid.
 
 proc testGemmGpu*[E](engine: var E; tiled: static TiledMma; label: string) =
-  ## gemm_gpu with EpiAXPBY (1, 0): C(32×32) = A(32×32)·B(32×32) over a 1×1 CTA grid,
+  ## gemm_kernel with EpiAXPBY (1, 0): C(32×32) = A(32×32)·B(32×32) over a 1×1 CTA grid,
   ## 16 trials, bit-exact vs the tf32 reference.
   ## C is NaN-prefilled, a spurious C read fails.
   const
@@ -660,11 +661,11 @@ proc testGemmGpu*[E](engine: var E; tiled: static TiledMma; label: string) =
       gpuC[i] = 0x7FC00000'f32    # NaN sentinel, a spurious C read fails
     engine.run<<((M div TILE_M, N div TILE_N), blockSize)>>("gemmGpuKernel", gpuC,
                (A_gpu, B_gpu, alpha, beta))
-    allClose(gpuC, C_ref, M, N, "gemm_gpu trial " & $trial)
-  echo "  OK: gemm_gpu M=32 N=32 K=32 matches reference within 1e-4 (tf32-exact fixture, ", label, " atom, 1x1 CTA grid, 256 threads, 16 trials, (1,0), NaN C)"
+    allClose(gpuC, C_ref, M, N, "gemm_kernel trial " & $trial)
+  echo "  OK: gemm_kernel M=32 N=32 K=32 matches reference within 1e-4 (tf32-exact fixture, ", label, " atom, 1x1 CTA grid, 256 threads, 16 trials, (1,0), NaN C)"
 
 proc testGemmGpuBeta*[E](engine: var E; tiled: static TiledMma; label: string) =
-  ## gemm_gpu with EpiAXPBY (α, β) = (1, 1): C(32×32) = A(32×32)·B(32×32)
+  ## gemm_kernel with EpiAXPBY (α, β) = (1, 1): C(32×32) = A(32×32)·B(32×32)
   ## over a 1×1 CTA grid, C_init pre-loaded from the fixture domain, verify
   ## D = α·AB + β·C_init elementwise.
   const
@@ -691,11 +692,11 @@ proc testGemmGpuBeta*[E](engine: var E; tiled: static TiledMma; label: string) =
     var gpuC = C_init
     engine.run<<((M div TILE_M, N div TILE_N), blockSize)>>("gemmGpuKernel", gpuC,
                (A_gpu, B_gpu, alpha, beta))
-    allClose(gpuC, C_ref, M, N, "gemm_gpu beta trial " & $trial)
-  echo "  OK: gemm_gpu (1,1) matches reference within 1e-4 (tf32-exact fixture, ", label, " atom, 1x1 CTA grid, C pre-loaded, 16 trials)"
+    allClose(gpuC, C_ref, M, N, "gemm_kernel beta trial " & $trial)
+  echo "  OK: gemm_kernel (1,1) matches reference within 1e-4 (tf32-exact fixture, ", label, " atom, 1x1 CTA grid, C pre-loaded, 16 trials)"
 
 proc testGemmGpuK64*[E](engine: var E; tiled: static TiledMma; label: string) =
-  ## gemm_gpu with K = 64: two tileK-sized slices of K (depth 32),
+  ## gemm_kernel with K = 64: two tileK-sized slices of K (depth 32),
   ## accumulated into one fragment, one epilogue pass, over a 1×1 CTA grid.
   const
     M = 32
@@ -720,11 +721,11 @@ proc testGemmGpuK64*[E](engine: var E; tiled: static TiledMma; label: string) =
       gpuC[i] = 0x7FC00000'f32
     engine.run<<((M div TILE_M, N div TILE_N), blockSize)>>("gemmGpuK64Kernel", gpuC,
                (A_gpu, B_gpu, alpha, beta))
-    allClose(gpuC, C_ref, M, N, "gemm_gpu K=64 trial " & $trial)
-  echo "  OK: gemm_gpu M=32 N=32 K=64 (2 k-tiles, tileK=32) matches reference within 1e-4 (tf32-exact fixture, ", label, " atom, 1x1 CTA grid, 256 threads, 16 trials, (1,0), NaN C)"
+    allClose(gpuC, C_ref, M, N, "gemm_kernel K=64 trial " & $trial)
+  echo "  OK: gemm_kernel M=32 N=32 K=64 (2 k-tiles, tileK=32) matches reference within 1e-4 (tf32-exact fixture, ", label, " atom, 1x1 CTA grid, 256 threads, 16 trials, (1,0), NaN C)"
 
 proc testGemmGpuIdentity*[E](engine: var E; tiled: static TiledMma; label: string) =
-  ## gemm_gpu with EpiIdentity: D = AB over a 1×1 CTA grid.
+  ## gemm_kernel with EpiIdentity: D = AB over a 1×1 CTA grid.
   ## D is NaN-prefilled, a dropped store leaves NaN and fails the check.
   const
     M = 32
@@ -747,11 +748,11 @@ proc testGemmGpuIdentity*[E](engine: var E; tiled: static TiledMma; label: strin
       gpuC[i] = 0x7FC00000'f32
     engine.run<<((M div TILE_M, N div TILE_N), blockSize)>>("gemmGpuIdentityKernel", gpuC,
                (A_gpu, B_gpu))
-    allClose(gpuC, C_ref, M, N, "gemm_gpu identity trial " & $trial)
-  echo "  OK: gemm_gpu identity (EpiIdentity, D = AB) matches reference within 1e-4 (tf32-exact fixture, ", label, " atom, 1x1 CTA grid, 256 threads, 16 trials, NaN D)"
+    allClose(gpuC, C_ref, M, N, "gemm_kernel identity trial " & $trial)
+  echo "  OK: gemm_kernel identity (EpiIdentity, D = AB) matches reference within 1e-4 (tf32-exact fixture, ", label, " atom, 1x1 CTA grid, 256 threads, 16 trials, NaN D)"
 
 proc testGemmGpuReLU*[E](engine: var E; tiled: static TiledMma; label: string) =
-  ## gemm_gpu with EpiReLU: D = max(0, AB) over a 1×1 CTA grid.
+  ## gemm_kernel with EpiReLU: D = max(0, AB) over a 1×1 CTA grid.
   ## Fixture domain -15..15 makes AB span negative values.
   const
     M = 32
@@ -774,11 +775,11 @@ proc testGemmGpuReLU*[E](engine: var E; tiled: static TiledMma; label: string) =
       gpuC[i] = 0x7FC00000'f32
     engine.run<<((M div TILE_M, N div TILE_N), blockSize)>>("gemmGpuReLUKernel", gpuC,
                (A_gpu, B_gpu))
-    allClose(gpuC, C_ref, M, N, "gemm_gpu relu trial " & $trial)
-  echo "  OK: gemm_gpu relu (EpiReLU, D = max(0, AB)) matches reference within 1e-4 (tf32-exact fixture, ", label, " atom, 1x1 CTA grid, 256 threads, 16 trials, NaN D)"
+    allClose(gpuC, C_ref, M, N, "gemm_kernel relu trial " & $trial)
+  echo "  OK: gemm_kernel relu (EpiReLU, D = max(0, AB)) matches reference within 1e-4 (tf32-exact fixture, ", label, " atom, 1x1 CTA grid, 256 threads, 16 trials, NaN D)"
 
 proc testGemmGpuBias*[E](engine: var E; tiled: static TiledMma; label: string) =
-  ## gemm_gpu with EpiAddBias: D = AB + bias over a 1×1 CTA grid.
+  ## gemm_kernel with EpiAddBias: D = AB + bias over a 1×1 CTA grid.
   ## Bias is a (N,) column vector (stride-0 rows in the op's input view),
   ## sharded onto the thread's fragment.
   const
@@ -805,5 +806,5 @@ proc testGemmGpuBias*[E](engine: var E; tiled: static TiledMma; label: string) =
       gpuC[i] = 0x7FC00000'f32
     engine.run<<((M div TILE_M, N div TILE_N), blockSize)>>("gemmGpuBiasKernel", gpuC,
                (A_gpu, B_gpu, bias))
-    allClose(gpuC, C_ref, M, N, "gemm_gpu bias trial " & $trial)
-  echo "  OK: gemm_gpu bias (EpiAddBias, D = AB + bias) matches reference within 1e-4 (tf32-exact fixture, ", label, " atom, 1x1 CTA grid, 256 threads, 16 trials, column broadcast, NaN D)"
+    allClose(gpuC, C_ref, M, N, "gemm_kernel bias trial " & $trial)
+  echo "  OK: gemm_kernel bias (EpiAddBias, D = AB + bias) matches reference within 1e-4 (tf32-exact fixture, ", label, " atom, 1x1 CTA grid, 256 threads, 16 trials, column broadcast, NaN D)"

--- a/workspace/ceramic/tests/gemm/manual_gemm_kernel_cuda.nim
+++ b/workspace/ceramic/tests/gemm/manual_gemm_kernel_cuda.nim
@@ -14,14 +14,14 @@
 ## Five kernels run over a 1×1 CTA grid (tile 32×32, tileK 32),
 ## 256 threads. K64 kernel runs two tileK-sized slices of K.
 ## Epilogues:
-##   gemmGpuKernel          EpiAXPBY,    D = α·AB + β·C
-##   gemmGpuIdentityKernel  EpiIdentity, D = AB
-##   gemmGpuReLUKernel      EpiReLU,     D = max(0, AB)
-##   gemmGpuBiasKernel      EpiAddBias,  D = AB + bias (column broadcast)
+##   gemmKernelAXPBY        EpiAXPBY,    D = α·AB + β·C
+##   gemmKernelIdentity     EpiIdentity, D = AB
+##   gemmKernelReLU         EpiReLU,     D = max(0, AB)
+##   gemmKernelBias         EpiAddBias,  D = AB + bias (column broadcast)
 ## C buffer is pre-filled with NaN: a dropped store leaves NaN != expected,
 ## and the β=0 branch must skip the C read. A spurious read also fails.
 ##
-## Reference, trial loop and report live in gemm_test_lib (testGemmGpu*),
+## Reference, trial loop and report live in gemm_test_lib (testGemmKernel*),
 ## launched over a 1×1 CTA grid.
 ##
 ## Requires an sm_80+ GPU. Run with:
@@ -52,7 +52,7 @@ const atom = atom_selector(uint32, uint32, float32)
 const tiled = make_tiled_mma(atom, threadLayoutOf(atom, 32, 32))
 
 const kernelCode = cuda:
-  proc gemmGpuKernel(
+  proc gemmKernelAXPBY(
       C: ptr UncheckedArray[float32],
       A, B: ptr UncheckedArray[uint32],
       alpha, beta: float32) {.global.} =
@@ -61,7 +61,7 @@ const kernelCode = cuda:
     var pC = make_view(C, (32, 32), (1, 32))
     gemm_kernel(pC, pA, pB, initEpiAXPBY(alpha, beta, pC))
 
-  proc gemmGpuK64Kernel(
+  proc gemmKernelK64(
       C: ptr UncheckedArray[float32],
       A, B: ptr UncheckedArray[uint32],
       alpha, beta: float32) {.global.} =
@@ -70,7 +70,7 @@ const kernelCode = cuda:
     var pC = make_view(C, (32, 32), (1, 32))
     gemm_kernel(pC, pA, pB, initEpiAXPBY(alpha, beta, pC))
 
-  proc gemmGpuIdentityKernel(
+  proc gemmKernelIdentity(
       C: ptr UncheckedArray[float32],
       A, B: ptr UncheckedArray[uint32]) {.global.} =
     let pA = make_view(A, (32, 32), (1, 32))
@@ -79,7 +79,7 @@ const kernelCode = cuda:
     gemm_kernel(pC, pA, pB, EpiIdentity())
 
 const kernelCodeBias = cuda:
-  proc gemmGpuReLUKernel(
+  proc gemmKernelReLU(
       C: ptr UncheckedArray[float32],
       A, B: ptr UncheckedArray[uint32]) {.global.} =
     let pA = make_view(A, (32, 32), (1, 32))
@@ -87,7 +87,7 @@ const kernelCodeBias = cuda:
     var pC = make_view(C, (32, 32), (1, 32))
     gemm_kernel(pC, pA, pB, EpiReLU())
 
-  proc gemmGpuBiasKernel(
+  proc gemmKernelBias(
       C: ptr UncheckedArray[float32],
       A, B: ptr UncheckedArray[uint32],
       bias: ptr UncheckedArray[float32]) {.global.} =
@@ -100,13 +100,13 @@ const kernelCodeBias = cuda:
 
 proc runTest() =
   var engine = bkCuda.init(kernelCode)
-  testGemmGpu(engine, tiled, "SM80")
-  testGemmGpuBeta(engine, tiled, "SM80")
-  testGemmGpuK64(engine, tiled, "SM80")
-  testGemmGpuIdentity(engine, tiled, "SM80")
+  testGemmKernel(engine, tiled, "SM80")
+  testGemmKernelBeta(engine, tiled, "SM80")
+  testGemmKernelK64(engine, tiled, "SM80")
+  testGemmKernelIdentity(engine, tiled, "SM80")
   var engineBias = bkCuda.init(kernelCodeBias)
-  testGemmGpuReLU(engineBias, tiled, "SM80")
-  testGemmGpuBias(engineBias, tiled, "SM80")
+  testGemmKernelReLU(engineBias, tiled, "SM80")
+  testGemmKernelBias(engineBias, tiled, "SM80")
 
 when isMainModule:
   runTest()

--- a/workspace/ceramic/tests/gemm/manual_gemm_kernel_cuda.nim
+++ b/workspace/ceramic/tests/gemm/manual_gemm_kernel_cuda.nim
@@ -1,8 +1,8 @@
-## Manual GPU test: gemm_gpu via NVRTC/CUDA.
+## Manual GPU test: gemm_kernel via NVRTC/CUDA.
 ##
-## gemm_gpu: the test kernels build input views over the raw buffers
-## and hand them to gemm_gpu.
-## gemm_gpu derives the tma policy (atom_selector + threadLayoutOf + tile_shape),
+## gemm_kernel: the test kernels build input views over the raw buffers
+## and hand them to gemm_kernel.
+## gemm_kernel derives the tma policy (atom_selector + threadLayoutOf + tile_shape),
 ## the CTA position from the ambient blockIdx.x/y,
 ## and the per-thread epilogue shard, then runs the gemm_cta body.
 ## Test kernels never see M/N/K, the tile, the thread layout or the grid coords.
@@ -26,8 +26,8 @@
 ##
 ## Requires an sm_80+ GPU. Run with:
 ##   nim c -r --hints:off --warnings:off \
-##     --outdir:build/tests/manual_gemm_gpu_cuda.nim --nimcache:nimcache/tests/manual_gemm_gpu_cuda.nim \
-##     workspace/ceramic/tests/gemm/manual_gemm_gpu_cuda.nim
+##     --outdir:build/tests/manual_gemm_kernel_cuda.nim --nimcache:nimcache/tests/manual_gemm_kernel_cuda.nim \
+##     workspace/ceramic/tests/gemm/manual_gemm_kernel_cuda.nim
 
 import workspace/ceramic/src/int_tuples
 import workspace/ceramic/src/layouts
@@ -47,7 +47,7 @@ import workspace/crucible
 {.experimental: "callOperator".}
 
 # Host derives the reference and launch tile/blockSize
-# from the same policy gemm_gpu computes internally.
+# from the same policy gemm_kernel computes internally.
 const atom = atom_selector(uint32, uint32, float32)
 const tiled = make_tiled_mma(atom, threadLayoutOf(atom, 32, 32))
 
@@ -59,7 +59,7 @@ const kernelCode = cuda:
     let pA = make_view(A, (32, 32), (1, 32))
     let pB = make_view(B, (32, 32), (1, 32))
     var pC = make_view(C, (32, 32), (1, 32))
-    gemm_gpu(pC, pA, pB, initEpiAXPBY(alpha, beta, pC))
+    gemm_kernel(pC, pA, pB, initEpiAXPBY(alpha, beta, pC))
 
   proc gemmGpuK64Kernel(
       C: ptr UncheckedArray[float32],
@@ -68,7 +68,7 @@ const kernelCode = cuda:
     let pA = make_view(A, (32, 64), (1, 32))
     let pB = make_view(B, (32, 64), (1, 32))
     var pC = make_view(C, (32, 32), (1, 32))
-    gemm_gpu(pC, pA, pB, initEpiAXPBY(alpha, beta, pC))
+    gemm_kernel(pC, pA, pB, initEpiAXPBY(alpha, beta, pC))
 
   proc gemmGpuIdentityKernel(
       C: ptr UncheckedArray[float32],
@@ -76,7 +76,7 @@ const kernelCode = cuda:
     let pA = make_view(A, (32, 32), (1, 32))
     let pB = make_view(B, (32, 32), (1, 32))
     var pC = make_view(C, (32, 32), (1, 32))
-    gemm_gpu(pC, pA, pB, EpiIdentity())
+    gemm_kernel(pC, pA, pB, EpiIdentity())
 
 const kernelCodeBias = cuda:
   proc gemmGpuReLUKernel(
@@ -85,7 +85,7 @@ const kernelCodeBias = cuda:
     let pA = make_view(A, (32, 32), (1, 32))
     let pB = make_view(B, (32, 32), (1, 32))
     var pC = make_view(C, (32, 32), (1, 32))
-    gemm_gpu(pC, pA, pB, EpiReLU())
+    gemm_kernel(pC, pA, pB, EpiReLU())
 
   proc gemmGpuBiasKernel(
       C: ptr UncheckedArray[float32],
@@ -96,7 +96,7 @@ const kernelCodeBias = cuda:
     var pC = make_view(C, (32, 32), (1, 32))
     # Bias is a (N,) column vector: the bias view has stride-0 rows,
     # so every row of a column reads the same bias element.
-    gemm_gpu(pC, pA, pB, initEpiAddBias(make_view(bias, (32, 32), (0, 1))))
+    gemm_kernel(pC, pA, pB, initEpiAddBias(make_view(bias, (32, 32), (0, 1))))
 
 proc runTest() =
   var engine = bkCuda.init(kernelCode)

--- a/workspace/ceramic/tests/gemm/manual_sm80_gemm_tiled_cuda.nim
+++ b/workspace/ceramic/tests/gemm/manual_sm80_gemm_tiled_cuda.nim
@@ -1,13 +1,13 @@
 ## Manual GPU test: the tiled GEMM (gemm_tiled) via NVRTC/CUDA.
 ##
 ## C(32×16) = α·A(32×16)·B(16×16) + β·C. 1×1 grid, K = TILE_K = 16
-## (two k slices through gemm_ukernel), config (α, β) = (1.0, 0.0),
+## (two k slices through gemm_warp), config (α, β) = (1.0, 0.0),
 ## 128 threads.
 ##
 ## gemm_tiled(tma, dFrag, sA, sB, TileShape, threadIdx) computes the
 ## thread's fragment for one tileK-sized slice of K:
 ## thread tiling → fragment gathering from the prepared smem tile →
-## gemm_ukernel's loop over the K dimension, accumulating into the
+## gemm_warp's loop over the K dimension, accumulating into the
 ## caller's dFrag.
 ## Kernel declares its own {.shared.} smem tiles, copies the full
 ## tileK-sized slice of K from gmem (unmasked: this test runs full

--- a/workspace/ceramic/tests/gemm/manual_sm80_gemm_warp_cuda.nim
+++ b/workspace/ceramic/tests/gemm/manual_sm80_gemm_warp_cuda.nim
@@ -1,8 +1,8 @@
-## Manual GPU test: the sm80 GEMM microkernel (gemm_ukernel)
+## Manual GPU test: the sm80 warp-level GEMM (gemm_warp)
 ## via NVRTC/CUDA.
 ##
 ## C(16×8) = A(16×16)·B(16×8): two m16n8k8 k slices through
-## gemm_ukernel, one gemm_atom per slice accumulated in cFrag,
+## gemm_warp, one gemm_atom per slice accumulated in cFrag,
 ## 32 threads. Epilogue is a direct identity copy to C.
 ##
 ## Atom is the parameter, SM80_16x8x8_F32TF32TF32F32_TN. Tiling is
@@ -12,8 +12,8 @@
 ## Requires an sm_80+ GPU. Run with:
 ##   CUDA_HOME=/usr/local/cuda-12 LD_LIBRARY_PATH=/usr/local/cuda-12/lib64 \
 ##   nim c -r --hints:off --warnings:off \
-##     --outdir:build/tests/manual_sm80_gemm_ukernel_cuda.nim --nimcache:nimcache/tests/manual_sm80_gemm_ukernel_cuda.nim \
-##     workspace/ceramic/tests/gemm/manual_sm80_gemm_ukernel_cuda.nim
+##     --outdir:build/tests/manual_sm80_gemm_warp_cuda.nim --nimcache:nimcache/tests/manual_sm80_gemm_warp_cuda.nim \
+##     workspace/ceramic/tests/gemm/manual_sm80_gemm_warp_cuda.nim
 
 import workspace/ceramic/src/int_tuples
 import workspace/ceramic/src/layouts
@@ -39,7 +39,7 @@ const tiled = TiledMma[typeof(atom), typeof(make_layout((1, 1, 1)))](
 func gemmUkernelMicrotile(tma: static TiledMma; t: int;
                           C: ptr UncheckedArray[float32];
                           A, B: ptr UncheckedArray[uint32]) {.inline.} =
-  ## C(16×8) = A(16×16)·B(16×8): two m16n8k8 k slices via gemm_ukernel.
+  ## C(16×8) = A(16×16)·B(16×8): two m16n8k8 k slices via gemm_warp.
   ## Fragment gathering: partition_A/B of the full (M, 2K)/(N, 2K) views,
   ## fragments as owning tensors (make_fragment_A/B). No loops, no
   ## offsets, no raw-addr views.
@@ -58,16 +58,16 @@ func gemmUkernelMicrotile(tma: static TiledMma; t: int;
   # fragments as owning tensors shaped like the partitions:
   # V flattened to atom register order, the k slices in the partition's
   # RepeatK mode, so one copyFrom gathers all slices in the flat order
-  # gemm_ukernel indexes per k slice
+  # gemm_warp indexes per k slice
   var aFrag = make_fragment_A(tma.atom, tAv)
   aFrag.copyFrom(tAv)
   var bFrag = make_fragment_B(tma.atom, tBv)
   bFrag.copyFrom(tBv)
-  # accumulator: flat (VC,), zeroed, gemm_ukernel accumulates in place
+  # accumulator: flat (VC,), zeroed, gemm_warp accumulates in place
   var cFrag = make_tensor(float32, (VC,))
   cFrag.fillWith(0.0'f32)
 
-  gemm_ukernel(tma.atom, cFrag, aFrag, bFrag)   # two mma.sync, accumulating
+  gemm_warp(tma.atom, cFrag, aFrag, bFrag)   # two mma.sync, accumulating
 
   for i in 0 ..< size(tCv.layout):
     tCv(i) = cFrag(i)

--- a/workspace/ceramic/tests/gemm/manual_sm80_gemm_warp_cuda.nim
+++ b/workspace/ceramic/tests/gemm/manual_sm80_gemm_warp_cuda.nim
@@ -36,7 +36,7 @@ const atom = SM80_16x8x8_F32TF32TF32F32_TN
 const tiled = TiledMma[typeof(atom), typeof(make_layout((1, 1, 1)))](
   atom: atom, threadLayout: make_layout((1, 1, 1)))
 
-func gemmUkernelMicrotile(tma: static TiledMma; t: int;
+func gemmWarpMicrotile(tma: static TiledMma; t: int;
                           C: ptr UncheckedArray[float32];
                           A, B: ptr UncheckedArray[uint32]) {.inline.} =
   ## C(16×8) = A(16×16)·B(16×8): two m16n8k8 k slices via gemm_warp.
@@ -73,13 +73,13 @@ func gemmUkernelMicrotile(tma: static TiledMma; t: int;
     tCv(i) = cFrag(i)
 
 const kernelCode = cuda:
-  proc gemmUkernelKernel(C: ptr UncheckedArray[float32],
+  proc gemmWarpKernel(C: ptr UncheckedArray[float32],
                          A, B: ptr UncheckedArray[uint32]) {.global.} =
-    gemmUkernelMicrotile(tiled, int(threadIdx.x), C, A, B)
+    gemmWarpMicrotile(tiled, int(threadIdx.x), C, A, B)
 
 proc runTest() =
   var engine = bkCuda.init(kernelCode)
-  testUkernel(engine, atom, "SM80")
+  testWarp(engine, atom, "SM80")
 
 when isMainModule:
   runTest()

--- a/workspace/crucible/src/codegen/ir/nim_to_gpu.nim
+++ b/workspace/crucible/src/codegen/ir/nim_to_gpu.nim
@@ -606,7 +606,7 @@ proc toGpuAst*(ctx: var GpuContext, reg: var TypeRegistry, node: NimNode,
     for i in 1 ..< node.len:
       if isTypeDescNode(node[i]): continue
       if (i - 1) in staticSkip: continue # static VALUE arg (e.g. the atom record in
-                                          # gemm_ukernel) — compile-time only, its
+                                          # gemm_warp) — compile-time only, its
                                           # param was dropped in parseProcParameters
       args.add ctx.toGpuAst(reg, node[i])
     if name in ctx.builtins and node[0].repr in NimGpuNumericBuiltinsOperators:


### PR DESCRIPTION
Rename gemm_ukernel (heritage from CPU BLIS) to gemm_warp and gemm_gpu -> gemm_kernel (device-side) + add detailed example with data partitioning and thread partitioning to GPU GEMM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Renamed the public GEMM entry points to clearly distinguish warp-level and kernel-level operations.
  * GEMM kernel configuration and thread organization are now documented, including memory movement, fragment ownership, and accumulation flow.

* **Documentation**
  * Added a worked example explaining GEMM execution across atoms, warps, tiles, CTAs, and kernels.

* **Tests**
  * Updated GEMM test descriptions, commands, and invocations to use the new names while preserving existing validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->