### PR TITLE
Crucible/Metal: Propagate address space when casting

### DIFF
--- a/workspace/crucible/src/codegen/targets/cuda_lang.nim
+++ b/workspace/crucible/src/codegen/targets/cuda_lang.nim
@@ -58,11 +58,8 @@ proc gpuTypeToString*(t: GpuType, ident: string = "", allowArrayToPtr = false,
   var skipIdent = false
   case t.kind
   of gtPtr:
-    var t = t # if `ptr UncheckedArray`, remove the `gtUA` layer. No meaning on CUDA
-    if t.to.kind == gtUA:
-      t.to = t.to.uaTo
-
-    if t.to.kind == gtArray: # ptr to array type
+    let inner = if t.to.kind == gtUA: t.to.uaTo else: t.to
+    if inner.kind == gtArray: # ptr to array type
       # need to pass `*` for the pointer into the identifier, i.e.
       # `state: var array[4, BigInt]`
       # must become
@@ -70,10 +67,10 @@ proc gpuTypeToString*(t: GpuType, ident: string = "", allowArrayToPtr = false,
       # so as our ident we pass `theIdent = (*<ident>)` and generate the type for the internal
       # array type, which yields e.g. `BigInt <theIdent>[4]`.
       let ptrStar = gpuTypeToString(t.kind)
-      result = gpuTypeToString(t.to, '(' & ptrStar & ident & ')')
+      result = gpuTypeToString(inner, '(' & ptrStar & ident & ')')
       skipIdent = true
     else:
-      let typ = gpuTypeToString(t.to, allowEmptyIdent = allowEmptyIdent)
+      let typ = gpuTypeToString(inner, allowEmptyIdent = allowEmptyIdent)
       let ptrStar = gpuTypeToString(t.kind)
       result = typ & ptrStar
   of gtArray:

--- a/workspace/crucible/src/codegen/targets/metal_lang.nim
+++ b/workspace/crucible/src/codegen/targets/metal_lang.nim
@@ -102,20 +102,17 @@ proc gpuTypeToString*(t: GpuType, ident: string = "",
   var skipIdent = false
   case t.kind
   of gtPtr:
-    var t = t # if `ptr UncheckedArray`, remove the `gtUA` layer. No meaning on MSL
-    if t.to.kind == gtUA:
-      t.to = t.to.uaTo
-
-    if t.to.kind == gtArray: # ptr to array type
+    let inner = if t.to.kind == gtUA: t.to.uaTo else: t.to
+    if inner.kind == gtArray: # ptr to array type
       # Need to pass `*` for the pointer into the identifier.
       # `state: var array[4, BigInt]` must become `BigInt (*state)[4]`.
       # So we pass `theIdent = (*<ident>)` and generate the type
       # for the internal array type, which yields `BigInt <theIdent>[4]`.
       let ptrStar = gpuTypeToString(t.kind)
-      result = gpuTypeToString(t.to, '(' & ptrStar & ident & ')')
+      result = gpuTypeToString(inner, '(' & ptrStar & ident & ')')
       skipIdent = true
     else:
-      let typ = gpuTypeToString(t.to, allowEmptyIdent = allowEmptyIdent)
+      let typ = gpuTypeToString(inner, allowEmptyIdent = allowEmptyIdent)
       let ptrStar = gpuTypeToString(t.kind)
       result = typ & ptrStar
   of gtArray:

--- a/workspace/crucible/src/codegen/targets/opencl_lang.nim
+++ b/workspace/crucible/src/codegen/targets/opencl_lang.nim
@@ -59,17 +59,13 @@ proc gpuTypeToString*(t: GpuType, ident: string = "", allowArrayToPtr = false,
   var skipIdent = false
   case t.kind
   of gtPtr:
-    var t = t
-    # Strip `gtUA` layer (ptr UncheckedArray[T] → ptr T)
-    if t.to.kind == gtUA:
-      t.to = t.to.uaTo
-
-    if t.to.kind == gtArray: # ptr to array type
+    let inner = if t.to.kind == gtUA: t.to.uaTo else: t.to
+    if inner.kind == gtArray: # ptr to array type
       let ptrStar = gpuTypeToString(t.kind)
-      result = gpuTypeToString(t.to, '(' & ptrStar & ident & ')')
+      result = gpuTypeToString(inner, '(' & ptrStar & ident & ')')
       skipIdent = true
     else:
-      let typ = gpuTypeToString(t.to, allowEmptyIdent = allowEmptyIdent)
+      let typ = gpuTypeToString(inner, allowEmptyIdent = allowEmptyIdent)
       let ptrStar = gpuTypeToString(t.kind)
       result = typ & ptrStar
   of gtArray:

--- a/workspace/crucible/src/codegen/targets/vulkan_lang.nim
+++ b/workspace/crucible/src/codegen/targets/vulkan_lang.nim
@@ -58,17 +58,13 @@ proc gpuTypeToString*(t: GpuType, ident: string = "", allowArrayToPtr = false,
   var skipIdent = false
   case t.kind
   of gtPtr:
-    var t = t
-    # Strip `gtUA` layer (ptr UncheckedArray[T] → ptr T)
-    if t.to.kind == gtUA:
-      t.to = t.to.uaTo
-
-    if t.to.kind == gtArray: # ptr to array type
+    let inner = if t.to.kind == gtUA: t.to.uaTo else: t.to
+    if inner.kind == gtArray: # ptr to array type
       let ptrStar = gpuTypeToString(t.kind)
-      result = gpuTypeToString(t.to, '(' & ptrStar & ident & ')')
+      result = gpuTypeToString(inner, '(' & ptrStar & ident & ')')
       skipIdent = true
     else:
-      let typ = gpuTypeToString(t.to, allowEmptyIdent = allowEmptyIdent)
+      let typ = gpuTypeToString(inner, allowEmptyIdent = allowEmptyIdent)
       let ptrStar = gpuTypeToString(t.kind)
       result = typ & ptrStar
   of gtArray:

--- a/workspace/crucible/tests/codegen/metal/test_metal_view_field_cast_space.nim
+++ b/workspace/crucible/tests/codegen/metal/test_metal_view_field_cast_space.nim
@@ -1,0 +1,48 @@
+## Metal: the kernel builds a view over a kernel buffer parameter
+## and passes `base +% offset` to a device fn that takes a `device` pointer.
+## This ensures that the buffer's address space (`device`) is propagated through casts.
+##
+## Run:
+##   cd tattletale
+##   nim c -r --hints:off --warnings:off \
+##     --outdir:build/tests --nimcache:nimcache/tests \
+##     workspace/crucible/tests/codegen/metal/test_metal_view_field_cast_space.nim
+
+import std/unittest
+import workspace/crucible
+
+type
+  GlView[T] = object
+    ## View over a device buffer: the base pointer plus runtime strides.
+    base: ptr UncheckedArray[T]
+    strideRow: int32
+    strideCol: int32
+
+template `+%`[T](p: ptr UncheckedArray[T], offset: SomeInteger): ptr UncheckedArray[T] =
+  ## Returns `p` advanced by `offset` elements (uint64 address arithmetic).
+  cast[ptr UncheckedArray[T]](cast[uint64](p) + uint64(offset) * uint64(sizeof(T)))
+
+const viewCastMsl = metal:
+  proc readAt[T](p: ptr UncheckedArray[T]; off: uint32): T =
+    p[off]
+
+  proc viewCastKernel(Out: ptr UncheckedArray[uint32];
+                      A: ptr UncheckedArray[uint16];
+                      N, K: int32) {.global.} =
+    let glA = GlView[uint16](base: A, strideRow: K, strideCol: 1)
+    let baseOff = uint32(2 * glA.strideRow + glA.strideCol)
+    Out[0] = uint32(readAt(glA.base +% baseOff, 0))
+
+proc runTest() =
+  suite "Metal - address-space propagation through pointer casts":
+    test "view base pointer arithmetic keeps the device address space":
+      var engine = bkMetal.init()
+      engine.ingest(viewCastMsl)
+      var A = [uint16(10), 20, 30, 40, 50, 60, 70, 80]
+      var res: array[1, uint32]
+      # baseOff = 2 * strideRow + strideCol = 2 * 3 + 1 = 7
+      engine.run("viewCastKernel", res, (A, int32(4), int32(3)))
+      check res[0] == uint32(A[7])
+
+when isMainModule:
+  runTest()


### PR DESCRIPTION
WebGPU does the right thing already :tm:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPU pointer type handling across CUDA, Metal, OpenCL, and Vulkan code generation.
  * Preserved correct pointer-to-array and regular pointer output while making address-space handling more reliable.

* **Tests**
  * Added coverage for Metal pointer casts, offsets, and device address-space propagation in strided view operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->