### PR TITLE
GPU raw code emission

### DIFF
--- a/workspace/crucible/src/codegen/ir/gpu_types.nim
+++ b/workspace/crucible/src/codegen/ir/gpu_types.nim
@@ -41,6 +41,7 @@ type
     gpuAlias        # A type alias
     gpuObjConstr    # Object (struct) constructor
     gpuInlineAsm    # Inline assembly (PTX)
+    gpuEmit         # Raw target-source injection ({.emit.})
     gpuAddr         # Address of an expression
     gpuDeref        # Dereferences an expression
     gpuConv         # A type conversion, i.e. `let x = 5; x.float`
@@ -138,6 +139,16 @@ type
     atvVolatile = "volatile"
     atvConstant = "__constant__" # use `{.constant.}` pragma, e.g. `var foo {.constant.}`
 
+  GpuEmitPartKind* = enum
+    peLiteral  ## Verbatim raw text run
+    peExpr     ## Expression part rendered through the target codegen
+
+  GpuEmitPart* = object
+    ## One ordered part of a `gpuEmit` statement: a verbatim literal run or an expression rendered by the target codegen.
+    case kind*: GpuEmitPartKind
+    of peLiteral: literal*: string
+    of peExpr: expr*: GpuAst
+
   GpuAst* = ref object
     case kind*: GpuNodeKind
     of gpuDiscard: discard
@@ -233,6 +244,8 @@ type
     of gpuInlineAsm:
       stmt*: string
       ops*: seq[GpuAst] ## Operand symbols (gpuIdent) for backtick names
+    of gpuEmit:
+      parts*: seq[GpuEmitPart] ## Ordered parts: literal runs verbatim, expr parts via target codegen
     of gpuComment:
       comment*: string
     of gpuConv:
@@ -640,6 +653,14 @@ proc clone*(ast: GpuAst): GpuAst =
     result.stmt = ast.stmt
     for op in ast.ops:
       result.ops.add op.clone()
+  of gpuEmit:
+    result = GpuAst(kind: gpuEmit)
+    for part in ast.parts:
+      case part.kind
+      of peLiteral:
+        result.parts.add GpuEmitPart(kind: peLiteral, literal: part.literal)
+      of peExpr:
+        result.parts.add GpuEmitPart(kind: peExpr, expr: part.expr.clone())
   of gpuAddr:
     result = GpuAst(kind: gpuAddr)
     result.aOf = ast.aOf.clone()
@@ -942,6 +963,13 @@ proc pretty*(n: GpuAst, indent: int = 0): string =
       result.add pretty(f.value, indent + 2)
   of gpuInlineAsm:
     result.add id(n.stmt)
+  of gpuEmit:
+    for part in n.parts:
+      case part.kind
+      of peLiteral:
+        result.add id(part.literal)
+      of peExpr:
+        result.add pretty(part.expr, indent + 2)
   of gpuComment:
     result.add id(n.comment)
   of gpuConv:
@@ -1019,6 +1047,15 @@ template iterImpl(ast: untyped, mutable: static bool): untyped =
     else:
       for el in ast.ocFields:
         yield el.value
+  of gpuEmit:
+    when mutable:
+      for part in mitems(ast.parts):
+        if part.kind == peExpr:
+          yield part.expr
+    else:
+      for part in ast.parts:
+        if part.kind == peExpr:
+          yield part.expr
   of gpuAddr:
     ya(aOf)
   of gpuDeref:

--- a/workspace/crucible/src/codegen/ir/nim_to_gpu.nim
+++ b/workspace/crucible/src/codegen/ir/nim_to_gpu.nim
@@ -289,6 +289,16 @@ proc fnReturnsValue(ctx: GpuContext, fn: GpuAst): bool =
     result = ctx.processedProcs[fn].retType.kind != gtVoid
   else:
     error "The function: " & $fn & " is not known anywhere."
+
+proc buildEmitStmt(ctx: var GpuContext, reg: var TypeRegistry, emitArg: NimNode): GpuAst =
+  result = GpuAst(kind: gpuEmit)
+  for part in emitArg:
+    case part.kind
+    of nnkStrLit, nnkTripleStrLit, nnkRStrLit:
+      result.parts.add GpuEmitPart(kind: peLiteral, literal: part.strVal)
+    else:
+      result.parts.add GpuEmitPart(kind: peExpr, expr: ctx.toGpuAst(reg, part))
+
 proc toGpuAst*(ctx: var GpuContext, reg: var TypeRegistry, node: NimNode,
                staticValueMask: seq[int] = @[]): GpuAst =
   ## XXX: things still left to do:
@@ -1014,9 +1024,32 @@ proc toGpuAst*(ctx: var GpuContext, reg: var TypeRegistry, node: NimNode,
     ## Irrelevant for GPU codegen — skip them.
     result = GpuAst(kind: gpuDiscard)
   of nnkPragma:
-    ## Pragmas are compile-time annotations (e.g. {.warning.} on operators).
-    ## They are irrelevant for GPU codegen — skip them.
-    result = GpuAst(kind: gpuDiscard)
+    ## Statement-level pragmas are compile-time annotations, except `{.emit: ... .}`
+    ## which injects raw target source (gpuEmit).
+    ## The emit pragma handles 2 forms:
+    ## - `{.emit: arg.}` arrives as `nnkExprColonExpr`
+    ## - `{.emit(arg).}` arrives as `nnkCall`
+    ## In both cases the argument sits at index 1 and takes one of two forms:
+    ## - `nnkArgList`: single-string and backtick forms.
+    ##   Backticks arrive already resolved to NimSym
+    ## - `nnkBracket`: the comma form
+    var emitArgs: seq[NimNode] = @[]
+    for child in node:
+      if child.kind in {nnkExprColonExpr, nnkCall} and
+         child.len >= 2 and
+         child[0].kind in {nnkIdent, nnkSym} and
+         child[0].strVal == "emit":
+        emitArgs.add child[1]
+    if emitArgs.len == 0:
+      # Pragmas are compile-time annotations (e.g. {.warning.} on operators).
+      # They are irrelevant for GPU codegen — skip them.
+      result = GpuAst(kind: gpuDiscard)
+    elif emitArgs.len == 1:
+      result = ctx.buildEmitStmt(reg, emitArgs[0])
+    else:
+      result = GpuAst(kind: gpuBlock)
+      for emitArg in emitArgs:
+        result.statements.add ctx.buildEmitStmt(reg, emitArg)
   of nnkWhenStmt:
     error "We shouldn't be seeing a `when` statement after sem check of the Nim code."
   else:

--- a/workspace/crucible/src/codegen/passes/passes_legalizations.nim
+++ b/workspace/crucible/src/codegen/passes/passes_legalizations.nim
@@ -32,7 +32,7 @@ proc insertResult(ctx: var GpuContext; fn: GpuAst) =
 
     for i in countdown(fn.pBody.statements.high, 0):
       let stmt = fn.pBody.statements[i]
-      if stmt.kind notin {gpuVar, gpuComment, gpuDiscard, gpuReturn, gpuIf, gpuFor, gpuWhile}:
+      if stmt.kind notin {gpuVar, gpuComment, gpuDiscard, gpuReturn, gpuIf, gpuFor, gpuWhile, gpuEmit}:
         if stmt.kind == gpuBlock and stmt.isExpr:
           if stmt.statements.len == 1:
             fn.pBody.statements[i] = GpuAst(kind: gpuAssign, aLeft: resId, aRight: stmt.statements[0])

--- a/workspace/crucible/src/codegen/targets/cuda_lang.nim
+++ b/workspace/crucible/src/codegen/targets/cuda_lang.nim
@@ -263,7 +263,7 @@ proc genCuda*(ctx: var GpuContext, ast: GpuAst, indent = 0): string =
       if code.len == 0:
         continue # skip gpuDiscard and empty statements
       result.add code
-      if el.kind != gpuBlock and not ctx.skipSemicolon:
+      if not el.isSelfTerminating() and not ctx.skipSemicolon:
         result.add ';'
       if i < ast.statements.high:
         result.add '\n'

--- a/workspace/crucible/src/codegen/targets/cuda_lang.nim
+++ b/workspace/crucible/src/codegen/targets/cuda_lang.nim
@@ -416,6 +416,12 @@ proc genCuda*(ctx: var GpuContext, ast: GpuAst, indent = 0): string =
   of gpuInlineAsm:
     result = indentStr & "asm(" & genAsmStmt(ast).strip & ");"
 
+  of gpuEmit:
+    # Self-terminating raw text: the gpuBlock loop appends no `;`
+    # (the emitted text owns its own terminators).
+    result = genEmitStmt(ctx, ast,
+      proc(c: var GpuContext; n: GpuAst): string = c.genCuda(n, 0))
+
   of gpuComment:
     result = indentStr & "/* " & ast.comment & " */"
 

--- a/workspace/crucible/src/codegen/targets/lang_utils.nim
+++ b/workspace/crucible/src/codegen/targets/lang_utils.nim
@@ -47,6 +47,22 @@ proc genAsmStmt*(ast: GpuAst): string =
       result.add s[i]
       inc i
 
+proc genEmitStmt*(ctx: var GpuContext; ast: GpuAst;
+                  renderExpr: proc(ctx: var GpuContext; n: GpuAst): string): string =
+  ## Renders a `gpuEmit` statement: literal parts pass through verbatim,
+  ## expression parts render through the per-target expression codegen.
+  for part in ast.parts:
+    case part.kind
+    of peLiteral:
+      result.add part.literal
+    of peExpr:
+      result.add renderExpr(ctx, part.expr)
+
+proc isSelfTerminating*(el: GpuAst): bool =
+  ## True when the statement renders its own terminator and the gpuBlock loop
+  ## must not append `;` (nested blocks and `gpuEmit` raw text).
+  result = el.kind in {gpuBlock, gpuEmit}
+
 proc isGlobal*(fn: GpuAst): bool =
   doAssert fn.kind == gpuProc, "Not a function, but: " & $fn.kind
   result = attGlobal in fn.pAttributes

--- a/workspace/crucible/src/codegen/targets/metal_lang.nim
+++ b/workspace/crucible/src/codegen/targets/metal_lang.nim
@@ -387,7 +387,7 @@ proc genMetalImpl(ctx: var GpuContext, ast: GpuAst, indent: int): string =
       if code.len == 0:
         continue # skip gpuDiscard and empty statements
       result.add code
-      if el.kind != gpuBlock and not ctx.skipSemicolon:
+      if not el.isSelfTerminating() and not ctx.skipSemicolon:
         result.add ';'
       if i < ast.statements.high:
         result.add '\n'
@@ -533,6 +533,12 @@ proc genMetalImpl(ctx: var GpuContext, ast: GpuAst, indent: int): string =
 
   of gpuInlineAsm:
     raiseAssert "Inline assembly is not supported on the Metal target."
+
+  of gpuEmit:
+    # Self-terminating raw text: the gpuBlock loop appends no `;`
+    # (the emitted text owns its own terminators).
+    result = genEmitStmt(ctx, ast,
+      proc(c: var GpuContext; n: GpuAst): string = c.genMetalImpl(n, 0))
 
   of gpuComment:
     result = indentStr & "/* " & ast.comment & " */"

--- a/workspace/crucible/src/codegen/targets/opencl_lang.nim
+++ b/workspace/crucible/src/codegen/targets/opencl_lang.nim
@@ -485,6 +485,12 @@ proc genOpenCL*(ctx: var GpuContext, ast: GpuAst, indent = 0): string =
   of gpuInlineAsm:
     result = indentStr & "asm(" & genAsmStmt(ast).strip & ");"
 
+  of gpuEmit:
+    # Self-terminating raw text: the gpuBlock loop appends no `;`
+    # (the emitted text owns its own terminators).
+    result = genEmitStmt(ctx, ast,
+      proc(c: var GpuContext; n: GpuAst): string = c.genOpenCL(n, 0))
+
   of gpuComment:
     result = indentStr & "/* " & ast.comment & " */"
 

--- a/workspace/crucible/src/codegen/targets/opencl_lang.nim
+++ b/workspace/crucible/src/codegen/targets/opencl_lang.nim
@@ -311,7 +311,7 @@ proc genOpenCL*(ctx: var GpuContext, ast: GpuAst, indent = 0): string =
       result.add '\n' & indentStr & "{ // " & ast.blockLabel & '\n'
     for i, el in ast.statements:
       result.add ctx.genOpenCL(el, indent)
-      if el.kind != gpuBlock and not ctx.skipSemicolon:
+      if not el.isSelfTerminating() and not ctx.skipSemicolon:
         result.add ';'
       if i < ast.statements.high:
         result.add '\n'

--- a/workspace/crucible/src/codegen/targets/vulkan_lang.nim
+++ b/workspace/crucible/src/codegen/targets/vulkan_lang.nim
@@ -301,7 +301,7 @@ proc genVulkan*(ctx: var GpuContext, ast: GpuAst, indent = 0): string =
       result.add '\n' & indentStr & "{ // " & ast.blockLabel & '\n'
     for i, el in ast.statements:
       result.add ctx.genVulkan(el, indent)
-      if el.kind != gpuBlock and not ctx.skipSemicolon:
+      if not el.isSelfTerminating() and not ctx.skipSemicolon:
         result.add ';'
       if i < ast.statements.high:
         result.add '\n'

--- a/workspace/crucible/src/codegen/targets/vulkan_lang.nim
+++ b/workspace/crucible/src/codegen/targets/vulkan_lang.nim
@@ -458,6 +458,12 @@ proc genVulkan*(ctx: var GpuContext, ast: GpuAst, indent = 0): string =
   of gpuInlineAsm:
     result = indentStr & "asm(" & genAsmStmt(ast).strip & ");"
 
+  of gpuEmit:
+    # Self-terminating raw text: the gpuBlock loop appends no `;`
+    # (the emitted text owns its own terminators).
+    result = genEmitStmt(ctx, ast,
+      proc(c: var GpuContext; n: GpuAst): string = c.genVulkan(n, 0))
+
   of gpuComment:
     result = indentStr & "/* " & ast.comment & " */"
 

--- a/workspace/crucible/src/codegen/targets/wgsl_lang.nim
+++ b/workspace/crucible/src/codegen/targets/wgsl_lang.nim
@@ -1084,7 +1084,10 @@ proc genWebGpu*(ctx: var GpuContext, ast: GpuAst, indent = 0): string =
     raiseAssert "Inline assembly not supported on the WebGPU target."
 
   of gpuEmit:
-    raiseAssert "gpuEmit is not yet supported on the WebGPU target."
+    # Self-terminating raw text: the gpuBlock loop appends no `;`
+    # (the emitted text owns its own terminators).
+    result = genEmitStmt(ctx, ast,
+      proc(c: var GpuContext; n: GpuAst): string = c.genWebGpu(n, 0))
 
   of gpuComment:
     result = indentStr & "/* " & ast.comment & " */"

--- a/workspace/crucible/src/codegen/targets/wgsl_lang.nim
+++ b/workspace/crucible/src/codegen/targets/wgsl_lang.nim
@@ -894,7 +894,7 @@ proc genWebGpu*(ctx: var GpuContext, ast: GpuAst, indent = 0): string =
       result.add '\n' & indentStr & "{ // " & ast.blockLabel & '\n'
     for i, el in ast.statements:
       result.add ctx.genWebGpu(el, indent)
-      if el.kind != gpuBlock and not ctx.skipSemicolon: # nested block ⇒ ; already added
+      if not el.isSelfTerminating() and not ctx.skipSemicolon: # nested blocks and emits carry their own terminators
         result.add ';'
       if i < ast.statements.high:
         result.add '\n'
@@ -1082,6 +1082,9 @@ proc genWebGpu*(ctx: var GpuContext, ast: GpuAst, indent = 0): string =
 
   of gpuInlineAsm:
     raiseAssert "Inline assembly not supported on the WebGPU target."
+
+  of gpuEmit:
+    raiseAssert "gpuEmit is not yet supported on the WebGPU target."
 
   of gpuComment:
     result = indentStr & "/* " & ast.comment & " */"

--- a/workspace/crucible/tests/codegen/metal/test_metal_emit.nim
+++ b/workspace/crucible/tests/codegen/metal/test_metal_emit.nim
@@ -1,0 +1,268 @@
+## Metal: `{.emit.}` raw MSL injection through the GPU DSL, end to end.
+##
+## Covered:
+## - the argument-form matrix: single string, comma form, backticks,
+##   triple-quoted multiline
+## - the not-silently-dropped regression for both emit spellings
+## - the insertResult exclusion
+## - generic-instantiation cloning
+## - `#define`-style payload byte-exactness
+## - a multi-emit pragma rendering every item in order
+## - a non-emit statement pragma mapping to gpuDiscard
+##
+## Emits are supported inside proc bodies and render at the statement position.
+## Top-level emits (outside any proc body) are out of scope.
+## Every kernel runs through `engine.run()` and the outputs are asserted,
+## never print-only.
+##
+## The emit is self-terminating: the printer appends no `;`, so the injected text
+## must carry its own terminator where MSL requires one.
+##
+## Run:
+##   cd tattletale
+##   nim c -r --hints:off --warnings:off \
+##     --outdir:build/tests --nimcache:nimcache/tests \
+##     workspace/crucible/tests/codegen/metal/test_metal_emit.nim
+
+import std/[strutils, unittest]
+import workspace/crucible
+
+# ── single string literal, injected as raw MSL ──────────────────────────────
+
+const t1Msl = metal:
+  proc t1Kernel(C: ptr UncheckedArray[uint32];
+                A: ptr UncheckedArray[uint32];
+                B: ptr UncheckedArray[uint32]) {.global.} =
+    {.emit: "C[0] = A[0] + B[0];".}
+
+# ── comma form, one interpolated ident (the `A` param) ──────────────────────
+
+const t2Msl = metal:
+  proc t2Kernel(C: ptr UncheckedArray[uint32];
+                A: ptr UncheckedArray[uint32]) {.global.} =
+    {.emit: ["C[0] = ", A, "[0] + 1;"].}
+
+# ── comma form, interleaved ident + call + arithmetic ───────────────────────
+
+const t3Msl = metal:
+  proc doubleIt(v: uint32): uint32 =
+    v * 2
+
+  proc t3Kernel(C: ptr UncheckedArray[uint32];
+                A: ptr UncheckedArray[uint32]) {.global.} =
+    let off: uint32 = 2
+    {.emit: ["C[0] = ", doubleIt(A[0]), " + ", off, ";"].}
+
+# ── backtick form on a local variable ───────────────────────────────────────
+
+const t4Msl = metal:
+  proc t4Kernel(C: ptr UncheckedArray[uint32];
+                A: ptr UncheckedArray[uint32]) {.global.} =
+    let tmp: uint32 = A[0] + 1
+    {.emit: "C[0] = `tmp` + 1;".}
+
+# ── triple-quoted multiline string ──────────────────────────────────────────
+
+const t5Msl = metal:
+  proc t5Kernel(C: ptr UncheckedArray[uint32];
+                A: ptr UncheckedArray[uint32];
+                B: ptr UncheckedArray[uint32]) {.global.} =
+    {.emit: """C[0] = A[0] + B[0];
+C[1] = A[1] + B[1];""".}
+
+# ── not silently dropped — the emit must override the DSL write ─────────────
+
+const t6Msl = metal:
+  proc t6Kernel(C: ptr UncheckedArray[uint32]) {.global.} =
+    C[0] = 0
+    {.emit: "C[0] = 42;".}
+
+# ── backtick form on a kernel parameter ─────────────────────────────────────
+
+const t7Msl = metal:
+  proc t7Kernel(C: ptr UncheckedArray[uint32];
+                x: ptr UncheckedArray[uint32]) {.global.} =
+    {.emit: "C[0] = `x`[0] + 1;".}
+
+# ── comma form on a kernel parameter ────────────────────────────────────────
+
+const t8Msl = metal:
+  proc t8Kernel(C: ptr UncheckedArray[uint32];
+                x: ptr UncheckedArray[uint32]) {.global.} =
+    {.emit: ["C[0] = ", x, "[0] + 1;"].}
+
+# ── insertResult exclusion — a non-void device fn with only a trailing emit
+#    must not become `result = <text>` ─────────────────────────────────────────
+
+const t10Msl = metal:
+  proc emit42(): uint32 =
+    {.emit: "return 42;".}
+
+  proc t10Kernel(C: ptr UncheckedArray[uint32]) {.global.} =
+    C[0] = emit42()
+
+# ── generic device fn (pointer param) with an emit — exercises the clone path
+#    through generic instantiation ────────────────────────────────────────────
+
+const t11Msl = metal:
+  proc emitInto[T](dst: ptr UncheckedArray[T]; v: T) =
+    {.emit: ["*", dst, " = ", v, ";"].}
+
+  proc t11Kernel(C: ptr UncheckedArray[uint32];
+                 A: ptr UncheckedArray[uint32]) {.global.} =
+    emitInto(C, A[0])
+
+# ── call-form emit `{.emit("...").}` is not silently dropped ────────────────
+
+const t12Msl = metal:
+  proc t12Kernel(C: ptr UncheckedArray[uint32]) {.global.} =
+    C[0] = 0
+    {.emit("C[0] = 42;").}
+
+# ── a #define-style directive must pass through byte-exact. A `;` appended by the printer
+#    would corrupt the macro (used below) ──────────────────────────────────────
+
+const t14Msl = metal:
+  proc t14Kernel(C: ptr UncheckedArray[uint32]) {.global.} =
+    {.emit: "#define MSL_EMIT_TILE 32".}
+    {.emit: "C[0] = MSL_EMIT_TILE + 1;".}
+
+# ── duplicate emit items in one pragma — every item renders, in order ────────
+
+const t15Msl = metal:
+  proc t15Kernel(C: ptr UncheckedArray[uint32]) {.global.} =
+    C[0] = 0
+    {.emit: "C[0] = 1;", emit: "C[0] = 2;".}
+
+# ── non-emit statement pragma inside a kernel stays a gpuDiscard ──────────────
+
+const t16Msl = metal:
+  proc t16Kernel(C: ptr UncheckedArray[uint32]) {.global.} =
+    {.warning: "this statement pragma must be discarded, not emitted".}
+    C[0] = 42
+
+# ── Host code ────────────────────────────────────────────────────────────────
+
+proc runTest() =   # private: tests run in a proc so engines are destroyed at return
+  suite "Metal - {.emit.} raw MSL injection":
+
+    test "single string literal emits the sum":
+      var engine = bkMetal.init()
+      engine.ingest(t1Msl)
+      var a: array[1, uint32] = [40'u32]
+      var b: array[1, uint32] = [2'u32]
+      var res: array[1, uint32]
+      engine.run("t1Kernel", res, (a, b))
+      check res[0] == 42
+
+    test "comma form with one interpolated ident":
+      var engine = bkMetal.init()
+      engine.ingest(t2Msl)
+      var a: array[1, uint32] = [41'u32]
+      var res: array[1, uint32]
+      engine.run("t2Kernel", res, (a,))
+      check res[0] == 42
+
+    test "comma form with ident + call + arithmetic":
+      var engine = bkMetal.init()
+      engine.ingest(t3Msl)
+      var a: array[1, uint32] = [20'u32]
+      var res: array[1, uint32]
+      engine.run("t3Kernel", res, (a,))
+      check res[0] == 42
+
+    test "backtick form on a local variable":
+      var engine = bkMetal.init()
+      engine.ingest(t4Msl)
+      var a: array[1, uint32] = [40'u32]
+      var res: array[1, uint32]
+      engine.run("t4Kernel", res, (a,))
+      check res[0] == 42
+
+    test "triple-quoted multiline string":
+      var engine = bkMetal.init()
+      engine.ingest(t5Msl)
+      var a: array[2, uint32] = [40'u32, 10'u32]
+      var b: array[2, uint32] = [2'u32, 3'u32]
+      var res: array[2, uint32]
+      engine.run("t5Kernel", res, (a, b))
+      check res[0] == 42
+      check res[1] == 13
+
+    test "emit is not silently dropped (must override the DSL write)":
+      var engine = bkMetal.init()
+      engine.ingest(t6Msl)
+      var res: array[1, uint32]
+      engine.run("t6Kernel", res, ())
+      check res[0] == 42
+
+    test "backtick form on a kernel parameter":
+      var engine = bkMetal.init()
+      engine.ingest(t7Msl)
+      var x: array[1, uint32] = [41'u32]
+      var res: array[1, uint32]
+      engine.run("t7Kernel", res, (x,))
+      check res[0] == 42
+
+    test "comma form on a kernel parameter":
+      var engine = bkMetal.init()
+      engine.ingest(t8Msl)
+      var x: array[1, uint32] = [41'u32]
+      var res: array[1, uint32]
+      engine.run("t8Kernel", res, (x,))
+      check res[0] == 42
+
+    test "trailing emit in a non-void device fn survives insertResult":
+      var engine = bkMetal.init()
+      engine.ingest(t10Msl)
+      var res: array[1, uint32]
+      engine.run("t10Kernel", res, ())
+      check res[0] == 42
+
+    test "emit survives generic instantiation (clone path)":
+      var engine = bkMetal.init()
+      engine.ingest(t11Msl)
+      var a: array[1, uint32] = [42'u32]
+      var res: array[1, uint32]
+      engine.run("t11Kernel", res, (a,))
+      check res[0] == 42
+
+    test "call-form emit is not silently dropped (must override the DSL write)":
+      var engine = bkMetal.init()
+      engine.ingest(t12Msl)
+      var res: array[1, uint32]
+      engine.run("t12Kernel", res, ())
+      check res[0] == 42
+
+    test "#define-style payload is byte-exact (no `;` appended)":
+      var engine = bkMetal.init()
+      engine.ingest(t14Msl)
+      let msl = engine.getArtifact()
+      check "#define MSL_EMIT_TILE 32" in msl
+      check "#define MSL_EMIT_TILE 32;" notin msl
+      var res: array[1, uint32]
+      engine.run("t14Kernel", res, ())
+      check res[0] == 33
+
+    test "every emit item in one pragma renders, in order, on separate lines":
+      # One gpuEmit per item: the generated MSL must not concatenate the
+      # two statements onto one line (a line-oriented payload would corrupt).
+      doAssert "C[0] = 1;C[0] = 2;" notin t15Msl,
+        "multi-item emit rendered on a single line:\n" & t15Msl
+      doAssert "C[0] = 1;" in t15Msl and "C[0] = 2;" in t15Msl,
+        "multi-item emit dropped an item:\n" & t15Msl
+      var engine = bkMetal.init()
+      engine.ingest(t15Msl)
+      var res: array[1, uint32]
+      engine.run("t15Kernel", res, ())
+      check res[0] == 2
+
+    test "non-emit statement pragma stays a gpuDiscard (kernel compiles and runs)":
+      var engine = bkMetal.init()
+      engine.ingest(t16Msl)
+      var res: array[1, uint32]
+      engine.run("t16Kernel", res, ())
+      check res[0] == 42
+
+when isMainModule:
+  runTest()

--- a/workspace/crucible/tests/codegen/opencl/test_opencl_emit.nim
+++ b/workspace/crucible/tests/codegen/opencl/test_opencl_emit.nim
@@ -1,0 +1,246 @@
+## OpenCL: `{.emit.}` raw OpenCL C injection through the GPU DSL, end to end.
+##
+## Covered:
+## - the argument-form matrix: single string, comma form, backticks,
+##   triple-quoted multiline
+## - the not-silently-dropped regression for both emit spellings
+## - the insertResult exclusion
+## - `#define`-style payload byte-exactness
+## - a multi-emit pragma rendering every item in order
+## - a non-emit statement pragma mapping to gpuDiscard
+##
+## Emits are supported inside proc bodies and render at the statement position.
+## The emit is self-terminating: the printer appends no `;`, so the injected
+## text must carry its own terminator where OpenCL C requires one.
+## Every kernel runs through `engine.run()` and the outputs are asserted,
+## never print-only.
+##
+## Run:
+##   cd tattletale
+##   nim c -r --hints:off --warnings:off \
+##     --outdir:build/tests --nimcache:nimcache/tests \
+##     workspace/crucible/tests/codegen/opencl/test_opencl_emit.nim
+
+import std/[strutils, unittest]
+import workspace/crucible
+
+# ── single string literal, injected as raw OpenCL C ─────────────────────────
+
+const t1Cl = opencl:
+  proc t1Kernel(C: ptr UncheckedArray[uint32];
+                A: ptr UncheckedArray[uint32];
+                B: ptr UncheckedArray[uint32]) {.global.} =
+    {.emit: "C[0] = A[0] + B[0];".}
+
+# ── comma form, one interpolated ident (the `A` param) ──────────────────────
+
+const t2Cl = opencl:
+  proc t2Kernel(C: ptr UncheckedArray[uint32];
+                A: ptr UncheckedArray[uint32]) {.global.} =
+    {.emit: ["C[0] = ", A, "[0] + 1;"].}
+
+# ── comma form, interleaved ident + call + arithmetic ───────────────────────
+
+const t3Cl = opencl:
+  proc doubleIt(v: uint32): uint32 =
+    v * 2
+
+  proc t3Kernel(C: ptr UncheckedArray[uint32];
+                A: ptr UncheckedArray[uint32]) {.global.} =
+    let off: uint32 = 2
+    {.emit: ["C[0] = ", doubleIt(A[0]), " + ", off, ";"].}
+
+# ── backtick form on a local variable ───────────────────────────────────────
+
+const t4Cl = opencl:
+  proc t4Kernel(C: ptr UncheckedArray[uint32];
+                A: ptr UncheckedArray[uint32]) {.global.} =
+    let tmp: uint32 = A[0] + 1
+    {.emit: "C[0] = `tmp` + 1;".}
+
+# ── triple-quoted multiline string ──────────────────────────────────────────
+
+const t5Cl = opencl:
+  proc t5Kernel(C: ptr UncheckedArray[uint32];
+                A: ptr UncheckedArray[uint32];
+                B: ptr UncheckedArray[uint32]) {.global.} =
+    {.emit: """C[0] = A[0] + B[0];
+C[1] = A[1] + B[1];""".}
+
+# ── not silently dropped — the emit must override the DSL write ─────────────
+
+const t6Cl = opencl:
+  proc t6Kernel(C: ptr UncheckedArray[uint32]) {.global.} =
+    C[0] = 0
+    {.emit: "C[0] = 42;".}
+
+# ── backtick form on a kernel parameter ─────────────────────────────────────
+
+const t7Cl = opencl:
+  proc t7Kernel(C: ptr UncheckedArray[uint32];
+                x: ptr UncheckedArray[uint32]) {.global.} =
+    {.emit: "C[0] = `x`[0] + 1;".}
+
+# ── comma form on a kernel parameter ────────────────────────────────────────
+
+const t8Cl = opencl:
+  proc t8Kernel(C: ptr UncheckedArray[uint32];
+                x: ptr UncheckedArray[uint32]) {.global.} =
+    {.emit: ["C[0] = ", x, "[0] + 1;"].}
+
+# ── insertResult exclusion — a non-void device fn with only a trailing emit
+#    must not become `result = <text>` ─────────────────────────────────────────
+
+const t10Cl = opencl:
+  proc emit42(): uint32 =
+    {.emit: "return 42;".}
+
+  proc t10Kernel(C: ptr UncheckedArray[uint32]) {.global.} =
+    C[0] = emit42()
+
+# ── call-form emit `{.emit("...").}` is not silently dropped ────────────────
+
+const t12Cl = opencl:
+  proc t12Kernel(C: ptr UncheckedArray[uint32]) {.global.} =
+    C[0] = 0
+    {.emit("C[0] = 42;").}
+
+# ── a #define-style directive must pass through byte-exact. A `;` appended by the printer
+#    would corrupt the macro (used below) ──────────────────────────────────────
+
+const t14Cl = opencl:
+  proc t14Kernel(C: ptr UncheckedArray[uint32]) {.global.} =
+    {.emit: "#define OPENCL_EMIT_TILE 32".}
+    {.emit: "C[0] = OPENCL_EMIT_TILE + 1;".}
+
+# ── duplicate emit items in one pragma — every item renders, in order ────────
+
+const t15Cl = opencl:
+  proc t15Kernel(C: ptr UncheckedArray[uint32]) {.global.} =
+    C[0] = 0
+    {.emit: "C[0] = 1;", emit: "C[0] = 2;".}
+
+# ── non-emit statement pragma inside a kernel stays a gpuDiscard ──────────────
+
+const t16Cl = opencl:
+  proc t16Kernel(C: ptr UncheckedArray[uint32]) {.global.} =
+    {.warning: "this statement pragma must be discarded, not emitted".}
+    C[0] = 42
+
+# ── Host code ────────────────────────────────────────────────────────────────
+
+proc runTest() =   # private: tests run in a proc so engines are destroyed at return
+  suite "OpenCL - {.emit.} raw OpenCL C injection":
+
+    test "single string literal emits the sum":
+      var engine = bkOpenCL.init()
+      engine.ingest(t1Cl)
+      var a: array[1, uint32] = [40'u32]
+      var b: array[1, uint32] = [2'u32]
+      var res: array[1, uint32]
+      engine.run("t1Kernel", res, (a, b))
+      check res[0] == 42
+
+    test "comma form with one interpolated ident":
+      var engine = bkOpenCL.init()
+      engine.ingest(t2Cl)
+      var a: array[1, uint32] = [41'u32]
+      var res: array[1, uint32]
+      engine.run("t2Kernel", res, (a,))
+      check res[0] == 42
+
+    test "comma form with ident + call + arithmetic":
+      var engine = bkOpenCL.init()
+      engine.ingest(t3Cl)
+      var a: array[1, uint32] = [20'u32]
+      var res: array[1, uint32]
+      engine.run("t3Kernel", res, (a,))
+      check res[0] == 42
+
+    test "backtick form on a local variable":
+      var engine = bkOpenCL.init()
+      engine.ingest(t4Cl)
+      var a: array[1, uint32] = [40'u32]
+      var res: array[1, uint32]
+      engine.run("t4Kernel", res, (a,))
+      check res[0] == 42
+
+    test "triple-quoted multiline string":
+      var engine = bkOpenCL.init()
+      engine.ingest(t5Cl)
+      var a: array[2, uint32] = [40'u32, 10'u32]
+      var b: array[2, uint32] = [2'u32, 3'u32]
+      var res: array[2, uint32]
+      engine.run("t5Kernel", res, (a, b))
+      check res[0] == 42
+      check res[1] == 13
+
+    test "emit is not silently dropped (must override the DSL write)":
+      var engine = bkOpenCL.init()
+      engine.ingest(t6Cl)
+      var res: array[1, uint32]
+      engine.run("t6Kernel", res, ())
+      check res[0] == 42
+
+    test "backtick form on a kernel parameter":
+      var engine = bkOpenCL.init()
+      engine.ingest(t7Cl)
+      var x: array[1, uint32] = [41'u32]
+      var res: array[1, uint32]
+      engine.run("t7Kernel", res, (x,))
+      check res[0] == 42
+
+    test "comma form on a kernel parameter":
+      var engine = bkOpenCL.init()
+      engine.ingest(t8Cl)
+      var x: array[1, uint32] = [41'u32]
+      var res: array[1, uint32]
+      engine.run("t8Kernel", res, (x,))
+      check res[0] == 42
+
+    test "trailing emit in a non-void device fn survives insertResult":
+      var engine = bkOpenCL.init()
+      engine.ingest(t10Cl)
+      var res: array[1, uint32]
+      engine.run("t10Kernel", res, ())
+      check res[0] == 42
+
+    test "call-form emit is not silently dropped (must override the DSL write)":
+      var engine = bkOpenCL.init()
+      engine.ingest(t12Cl)
+      var res: array[1, uint32]
+      engine.run("t12Kernel", res, ())
+      check res[0] == 42
+
+    test "#define-style payload is byte-exact (no `;` appended)":
+      var engine = bkOpenCL.init()
+      engine.ingest(t14Cl)
+      let src = engine.getArtifact()
+      check "#define OPENCL_EMIT_TILE 32" in src
+      check "#define OPENCL_EMIT_TILE 32;" notin src
+      var res: array[1, uint32]
+      engine.run("t14Kernel", res, ())
+      check res[0] == 33
+
+    test "every emit item in one pragma renders, in order, on separate lines":
+      # One gpuEmit per item: the statements render on separate lines.
+      # A concatenated line would corrupt line-oriented payloads.
+      doAssert "C[0] = 1;C[0] = 2;" notin t15Cl,
+        "multi-item emit rendered on a single line:\n" & t15Cl
+      doAssert "C[0] = 1;" in t15Cl and "C[0] = 2;" in t15Cl,
+        "multi-item emit dropped an item:\n" & t15Cl
+      var engine = bkOpenCL.init()
+      engine.ingest(t15Cl)
+      var res: array[1, uint32]
+      engine.run("t15Kernel", res, ())
+      check res[0] == 2
+
+    test "non-emit statement pragma stays a gpuDiscard (kernel compiles and runs)":
+      var engine = bkOpenCL.init()
+      engine.ingest(t16Cl)
+      var res: array[1, uint32]
+      engine.run("t16Kernel", res, ())
+      check res[0] == 42
+
+when isMainModule:
+  runTest()

--- a/workspace/crucible/tests/codegen/vulkan/test_vulkan_emit.nim
+++ b/workspace/crucible/tests/codegen/vulkan/test_vulkan_emit.nim
@@ -1,0 +1,252 @@
+## Vulkan: `{.emit.}` raw GLSL injection through the GPU DSL, end to end.
+##
+## Covered:
+## - the argument-form matrix: single string, comma form, backticks,
+##   triple-quoted multiline
+## - the not-silently-dropped regression for both emit spellings
+## - the insertResult exclusion
+## - `#define`-style payload byte-exactness
+## - a multi-emit pragma rendering every item in order
+## - a non-emit statement pragma mapping to gpuDiscard
+##
+## Emits are supported inside proc bodies and render at the statement position.
+## The emit is self-terminating: the printer appends no `;`, so the injected
+## text must carry its own terminator where GLSL requires one.
+## Kernels carry `{.global, workgroup: (1, 1, 1).}` because the workgroup size
+## is baked into the shader at codegen time.
+## Every kernel runs through `engine.run()` and the outputs are asserted,
+## never print-only. `engine.getArtifact()` is SPIR-V, so source-text asserts
+## read the generated GLSL from the `vulkan:` block constant directly.
+##
+## Run:
+##   cd tattletale
+##   nim c -r --hints:off --warnings:off \
+##     --outdir:build/tests --nimcache:nimcache/tests \
+##     workspace/crucible/tests/codegen/vulkan/test_vulkan_emit.nim
+
+import std/[strutils, unittest]
+import workspace/crucible
+
+# ── single string literal, injected as raw GLSL ─────────────────────────────
+
+const t1Vk = vulkan:
+  proc t1Kernel(C: ptr UncheckedArray[uint32];
+                A: ptr UncheckedArray[uint32];
+                B: ptr UncheckedArray[uint32]) {.global, workgroup: (1, 1, 1).} =
+    {.emit: "C[0] = A[0] + B[0];".}
+
+# ── comma form, one interpolated ident (the `A` param) ──────────────────────
+
+const t2Vk = vulkan:
+  proc t2Kernel(C: ptr UncheckedArray[uint32];
+                A: ptr UncheckedArray[uint32]) {.global, workgroup: (1, 1, 1).} =
+    {.emit: ["C[0] = ", A, "[0] + 1;"].}
+
+# ── comma form, interleaved ident + call + arithmetic ───────────────────────
+
+const t3Vk = vulkan:
+  proc doubleIt(v: uint32): uint32 =
+    v * 2
+
+  proc t3Kernel(C: ptr UncheckedArray[uint32];
+                A: ptr UncheckedArray[uint32]) {.global, workgroup: (1, 1, 1).} =
+    let off: uint32 = 2
+    {.emit: ["C[0] = ", doubleIt(A[0]), " + ", off, ";"].}
+
+# ── backtick form on a local variable ───────────────────────────────────────
+
+const t4Vk = vulkan:
+  proc t4Kernel(C: ptr UncheckedArray[uint32];
+                A: ptr UncheckedArray[uint32]) {.global, workgroup: (1, 1, 1).} =
+    let tmp: uint32 = A[0] + 1
+    {.emit: "C[0] = `tmp` + 1;".}
+
+# ── triple-quoted multiline string ──────────────────────────────────────────
+
+const t5Vk = vulkan:
+  proc t5Kernel(C: ptr UncheckedArray[uint32];
+                A: ptr UncheckedArray[uint32];
+                B: ptr UncheckedArray[uint32]) {.global, workgroup: (1, 1, 1).} =
+    {.emit: """C[0] = A[0] + B[0];
+C[1] = A[1] + B[1];""".}
+
+# ── not silently dropped — the emit must override the DSL write ─────────────
+
+const t6Vk = vulkan:
+  proc t6Kernel(C: ptr UncheckedArray[uint32]) {.global, workgroup: (1, 1, 1).} =
+    C[0] = 0
+    {.emit: "C[0] = 42;".}
+
+# ── backtick form on a kernel parameter ─────────────────────────────────────
+
+const t7Vk = vulkan:
+  proc t7Kernel(C: ptr UncheckedArray[uint32];
+                x: ptr UncheckedArray[uint32]) {.global, workgroup: (1, 1, 1).} =
+    {.emit: "C[0] = `x`[0] + 1;".}
+
+# ── comma form on a kernel parameter ────────────────────────────────────────
+
+const t8Vk = vulkan:
+  proc t8Kernel(C: ptr UncheckedArray[uint32];
+                x: ptr UncheckedArray[uint32]) {.global, workgroup: (1, 1, 1).} =
+    {.emit: ["C[0] = ", x, "[0] + 1;"].}
+
+# ── insertResult exclusion — a non-void device fn with only a trailing emit
+#    must not become `result = <text>` ─────────────────────────────────────────
+
+const t10Vk = vulkan:
+  proc emit42(): uint32 =
+    {.emit: "return 42;".}
+
+  proc t10Kernel(C: ptr UncheckedArray[uint32]) {.global, workgroup: (1, 1, 1).} =
+    C[0] = emit42()
+
+# ── call-form emit `{.emit("...").}` is not silently dropped ────────────────
+
+const t12Vk = vulkan:
+  proc t12Kernel(C: ptr UncheckedArray[uint32]) {.global, workgroup: (1, 1, 1).} =
+    C[0] = 0
+    {.emit("C[0] = 42;").}
+
+# ── a #define-style directive must pass through byte-exact. A `;` appended by the printer
+#    would corrupt the macro (used below) ──────────────────────────────────────
+
+const t14Vk = vulkan:
+  proc t14Kernel(C: ptr UncheckedArray[uint32]) {.global, workgroup: (1, 1, 1).} =
+    {.emit: "#define VULKAN_EMIT_TILE 32".}
+    {.emit: "C[0] = VULKAN_EMIT_TILE + 1;".}
+
+# ── duplicate emit items in one pragma — every item renders, in order ────────
+
+const t15Vk = vulkan:
+  proc t15Kernel(C: ptr UncheckedArray[uint32]) {.global, workgroup: (1, 1, 1).} =
+    C[0] = 0
+    {.emit: "C[0] = 1;", emit: "C[0] = 2;".}
+
+# ── non-emit statement pragma inside a kernel stays a gpuDiscard ──────────────
+
+const t16Vk = vulkan:
+  proc t16Kernel(C: ptr UncheckedArray[uint32]) {.global, workgroup: (1, 1, 1).} =
+    {.warning: "this statement pragma must be discarded, not emitted".}
+    C[0] = 42
+
+# ── Host code ────────────────────────────────────────────────────────────────
+
+proc runTest() =   # private: tests run in a proc so engines are destroyed at return
+  suite "Vulkan - {.emit.} raw GLSL injection":
+
+    test "single string literal emits the sum":
+      var engine = bkVulkan.init()
+      engine.ingest(t1Vk)
+      var a: array[1, uint32] = [40'u32]
+      var b: array[1, uint32] = [2'u32]
+      var res: array[1, uint32]
+      engine.run("t1Kernel", res, (a, b))
+      check res[0] == 42
+
+    test "comma form with one interpolated ident":
+      var engine = bkVulkan.init()
+      engine.ingest(t2Vk)
+      var a: array[1, uint32] = [41'u32]
+      var res: array[1, uint32]
+      engine.run("t2Kernel", res, (a,))
+      check res[0] == 42
+
+    test "comma form with ident + call + arithmetic":
+      var engine = bkVulkan.init()
+      engine.ingest(t3Vk)
+      var a: array[1, uint32] = [20'u32]
+      var res: array[1, uint32]
+      engine.run("t3Kernel", res, (a,))
+      check res[0] == 42
+
+    test "backtick form on a local variable":
+      var engine = bkVulkan.init()
+      engine.ingest(t4Vk)
+      var a: array[1, uint32] = [40'u32]
+      var res: array[1, uint32]
+      engine.run("t4Kernel", res, (a,))
+      check res[0] == 42
+
+    test "triple-quoted multiline string":
+      var engine = bkVulkan.init()
+      engine.ingest(t5Vk)
+      var a: array[2, uint32] = [40'u32, 10'u32]
+      var b: array[2, uint32] = [2'u32, 3'u32]
+      var res: array[2, uint32]
+      engine.run("t5Kernel", res, (a, b))
+      check res[0] == 42
+      check res[1] == 13
+
+    test "emit is not silently dropped (must override the DSL write)":
+      var engine = bkVulkan.init()
+      engine.ingest(t6Vk)
+      var res: array[1, uint32]
+      engine.run("t6Kernel", res, ())
+      check res[0] == 42
+
+    test "backtick form on a kernel parameter":
+      var engine = bkVulkan.init()
+      engine.ingest(t7Vk)
+      var x: array[1, uint32] = [41'u32]
+      var res: array[1, uint32]
+      engine.run("t7Kernel", res, (x,))
+      check res[0] == 42
+
+    test "comma form on a kernel parameter":
+      var engine = bkVulkan.init()
+      engine.ingest(t8Vk)
+      var x: array[1, uint32] = [41'u32]
+      var res: array[1, uint32]
+      engine.run("t8Kernel", res, (x,))
+      check res[0] == 42
+
+    test "trailing emit in a non-void device fn survives insertResult":
+      var engine = bkVulkan.init()
+      engine.ingest(t10Vk)
+      var res: array[1, uint32]
+      engine.run("t10Kernel", res, ())
+      check res[0] == 42
+
+    test "call-form emit is not silently dropped (must override the DSL write)":
+      var engine = bkVulkan.init()
+      engine.ingest(t12Vk)
+      var res: array[1, uint32]
+      engine.run("t12Kernel", res, ())
+      check res[0] == 42
+
+    test "#define-style payload is byte-exact (no `;` appended)":
+      # The Vulkan engine artifact is SPIR-V, so the byte-exact check
+      # reads the generated GLSL from the `vulkan:` block constant.
+      doAssert "#define VULKAN_EMIT_TILE 32" in t14Vk,
+        "emit dropped the #define:\n" & t14Vk
+      doAssert "#define VULKAN_EMIT_TILE 32;" notin t14Vk,
+        "printer appended `;` to the #define:\n" & t14Vk
+      var engine = bkVulkan.init()
+      engine.ingest(t14Vk)
+      var res: array[1, uint32]
+      engine.run("t14Kernel", res, ())
+      check res[0] == 33
+
+    test "every emit item in one pragma renders, in order, on separate lines":
+      # One gpuEmit per item: the statements render on separate lines.
+      # A concatenated line would corrupt line-oriented payloads.
+      doAssert "C[0] = 1;C[0] = 2;" notin t15Vk,
+        "multi-item emit rendered on a single line:\n" & t15Vk
+      doAssert "C[0] = 1;" in t15Vk and "C[0] = 2;" in t15Vk,
+        "multi-item emit dropped an item:\n" & t15Vk
+      var engine = bkVulkan.init()
+      engine.ingest(t15Vk)
+      var res: array[1, uint32]
+      engine.run("t15Kernel", res, ())
+      check res[0] == 2
+
+    test "non-emit statement pragma stays a gpuDiscard (kernel compiles and runs)":
+      var engine = bkVulkan.init()
+      engine.ingest(t16Vk)
+      var res: array[1, uint32]
+      engine.run("t16Kernel", res, ())
+      check res[0] == 42
+
+when isMainModule:
+  runTest()

--- a/workspace/crucible/tests/codegen/webgpu/test_webgpu_emit.nim
+++ b/workspace/crucible/tests/codegen/webgpu/test_webgpu_emit.nim
@@ -1,0 +1,245 @@
+## WebGPU: `{.emit.}` raw WGSL injection through the GPU DSL, end to end.
+##
+## Covered:
+## - the argument-form matrix: single string, comma form, backticks,
+##   triple-quoted multiline
+## - the not-silently-dropped regression for both emit spellings
+## - the insertResult exclusion
+## - self-termination: the emitted text carries its own `;` and the printer
+##   appends none. WGSL has no preprocessor, so the byte-exact probe
+##   targets the statement line itself, not a `#define`
+## - a multi-emit pragma rendering every item in order
+## - a non-emit statement pragma mapping to gpuDiscard
+##
+## Emits are supported inside proc bodies and render at the statement position.
+## The emit is self-terminating: the printer appends no `;`, so the injected
+## text must carry its own `;` where WGSL requires one.
+## Kernels carry `{.global, workgroup: (1, 1, 1).}` because the workgroup size
+## is baked into the shader at codegen time.
+## Every kernel runs through `engine.run()` and the outputs are asserted,
+## never print-only.
+##
+## Run:
+##   cd tattletale
+##   nim c -r --hints:off --warnings:off \
+##     --outdir:build/tests --nimcache:nimcache/tests \
+##     workspace/crucible/tests/codegen/webgpu/test_webgpu_emit.nim
+
+import std/[strutils, unittest]
+import workspace/crucible
+
+# ── single string literal, injected as raw WGSL ─────────────────────────────
+
+const t1Wgsl = webgpu:
+  proc t1Kernel(C: ptr UncheckedArray[uint32];
+                A: ptr UncheckedArray[uint32];
+                B: ptr UncheckedArray[uint32]) {.global, workgroup: (1, 1, 1).} =
+    {.emit: "C[0] = A[0] + B[0];".}
+
+# ── comma form, one interpolated ident (the `A` param) ──────────────────────
+
+const t2Wgsl = webgpu:
+  proc t2Kernel(C: ptr UncheckedArray[uint32];
+                A: ptr UncheckedArray[uint32]) {.global, workgroup: (1, 1, 1).} =
+    {.emit: ["C[0] = ", A, "[0] + 1;"].}
+
+# ── comma form, interleaved ident + call + arithmetic ───────────────────────
+
+const t3Wgsl = webgpu:
+  proc doubleIt(v: uint32): uint32 =
+    v * 2
+
+  proc t3Kernel(C: ptr UncheckedArray[uint32];
+                A: ptr UncheckedArray[uint32]) {.global, workgroup: (1, 1, 1).} =
+    let off: uint32 = 2
+    {.emit: ["C[0] = ", doubleIt(A[0]), " + ", off, ";"].}
+
+# ── backtick form on a local variable ───────────────────────────────────────
+
+const t4Wgsl = webgpu:
+  proc t4Kernel(C: ptr UncheckedArray[uint32];
+                A: ptr UncheckedArray[uint32]) {.global, workgroup: (1, 1, 1).} =
+    let tmp: uint32 = A[0] + 1
+    {.emit: "C[0] = `tmp` + 1;".}
+
+# ── triple-quoted multiline string ──────────────────────────────────────────
+
+const t5Wgsl = webgpu:
+  proc t5Kernel(C: ptr UncheckedArray[uint32];
+                A: ptr UncheckedArray[uint32];
+                B: ptr UncheckedArray[uint32]) {.global, workgroup: (1, 1, 1).} =
+    {.emit: """C[0] = A[0] + B[0];
+C[1] = A[1] + B[1];""".}
+
+# ── not silently dropped — the emit must override the DSL write ─────────────
+
+const t6Wgsl = webgpu:
+  proc t6Kernel(C: ptr UncheckedArray[uint32]) {.global, workgroup: (1, 1, 1).} =
+    C[0] = 0
+    {.emit: "C[0] = 42;".}
+
+# ── backtick form on a kernel parameter ─────────────────────────────────────
+
+const t7Wgsl = webgpu:
+  proc t7Kernel(C: ptr UncheckedArray[uint32];
+                x: ptr UncheckedArray[uint32]) {.global, workgroup: (1, 1, 1).} =
+    {.emit: "C[0] = `x`[0] + 1;".}
+
+# ── comma form on a kernel parameter ────────────────────────────────────────
+
+const t8Wgsl = webgpu:
+  proc t8Kernel(C: ptr UncheckedArray[uint32];
+                x: ptr UncheckedArray[uint32]) {.global, workgroup: (1, 1, 1).} =
+    {.emit: ["C[0] = ", x, "[0] + 1;"].}
+
+# ── insertResult exclusion — a non-void device fn with only a trailing emit
+#    must not become `result = <text>` ─────────────────────────────────────────
+
+const t10Wgsl = webgpu:
+  proc emit42(): uint32 =
+    {.emit: "return 42;".}
+
+  proc t10Kernel(C: ptr UncheckedArray[uint32]) {.global, workgroup: (1, 1, 1).} =
+    C[0] = emit42()
+
+# ── call-form emit `{.emit("...").}` is not silently dropped ────────────────
+
+const t12Wgsl = webgpu:
+  proc t12Kernel(C: ptr UncheckedArray[uint32]) {.global, workgroup: (1, 1, 1).} =
+    C[0] = 0
+    {.emit("C[0] = 42;").}
+
+# ── duplicate emit items in one pragma — every item renders, in order ────────
+
+const t15Wgsl = webgpu:
+  proc t15Kernel(C: ptr UncheckedArray[uint32]) {.global, workgroup: (1, 1, 1).} =
+    C[0] = 0
+    {.emit: "C[0] = 1;", emit: "C[0] = 2;".}
+
+# ── non-emit statement pragma inside a kernel stays a gpuDiscard ──────────────
+
+const t16Wgsl = webgpu:
+  proc t16Kernel(C: ptr UncheckedArray[uint32]) {.global, workgroup: (1, 1, 1).} =
+    {.warning: "this statement pragma must be discarded, not emitted".}
+    C[0] = 42
+
+# ── Host code ────────────────────────────────────────────────────────────────
+
+proc runTest() =   # private: tests run in a proc so engines are destroyed at return
+  suite "WebGPU - {.emit.} raw WGSL injection":
+
+    test "single string literal emits the sum":
+      var engine = bkWGSL.init()
+      engine.ingest(t1Wgsl)
+      var a: array[1, uint32] = [40'u32]
+      var b: array[1, uint32] = [2'u32]
+      var res: array[1, uint32]
+      engine.run("t1Kernel", res, (a, b))
+      check res[0] == 42
+
+    test "comma form with one interpolated ident":
+      var engine = bkWGSL.init()
+      engine.ingest(t2Wgsl)
+      let src = engine.getArtifact()
+      # The interpolated buffer param renders through WGSL codegen
+      # as `(&A)`, the storage-pointer form of a global buffer access.
+      check "(&A)[0] + 1;" in src
+      var a: array[1, uint32] = [41'u32]
+      var res: array[1, uint32]
+      engine.run("t2Kernel", res, (a,))
+      check res[0] == 42
+
+    test "comma form with ident + call + arithmetic":
+      var engine = bkWGSL.init()
+      engine.ingest(t3Wgsl)
+      var a: array[1, uint32] = [20'u32]
+      var res: array[1, uint32]
+      engine.run("t3Kernel", res, (a,))
+      check res[0] == 42
+
+    test "backtick form on a local variable":
+      var engine = bkWGSL.init()
+      engine.ingest(t4Wgsl)
+      var a: array[1, uint32] = [40'u32]
+      var res: array[1, uint32]
+      engine.run("t4Kernel", res, (a,))
+      check res[0] == 42
+
+    test "triple-quoted multiline string":
+      var engine = bkWGSL.init()
+      engine.ingest(t5Wgsl)
+      var a: array[2, uint32] = [40'u32, 10'u32]
+      var b: array[2, uint32] = [2'u32, 3'u32]
+      var res: array[2, uint32]
+      engine.run("t5Kernel", res, (a, b))
+      check res[0] == 42
+      check res[1] == 13
+
+    test "emit is not silently dropped (must override the DSL write)":
+      var engine = bkWGSL.init()
+      engine.ingest(t6Wgsl)
+      var res: array[1, uint32]
+      engine.run("t6Kernel", res, ())
+      check res[0] == 42
+
+    test "backtick form on a kernel parameter":
+      var engine = bkWGSL.init()
+      engine.ingest(t7Wgsl)
+      var x: array[1, uint32] = [41'u32]
+      var res: array[1, uint32]
+      engine.run("t7Kernel", res, (x,))
+      check res[0] == 42
+
+    test "comma form on a kernel parameter":
+      var engine = bkWGSL.init()
+      engine.ingest(t8Wgsl)
+      var x: array[1, uint32] = [41'u32]
+      var res: array[1, uint32]
+      engine.run("t8Kernel", res, (x,))
+      check res[0] == 42
+
+    test "trailing emit in a non-void device fn survives insertResult":
+      var engine = bkWGSL.init()
+      engine.ingest(t10Wgsl)
+      var res: array[1, uint32]
+      engine.run("t10Kernel", res, ())
+      check res[0] == 42
+
+    test "call-form emit is not silently dropped (must override the DSL write)":
+      var engine = bkWGSL.init()
+      engine.ingest(t12Wgsl)
+      var res: array[1, uint32]
+      engine.run("t12Kernel", res, ())
+      check res[0] == 42
+
+    test "emitted statement carries exactly one terminator (no `;` appended)":
+      # WGSL has no preprocessor, so the byte-exact probe is the statement
+      # line itself: one `;` from the emitted text, none from the printer.
+      var engine = bkWGSL.init()
+      engine.ingest(t1Wgsl)
+      let src = engine.getArtifact()
+      check "C[0] = A[0] + B[0];" in src
+      check "C[0] = A[0] + B[0];;" notin src
+
+    test "every emit item in one pragma renders, in order, on separate lines":
+      # One gpuEmit per item: the statements render on separate lines.
+      # A concatenated line would corrupt line-oriented payloads.
+      doAssert "C[0] = 1;C[0] = 2;" notin t15Wgsl,
+        "multi-item emit rendered on a single line:\n" & t15Wgsl
+      doAssert "C[0] = 1;" in t15Wgsl and "C[0] = 2;" in t15Wgsl,
+        "multi-item emit dropped an item:\n" & t15Wgsl
+      var engine = bkWGSL.init()
+      engine.ingest(t15Wgsl)
+      var res: array[1, uint32]
+      engine.run("t15Kernel", res, ())
+      check res[0] == 2
+
+    test "non-emit statement pragma stays a gpuDiscard (kernel compiles and runs)":
+      var engine = bkWGSL.init()
+      engine.ingest(t16Wgsl)
+      var res: array[1, uint32]
+      engine.run("t16Kernel", res, ())
+      check res[0] == 42
+
+when isMainModule:
+  runTest()


### PR DESCRIPTION
This adds raw emit to inline raw Cuda/Metal/OpenCL/Vulkan/WebGPU via the {.emit: """<my raw code>""".}. It also supports variable interpolation via {.emit: """<my raw code>""", a, """<next raw code>""".}

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for `{.emit.}` pragmas in GPU code generation.
  - Supports literal text, expressions, interpolation, multiline content, directives, and call-form syntax.
  - Raw emitted code is available across CUDA, Metal, OpenCL, Vulkan, and WebGPU targets.
  - Preserves emission order and existing statement terminators.

- **Tests**
  - Added end-to-end coverage for emitted code across supported GPU backends, including execution and generated-source validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->