### PR TITLE
Crucible/Metal: support magic coordinate builtins in {.device.} and untagged functions

### DIFF
--- a/workspace/crucible/src/codegen/passes/passes_preprocessing.nim
+++ b/workspace/crucible/src/codegen/passes/passes_preprocessing.nim
@@ -1347,7 +1347,179 @@ proc registerOpenclPasses*(reg: var PassRegistry) =
           ctx.insertByrefAddrsImpl(fn.pBody)
   )
 
+# ═══════════════════════════════════════════════════════════════════════════
+# Phase 6: materializeIndexBuiltinParams pass (Metal)
+# ═══════════════════════════════════════════════════════════════════════════
+# MSL device functions have no implicit thread index: a body that references a
+# canonical coordinate builtin must bind it to a param the caller forwards.
+# This pass computes each function's transitive builtin needs once and appends
+# one param per need into `pParams`, for kernels and device functions alike,
+# with the param's symbol carrying the builtin kind (`coordBuiltin`, resolved
+# from the canonical name exactly as the frontend marks builtin symbols). The
+# Metal printer then discriminates the attribute form (kernels) from the plain
+# form (device functions) by that symbol field alone, and call sites forward
+# the canonical names.
+
+proc collectCoordBuiltinIdents(n: GpuAst, acc: var seq[(string, GpuCoordBuiltinKind)]) =
+  ## Records coordinate-builtin identifiers in first-use order, deduped by name.
+  ## The symbol's `coordBuiltin` decides, never the name: a local or declared
+  ## param shadowing a canonical name carries `gbkNone` and is skipped.
+  case n.kind
+  of gpuIdent:
+    if n.symbol != nil and n.symbol.coordBuiltin != gbkNone:
+      let name = n.ident()
+      if not acc.anyIt(it[0] == name):
+        acc.add (name, n.symbol.coordBuiltin)
+  else:
+    for ch in n:
+      collectCoordBuiltinIdents(ch, acc)
+
+proc collectCallees(n: GpuAst, callees: var seq[GpuAst]) =
+  ## Records the functions a body calls, in first-use order, deduped.
+  ## Barrier calls are skipped: they lower to a native statement, never a
+  ## function call.
+  case n.kind
+  of gpuCall:
+    if n.cName.symbol.synchroBuiltin == gbkNone and not callees.anyIt(it == n.cName):
+      callees.add n.cName
+    for ch in n:
+      collectCallees(ch, callees)
+  else:
+    for ch in n:
+      collectCallees(ch, callees)
+
+proc fnBuiltinNeedsImpl(ctx: GpuContext, fn: GpuAst,
+                        acc: var seq[(string, GpuCoordBuiltinKind)],
+                        visited: var seq[string]) =
+  ## Appends the coordinate builtins `fn` must bind, transitively: the builtins
+  ## its own body references, then the needs of every device function it calls,
+  ## each name first-seen once. A visited set guards recursive calls.
+  let key = fn.pName.symbol.iSym
+  if key in visited:
+    return
+  visited.add key
+  collectCoordBuiltinIdents(fn.pBody, acc)
+  var callees: seq[GpuAst]
+  collectCallees(fn.pBody, callees)
+  for calleeIdent in callees:
+    let callee = ctx.allFnTab.getOrDefault(calleeIdent,
+                                           ctx.genericInsts.getOrDefault(calleeIdent))
+    if not callee.isNil:
+      if callee.kind == gpuProc:
+        fnBuiltinNeedsImpl(ctx, callee, acc, visited)
+
+proc fnBuiltinNeeds(ctx: GpuContext, fn: GpuAst): seq[(string, GpuCoordBuiltinKind)] =
+  ## Transitive coordinate-builtin needs of `fn`: its own body, then every
+  ## device function it calls. The same first-seen order is used at every
+  ## emission site, so the identity-named identifiers bind to the params.
+  var visited: seq[string]
+  fnBuiltinNeedsImpl(ctx, fn, result, visited)
+
+proc builtinParamType(kind: GpuCoordBuiltinKind): GpuType =
+  ## IR type of a coordinate builtin bound as a param: scalar `uint32` for the
+  ## flat thread index, the MSL `uint3` vector spelling otherwise. `uint3` is a
+  ## synthetic generic name carrying the printer's native spelling; no struct
+  ## is ever registered for it.
+  if kind == gbkThreadIndexInThreadgroup:
+    GpuType(kind: gtUint32)
+  else:
+    GpuType(kind: gtGenericInst, gName: "uint3")
+
+proc appendBuiltinParams(fn: GpuAst,
+                         needs: seq[(string, GpuCoordBuiltinKind)]) =
+  ## Appends one plain param per transitive coordinate-builtin need, after the
+  ## declared params, for kernels and device functions alike. The param's
+  ## symbol carries the builtin kind (`coordBuiltin` resolved from the
+  ## canonical name via the builtin catalog, the same marking the frontend
+  ## applies to builtin identifiers), so the printer emits the attribute form
+  ## for kernels and the plain form for device functions by the symbol alone.
+  for (name, kind) in needs:
+    let typ = builtinParamType(kind)
+    let sym = newSymbol(name, iSym = name & "_builtin", symKind = gsDeviceKernelParam)
+    sym.coordBuiltin = coordBuiltinKind(name)
+    let ident = GpuAst(kind: gpuIdent, symbol: sym)
+    fn.pParams.add GpuParam(ident: ident, typ: typ,
+                            addressSpace: asRMEM, passByRef: false)
+
+proc appendBuiltinForwardingArgs(n: var GpuAst,
+                                 needs: seq[(string, GpuCoordBuiltinKind)]) =
+  ## Appends one forwarding arg per callee need, in the callee's needs order.
+  ## The identity-named identifiers bind to the caller's own params (kernel
+  ## attribute params or device-fn hidden params) in the emitted source.
+  for (name, _) in needs:
+    let sym = newSymbol(name, iSym = name & "_builtin", symKind = gsLocal)
+    n.cArgs.add GpuAst(kind: gpuIdent, symbol: sym)
+
+proc materializeCallArgsImpl(ctx: GpuContext, n: var GpuAst,
+                             needs: Table[string, seq[(string, GpuCoordBuiltinKind)]]) =
+  ## Appends the forwarding args to every `gpuCall` whose callee has
+  ## coordinate-builtin needs, in the callee's needs order. The walk happens
+  ## before the append so the argument list is not mutated mid-iteration.
+  case n.kind
+  of gpuCall:
+    let callee = ctx.allFnTab.getOrDefault(n.cName,
+                                           ctx.genericInsts.getOrDefault(n.cName))
+    var calleeNeeds: seq[(string, GpuCoordBuiltinKind)]
+    if not callee.isNil:
+      if callee.kind == gpuProc:
+        calleeNeeds = needs.getOrDefault(callee.pName.symbol.iSym, @[])
+    for ch in mitems(n):
+      materializeCallArgsImpl(ctx, ch, needs)
+    appendBuiltinForwardingArgs(n, calleeNeeds)
+  else:
+    for ch in mitems(n):
+      materializeCallArgsImpl(ctx, ch, needs)
+
+proc materializeIndexBuiltinParamsImpl*(ctx: var GpuContext) =
+  ## Materializes coordinate-builtin binding for the Metal backend:
+  ## - every function receives its transitive needs as params appended to
+  ##   `pParams`, after the declared params, the symbol carrying the builtin kind
+  ## - every call site forwards the callee's needs as trailing args
+  ##
+  ## MSL device functions have no implicit thread index, so a body that
+  ## references a canonical coordinate builtin binds it to a param the caller
+  ## forwards. The closure analysis runs first, once per function, so every
+  ## rewrite reads the same memoized needs in the same first-seen order.
+  var needs = initTable[string, seq[(string, GpuCoordBuiltinKind)]]()
+  for fnKey in ctx.allFnTab.keys:
+    var fn = ctx.allFnTab[fnKey]
+    if fn.kind == gpuProc:
+      needs[fn.pName.symbol.iSym] = fnBuiltinNeeds(ctx, fn)
+  for fnKey in ctx.genericInsts.keys:
+    var fn = ctx.genericInsts[fnKey]
+    if fn.kind == gpuProc:
+      needs[fn.pName.symbol.iSym] = fnBuiltinNeeds(ctx, fn)
+
+  # A pulled-in device function is registered in both `allFnTab` and
+  # `genericInsts` under the same symbol: rewrite each function once.
+  # Kernels and device functions alike receive the needs as params; the
+  # printer's attribute form vs plain form is decided by the symbol's
+  # `coordBuiltin` at emission time.
+  var done = initHashSet[string]()
+  for fnKey in ctx.allFnTab.keys:
+    var fn = ctx.allFnTab[fnKey]
+    if fn.kind == gpuProc:
+      let key = fn.pName.symbol.iSym
+      if key in done:
+        continue
+      done.incl key
+      appendBuiltinParams(fn, needs[key])
+      materializeCallArgsImpl(ctx, fn.pBody, needs)
+  for fnKey in ctx.genericInsts.keys:
+    var fn = ctx.genericInsts[fnKey]
+    if fn.kind == gpuProc:
+      let key = fn.pName.symbol.iSym
+      if key in done:
+        continue
+      done.incl key
+      appendBuiltinParams(fn, needs[key])
+      materializeCallArgsImpl(ctx, fn.pBody, needs)
+
 proc registerMetalPasses*(reg: var PassRegistry) =
-  ## Registers nothing. MSL is a C-family language (like CUDA), so the common passes
-  ## (`registerCommonPasses`) already cover the IR shapes the printer needs.
-  discard
+  ## Register Metal-specific preprocessing passes.
+  reg.register("materializeIndexBuiltinParams", pkTransform, phaseMain,
+    "Materializes coordinate-builtin binding: builtin params appended to pParams, call-site forwarding args",
+    dependsOn = @["emitFunctionSignatures"],
+    run = proc(ctx: var GpuContext): void =
+      materializeIndexBuiltinParamsImpl(ctx)
+  )

--- a/workspace/crucible/src/codegen/targets/metal_lang.nim
+++ b/workspace/crucible/src/codegen/targets/metal_lang.nim
@@ -10,6 +10,8 @@
 ## Lowers the shared GPU IR to MSL, modeled on the CUDA printer with Metal's ABI rules:
 ##   - kernel arguments are buffers (`device` pointers for arrays, `constant` references for scalars)
 ##   - referenced index builtins become attribute-qualified `uint3` parameters, one per use
+##   - device functions receive the same builtins as hidden plain parameters, forwarded at call sites
+##     (MSL device functions have no implicit thread index)
 ##   - the threadgroup size stays host-side (dispatch-time) and is never baked into the shader.
 ##
 ## `MetalReservedKeywords` is the MSL reserved-word table minus the boolean literals
@@ -215,6 +217,8 @@ proc genLit*(ast: GpuAst): string =
 proc collectAttrIdents(n: GpuAst, attrIdents: var seq[(string, GpuCoordBuiltinKind)]) =
   ## Records coordinate-builtin identifiers in first-use order, deduped by name.
   ## The `gpuCall` name is not part of the child walk, so the barrier never becomes an attribute param.
+  ## The symbol's `coordBuiltin` decides, never the name: a local or declared
+  ## param shadowing a canonical name carries `gbkNone` and is skipped.
   case n.kind
   of gpuIdent:
     if n.symbol != nil and n.symbol.coordBuiltin != gbkNone:
@@ -225,17 +229,57 @@ proc collectAttrIdents(n: GpuAst, attrIdents: var seq[(string, GpuCoordBuiltinKi
     for ch in n:
       collectAttrIdents(ch, attrIdents)
 
+proc collectCallees(n: GpuAst, callees: var seq[GpuAst]) =
+  ## Records the functions a body calls, in first-use order, deduped.
+  ## Barrier calls are skipped: they lower to a native MSL statement, never a
+  ## function call.
+  case n.kind
+  of gpuCall:
+    if n.cName.symbol.synchroBuiltin == gbkNone and not callees.anyIt(it == n.cName):
+      callees.add n.cName
+    for ch in n:
+      collectCallees(ch, callees)
+  else:
+    for ch in n:
+      collectCallees(ch, callees)
+
+proc fnBuiltinNeedsImpl(ctx: GpuContext, fn: GpuAst,
+                        acc: var seq[(string, GpuCoordBuiltinKind)],
+                        visited: var seq[string]) =
+  ## Appends the coordinate builtins `fn` must bind, transitively: the
+  ## builtins its own body references, then the needs of every device function
+  ## it calls, each name first-seen once. A visited set guards recursive calls.
+  let key = fn.pName.symbol.iSym
+  if key in visited:
+    return
+  visited.add key
+  collectAttrIdents(fn.pBody, acc)
+  var callees: seq[GpuAst]
+  collectCallees(fn.pBody, callees)
+  for calleeIdent in callees:
+    let callee = ctx.fnTab.getOrDefault(calleeIdent, ctx.allFnTab.getOrDefault(calleeIdent))
+    if callee != nil and callee.kind == gpuProc:
+      fnBuiltinNeedsImpl(ctx, callee, acc, visited)
+
+proc fnBuiltinNeeds(ctx: GpuContext, fn: GpuAst): seq[(string, GpuCoordBuiltinKind)] =
+  ## Transitive coordinate-builtin needs of `fn`: its own body, then every
+  ## device function it calls. Emitted as kernel attribute params, device-fn
+  ## hidden params, and call-site forwarding args, in this same order at every
+  ## site, so the identity-named identifiers bind to the params.
+  var visited: seq[string]
+  fnBuiltinNeedsImpl(ctx, fn, result, visited)
+
 proc genKernelParams(ctx: var GpuContext, fn: GpuAst): string =
   ## MSL kernel parameter list:
   ## - buffer params: `device T*`, never const — matches device-fn params, and
   ##   MSL accepts non-const input buffers
   ## - scalars: `constant T&`
-  ## - the attribute params for the index builtins the kernel body references
+  ## - the attribute params for the index builtins the kernel needs: its own
+  ##   body, plus the transitive needs of every device function it calls
   ## The workgroup size is dispatch-time, hence no baked threadgroup-size attribute.
   ## Scalars stay 4 bytes on the host (arg_blobs blobOf), so scalar `bool` is declared `int`.
   ## Buffer elements marshal at their Nim width, so bool buffers declare `bool` (1 byte).
-  var attrIdents: seq[(string, GpuCoordBuiltinKind)]
-  collectAttrIdents(fn.pBody, attrIdents)
+  let attrIdents = fnBuiltinNeeds(ctx, fn)
   var params: seq[string]
   var bufferIdx = 0
   for p in fn.pParams:
@@ -340,6 +384,12 @@ proc genMetalImpl(ctx: var GpuContext, ast: GpuAst, indent: int): string =
           params.add "thread const " & gpuTypeToString(p.typ, allowEmptyIdent = true) & "& " & p.ident.ident()
         else:
           params.add ctx.genDeviceParam(p)
+      for (name, kind) in fnBuiltinNeeds(ctx, ast):
+        # MSL device functions have no implicit thread index: a body that
+        # references a coordinate builtin binds it to a hidden param the
+        # caller forwards. Kernels receive the attribute form (genKernelParams).
+        let builtinType = if kind == gbkThreadIndexInThreadgroup: "uint" else: "uint3"
+        params.add builtinType & " " & name
     let fnArgs = params.join(", ")
     let fnSig = genFunctionType(ast.pRetType, ast.pName.ident(), fnArgs)
 
@@ -445,6 +495,13 @@ proc genMetalImpl(ctx: var GpuContext, ast: GpuAst, indent: int): string =
       var args: seq[string]
       for a in ast.cArgs:
         args.add ctx.genMetalImpl(a, 0)
+      let callee = ctx.fnTab.getOrDefault(ast.cName, ctx.allFnTab.getOrDefault(ast.cName))
+      if callee != nil and callee.kind == gpuProc:
+        # Forward the callee's needed coordinate builtins: the canonical names
+        # bind to the caller's own params (attribute params for kernels, hidden
+        # params for device functions).
+        for (name, _) in fnBuiltinNeeds(ctx, callee):
+          args.add name
       result = indentStr & ctx.getFnName(bkMetal, ast) & '(' & args.join(", ") & ')'
   of gpuTemplateCall:
     when nimvm:
@@ -464,8 +521,9 @@ proc genMetalImpl(ctx: var GpuContext, ast: GpuAst, indent: int): string =
 
   of gpuIdent:
     # Identity naming: the source-level builtin names are the MSL attribute names,
-    # so a builtin-marked identifier emits verbatim
-    # and binds to the attribute param `genKernelParams` injects for that reference.
+    # so a builtin-marked identifier emits verbatim and binds to the attribute
+    # param `genKernelParams` injects for a kernel, or to the hidden plain param
+    # a device function receives for the same builtin.
     # Unmarked identifiers never get a param, so an undeclared name stays a loud MSL error.
     checkReservedIdent(ast.ident(), "identifier")
     result = ast.ident()

--- a/workspace/crucible/src/codegen/targets/metal_lang.nim
+++ b/workspace/crucible/src/codegen/targets/metal_lang.nim
@@ -9,8 +9,10 @@
 ##
 ## Lowers the shared GPU IR to MSL, modeled on the CUDA printer with Metal's ABI rules:
 ##   - kernel arguments are buffers (`device` pointers for arrays, `constant` references for scalars)
-##   - referenced index builtins become attribute-qualified `uint3` parameters, one per use
-##   - device functions receive the same builtins as hidden plain parameters, forwarded at call sites
+##   - coordinate builtins ride in the param list: the `materializeIndexBuiltinParams` pass
+##     appends one param per referenced builtin, marked on the symbol's `coordBuiltin`.
+##     Kernels emit the attribute-qualified form (`uint3 name [[name]]`), device functions
+##     the plain form, and call sites forward the names
 ##     (MSL device functions have no implicit thread index)
 ##   - the threadgroup size stays host-side (dispatch-time) and is never baked into the shader.
 ##
@@ -214,77 +216,30 @@ proc genLit*(ast: GpuAst): string =
     else:
       result = ast.lValue
 
-proc collectAttrIdents(n: GpuAst, attrIdents: var seq[(string, GpuCoordBuiltinKind)]) =
-  ## Records coordinate-builtin identifiers in first-use order, deduped by name.
-  ## The `gpuCall` name is not part of the child walk, so the barrier never becomes an attribute param.
-  ## The symbol's `coordBuiltin` decides, never the name: a local or declared
-  ## param shadowing a canonical name carries `gbkNone` and is skipped.
-  case n.kind
-  of gpuIdent:
-    if n.symbol != nil and n.symbol.coordBuiltin != gbkNone:
-      let name = n.ident()
-      if not attrIdents.anyIt(it[0] == name):
-        attrIdents.add (name, n.symbol.coordBuiltin)
-  else:
-    for ch in n:
-      collectAttrIdents(ch, attrIdents)
-
-proc collectCallees(n: GpuAst, callees: var seq[GpuAst]) =
-  ## Records the functions a body calls, in first-use order, deduped.
-  ## Barrier calls are skipped: they lower to a native MSL statement, never a
-  ## function call.
-  case n.kind
-  of gpuCall:
-    if n.cName.symbol.synchroBuiltin == gbkNone and not callees.anyIt(it == n.cName):
-      callees.add n.cName
-    for ch in n:
-      collectCallees(ch, callees)
-  else:
-    for ch in n:
-      collectCallees(ch, callees)
-
-proc fnBuiltinNeedsImpl(ctx: GpuContext, fn: GpuAst,
-                        acc: var seq[(string, GpuCoordBuiltinKind)],
-                        visited: var seq[string]) =
-  ## Appends the coordinate builtins `fn` must bind, transitively: the
-  ## builtins its own body references, then the needs of every device function
-  ## it calls, each name first-seen once. A visited set guards recursive calls.
-  let key = fn.pName.symbol.iSym
-  if key in visited:
-    return
-  visited.add key
-  collectAttrIdents(fn.pBody, acc)
-  var callees: seq[GpuAst]
-  collectCallees(fn.pBody, callees)
-  for calleeIdent in callees:
-    let callee = ctx.fnTab.getOrDefault(calleeIdent, ctx.allFnTab.getOrDefault(calleeIdent))
-    if callee != nil and callee.kind == gpuProc:
-      fnBuiltinNeedsImpl(ctx, callee, acc, visited)
-
-proc fnBuiltinNeeds(ctx: GpuContext, fn: GpuAst): seq[(string, GpuCoordBuiltinKind)] =
-  ## Transitive coordinate-builtin needs of `fn`: its own body, then every
-  ## device function it calls. Emitted as kernel attribute params, device-fn
-  ## hidden params, and call-site forwarding args, in this same order at every
-  ## site, so the identity-named identifiers bind to the params.
-  var visited: seq[string]
-  fnBuiltinNeedsImpl(ctx, fn, result, visited)
-
 proc genKernelParams(ctx: var GpuContext, fn: GpuAst): string =
   ## MSL kernel parameter list:
   ## - buffer params: `device T*`, never const — matches device-fn params, and
   ##   MSL accepts non-const input buffers
   ## - scalars: `constant T&`
-  ## - the attribute params for the index builtins the kernel needs: its own
-  ##   body, plus the transitive needs of every device function it calls
+  ## - a param whose symbol carries a coordinate builtin kind emits the
+  ##   attribute form (`uint3 name [[name]]`, scalar `uint` for the flat thread
+  ##   index): no `[[buffer(n)]]` binding, and it does not advance the buffer
+  ##   index. The `materializeIndexBuiltinParams` pass appends these after the
+  ##   declared params, so declared params keep their `[[buffer(n)]]` positions.
   ## The workgroup size is dispatch-time, hence no baked threadgroup-size attribute.
   ## Scalars stay 4 bytes on the host (arg_blobs blobOf), so scalar `bool` is declared `int`.
   ## Buffer elements marshal at their Nim width, so bool buffers declare `bool` (1 byte).
-  let attrIdents = fnBuiltinNeeds(ctx, fn)
   var params: seq[string]
   var bufferIdx = 0
   for p in fn.pParams:
     let name = p.ident.ident()
     checkReservedIdent(name, "parameter")
+    if p.ident.symbol.coordBuiltin != gbkNone:
+      # The five coordinate builtins are `uint3` attribute params.
+      # The flat thread index `gbkThreadIndexInThreadgroup` is a scalar `uint` builtin.
+      let attrType = if p.ident.symbol.coordBuiltin == gbkThreadIndexInThreadgroup: "uint" else: "uint3"
+      params.add attrType & " " & name & " [[" & name & "]]"
+      continue
     let binding = " [[buffer(" & $bufferIdx & ")]]"
     if p.typ.kind == gtPtr:
       var inner = p.typ.to
@@ -298,11 +253,6 @@ proc genKernelParams(ctx: var GpuContext, fn: GpuAst): string =
         elem = "int"
       params.add "constant " & elem & "& " & name & binding
     inc bufferIdx
-  for (attr, kind) in attrIdents:
-    # The five coordinate builtins are `uint3` attribute params.
-    # The flat thread index `gbkThreadIndexInThreadgroup` is a scalar `uint` builtin.
-    let attrType = if kind == gbkThreadIndexInThreadgroup: "uint" else: "uint3"
-    params.add attrType & " " & attr & " [[" & attr & "]]"
   result = params.join(", ")
 
 proc genDeviceParam(ctx: var GpuContext, p: GpuParam): string =
@@ -384,12 +334,6 @@ proc genMetalImpl(ctx: var GpuContext, ast: GpuAst, indent: int): string =
           params.add "thread const " & gpuTypeToString(p.typ, allowEmptyIdent = true) & "& " & p.ident.ident()
         else:
           params.add ctx.genDeviceParam(p)
-      for (name, kind) in fnBuiltinNeeds(ctx, ast):
-        # MSL device functions have no implicit thread index: a body that
-        # references a coordinate builtin binds it to a hidden param the
-        # caller forwards. Kernels receive the attribute form (genKernelParams).
-        let builtinType = if kind == gbkThreadIndexInThreadgroup: "uint" else: "uint3"
-        params.add builtinType & " " & name
     let fnArgs = params.join(", ")
     let fnSig = genFunctionType(ast.pRetType, ast.pName.ident(), fnArgs)
 
@@ -495,13 +439,6 @@ proc genMetalImpl(ctx: var GpuContext, ast: GpuAst, indent: int): string =
       var args: seq[string]
       for a in ast.cArgs:
         args.add ctx.genMetalImpl(a, 0)
-      let callee = ctx.fnTab.getOrDefault(ast.cName, ctx.allFnTab.getOrDefault(ast.cName))
-      if callee != nil and callee.kind == gpuProc:
-        # Forward the callee's needed coordinate builtins: the canonical names
-        # bind to the caller's own params (attribute params for kernels, hidden
-        # params for device functions).
-        for (name, _) in fnBuiltinNeeds(ctx, callee):
-          args.add name
       result = indentStr & ctx.getFnName(bkMetal, ast) & '(' & args.join(", ") & ')'
   of gpuTemplateCall:
     when nimvm:
@@ -522,8 +459,8 @@ proc genMetalImpl(ctx: var GpuContext, ast: GpuAst, indent: int): string =
   of gpuIdent:
     # Identity naming: the source-level builtin names are the MSL attribute names,
     # so a builtin-marked identifier emits verbatim and binds to the attribute
-    # param `genKernelParams` injects for a kernel, or to the hidden plain param
-    # a device function receives for the same builtin.
+    # param `genKernelParams` emits for a kernel, or to the plain param a device
+    # function receives for the same builtin.
     # Unmarked identifiers never get a param, so an undeclared name stays a loud MSL error.
     checkReservedIdent(ast.ident(), "identifier")
     result = ast.ident()

--- a/workspace/crucible/tests/codegen/ir/test_ir_materializeIndexBuiltinParams.nim
+++ b/workspace/crucible/tests/codegen/ir/test_ir_materializeIndexBuiltinParams.nim
@@ -1,0 +1,288 @@
+## Phase 6: materializeIndexBuiltinParams pass test
+##
+## MSL device functions have no implicit thread index, so a body that
+## references a canonical coordinate builtin must bind it to a param the caller
+## forwards. The pass computes each function's transitive builtin needs once
+## and appends one param per need into `pParams`, for kernels AND device
+## functions, after the declared params. Each appended param's symbol carries
+## the builtin kind (`ident.symbol.coordBuiltin`), so the Metal printer
+## discriminates the attribute form (kernels) from the plain form (device
+## functions) by that symbol field alone. This test asserts the rewrite on
+## hand-built IR:
+## - builtin params land in `pParams` (kernel + device fn) with
+##   `ident.symbol.coordBuiltin` carrying the kind
+## - declared params keep their positions and types (the buffer-binding order
+##   the printer relies on)
+## - a call site forwards the args in the callee's needs order
+## - a local shadowing a canonical name (gbkNone) is NOT collected
+## - a device fn calling itself terminates and rewrites consistently
+## - a fn registered in both tables is rewritten once
+## - a barrier call is never treated as a callee
+##
+## Run:
+##   cd tattletale
+##   nim c -r --hints:off --warnings:off --debugger:native \
+##     --outdir:build/tests/ir --nimcache:nimcache/tests/ir \
+##     workspace/crucible/tests/codegen/ir/test_ir_materializeIndexBuiltinParams.nim
+
+import std / [tables, sequtils]
+import workspace/crucible/src/codegen/ir/gpu_types
+import workspace/crucible/src/codegen/passes/passes_preprocessing
+
+# ── IR builders ─────────────────────────────────────────────────────────────
+
+proc builtinIdent(name: string; kind: GpuCoordBuiltinKind): GpuAst =
+  ## gpuIdent for a canonical coordinate builtin, with its IR kind marked.
+  let sym = newSymbol(name, iSym = name & "_sym", symKind = gsBuiltin)
+  sym.coordBuiltin = kind
+  GpuAst(kind: gpuIdent, symbol: sym)
+
+proc plainIdent(name: string): GpuAst =
+  ## gpuIdent for a plain (non-builtin) name, e.g. a local shadowing a
+  ## canonical builtin name: `coordBuiltin` stays `gbkNone`.
+  GpuAst(kind: gpuIdent, symbol: newSymbol(name, iSym = name & "_local"))
+
+proc makeCall(callee: GpuAst): GpuAst =
+  ## gpuCall to `callee`, sharing its pName symbol so the pass's table lookup
+  ## (hashed on the symbol) resolves it.
+  GpuAst(kind: gpuCall, cName: callee.pName.clone(), cArgs: @[])
+
+proc makeProc(name: string; body: GpuAst; isKernel = false): GpuAst =
+  ## gpuProc with a fresh symbol; the body is a gpuBlock of statements.
+  var fn = GpuAst(kind: gpuProc)
+  fn.pName = GpuAst(kind: gpuIdent,
+                    symbol: newSymbol(name, iSym = name & "_isym", symKind = gsProc))
+  fn.pRetType = GpuType(kind: gtVoid)
+  fn.pBody = body
+  if isKernel:
+    fn.pAttributes = {attGlobal}
+  else:
+    fn.pAttributes = {attDevice}
+  fn
+
+proc makeParam(name: string; typ: GpuType; space: AddressSpace): GpuParam =
+  ## Declared param (gbkNone symbol), as a kernel or device fn would carry.
+  GpuParam(ident: GpuAst(kind: gpuIdent,
+                         symbol: newSymbol(name, iSym = name & "_isym",
+                                           symKind = gsGlobalKernelParam)),
+           typ: typ, addressSpace: space, passByRef: false)
+
+proc blockOf(stmts: varargs[GpuAst]): GpuAst =
+  ## gpuBlock of statements, the shape every pass body walk expects.
+  GpuAst(kind: gpuBlock, statements: @stmts)
+
+proc callArgNames(fn: GpuAst; stmtIdx: int): seq[string] =
+  ## Ident names of the call-site args of `fn`'s `stmtIdx`-th statement.
+  let call = fn.pBody.statements[stmtIdx]
+  doAssert call.kind == gpuCall, "statement " & $stmtIdx & " is not a call"
+  for a in call.cArgs:
+    result.add a.ident()
+
+proc paramNames(fn: GpuAst): seq[string] =
+  ## Ident names of `fn`'s params, in order.
+  for p in fn.pParams:
+    result.add p.ident.ident()
+
+proc paramKinds(fn: GpuAst): seq[GpuCoordBuiltinKind] =
+  ## `coordBuiltin` kinds of `fn`'s params, in order.
+  for p in fn.pParams:
+    result.add p.ident.symbol.coordBuiltin
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 1. Device fn gains the builtin params: canonical name + coordBuiltin kind + type
+# ═══════════════════════════════════════════════════════════════════════════
+block:
+  let body = blockOf(
+    builtinIdent("thread_position_in_threadgroup", gbkThreadPositionInThreadgroup),
+    builtinIdent("thread_index_in_threadgroup", gbkThreadIndexInThreadgroup)
+  )
+  var fn = makeProc("need", body)
+  var ctx = GpuContext()
+  ctx.allFnTab[fn.pName] = fn
+
+  materializeIndexBuiltinParamsImpl(ctx)
+
+  doAssert fn.pParams.len == 2,
+    "device fn must gain one builtin param per need, got " & $fn.pParams.len
+  doAssert fn.pParams[0].ident.ident() == "thread_position_in_threadgroup",
+    "builtin param must use the canonical name"
+  doAssert fn.pParams[0].ident.symbol.coordBuiltin == gbkThreadPositionInThreadgroup,
+    "builtin param symbol must carry the builtin kind"
+  doAssert fn.pParams[0].typ.kind == gtGenericInst,
+    "vector builtin param must carry the uint3 generic spelling"
+  doAssert fn.pParams[0].typ.gName == "uint3"
+  doAssert fn.pParams[1].ident.ident() == "thread_index_in_threadgroup"
+  doAssert fn.pParams[1].ident.symbol.coordBuiltin == gbkThreadIndexInThreadgroup,
+    "flat thread index param symbol must carry the builtin kind"
+  doAssert fn.pParams[1].typ.kind == gtUint32,
+    "flat thread index param must be scalar uint32"
+  echo "  OK — device fn gains builtin params (canonical name, coordBuiltin kind, uint3/uint type)"
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 2. Kernel gains the builtin params: own ref AND transitive callee need,
+#    declared params keep positions and types (binding-order invariant)
+# ═══════════════════════════════════════════════════════════════════════════
+block:
+  var callee = makeProc("callee",
+    blockOf(builtinIdent("thread_position_in_grid", gbkThreadPositionInGrid)))
+  var kernel = makeProc("kern",
+    blockOf(
+      builtinIdent("threadgroups_per_grid", gbkThreadgroupsPerGrid),
+      makeCall(callee)
+    ), isKernel = true)
+  # Declared params, as a real kernel carries: a buffer and a scalar.
+  kernel.pParams = @[
+    makeParam("data", GpuType(kind: gtPtr, to: GpuType(kind: gtUint32)), asDevice),
+    makeParam("n", GpuType(kind: gtUint32), asConstant)
+  ]
+  var ctx = GpuContext()
+  ctx.allFnTab[callee.pName] = callee
+  ctx.allFnTab[kernel.pName] = kernel
+
+  materializeIndexBuiltinParamsImpl(ctx)
+
+  # Declared params keep their positions, types, and unmarked symbols.
+  doAssert kernel.pParams.len == 4,
+    "kernel pParams = 2 declared + 2 builtin params, got " & $kernel.pParams.len
+  doAssert paramNames(kernel) == @["data", "n",
+    "threadgroups_per_grid", "thread_position_in_grid"],
+    "declared params first, builtin params appended after"
+  doAssert kernel.pParams[0].typ.kind == gtPtr,
+    "declared buffer param keeps its pointer type"
+  doAssert kernel.pParams[0].typ.to.kind == gtUint32
+  doAssert kernel.pParams[1].typ.kind == gtUint32,
+    "declared scalar param keeps its type"
+  doAssert paramKinds(kernel) == @[GpuCoordBuiltinKind.gbkNone, GpuCoordBuiltinKind.gbkNone,
+    gbkThreadgroupsPerGrid, gbkThreadPositionInGrid],
+    "declared params stay gbkNone; builtin params carry the kinds"
+  doAssert callee.pParams.len == 1,
+    "callee device fn must gain its own builtin param"
+  doAssert callee.pParams[0].ident.ident() == "thread_position_in_grid"
+  doAssert callee.pParams[0].ident.symbol.coordBuiltin == gbkThreadPositionInGrid
+  echo "  OK — kernel pParams: declared params keep positions/types, builtin params appended with kinds"
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 3. Call site forwards the args in the callee's needs order
+# ═══════════════════════════════════════════════════════════════════════════
+block:
+  var d1 = makeProc("d1",
+    blockOf(builtinIdent("thread_position_in_grid", gbkThreadPositionInGrid)))
+  var d2 = makeProc("d2",
+    blockOf(
+      builtinIdent("thread_position_in_threadgroup", gbkThreadPositionInThreadgroup),
+      builtinIdent("thread_index_in_threadgroup", gbkThreadIndexInThreadgroup)
+    ))
+  var kernel = makeProc("kern2",
+    blockOf(makeCall(d1), makeCall(d2)), isKernel = true)
+  var ctx = GpuContext()
+  ctx.allFnTab[d1.pName] = d1
+  ctx.allFnTab[d2.pName] = d2
+  ctx.allFnTab[kernel.pName] = kernel
+
+  materializeIndexBuiltinParamsImpl(ctx)
+
+  # Kernel params: first-seen over own refs (none) then callee subtrees.
+  doAssert paramNames(kernel) == @[
+    "thread_position_in_grid",
+    "thread_position_in_threadgroup",
+    "thread_index_in_threadgroup"
+  ], "kernel builtin params must follow callee order, deduped"
+  doAssert paramKinds(kernel) == @[
+    gbkThreadPositionInGrid,
+    gbkThreadPositionInThreadgroup,
+    gbkThreadIndexInThreadgroup
+  ]
+  # Call 1 forwards d1's single need; call 2 forwards d2's needs in d2's order.
+  doAssert callArgNames(kernel, 0) == @["thread_position_in_grid"],
+    "call to d1 must forward exactly d1's need"
+  doAssert callArgNames(kernel, 1) == @[
+    "thread_position_in_threadgroup", "thread_index_in_threadgroup"
+  ], "call to d2 must forward d2's needs in d2's order"
+  doAssert paramNames(d2) == @[
+    "thread_position_in_threadgroup", "thread_index_in_threadgroup"
+  ]
+  doAssert paramKinds(d2) == @[gbkThreadPositionInThreadgroup, gbkThreadIndexInThreadgroup]
+  echo "  OK — call sites forward the callee's needs in callee order"
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 4. Shadowing local (coordBuiltin == gbkNone) is NOT collected
+# ═══════════════════════════════════════════════════════════════════════════
+block:
+  let shadow = plainIdent("thread_position_in_grid")
+  doAssert shadow.symbol.coordBuiltin == gbkNone,
+    "a plain local must carry no coordinate kind"
+  var fn = makeProc("shadow", blockOf(shadow))
+  var ctx = GpuContext()
+  ctx.allFnTab[fn.pName] = fn
+
+  materializeIndexBuiltinParamsImpl(ctx)
+
+  doAssert fn.pParams.len == 0,
+    "a local shadowing a canonical name must not produce a builtin param"
+  echo "  OK — shadowed builtin local (gbkNone) not collected"
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 5. Recursion (a device fn calling itself) terminates
+# ═══════════════════════════════════════════════════════════════════════════
+block:
+  var fn = makeProc("rec", GpuAst(kind: gpuBlock))
+  fn.pBody = blockOf(
+    builtinIdent("thread_index_in_threadgroup", gbkThreadIndexInThreadgroup),
+    makeCall(fn)
+  )
+  var ctx = GpuContext()
+  ctx.allFnTab[fn.pName] = fn
+
+  materializeIndexBuiltinParamsImpl(ctx)
+
+  doAssert fn.pParams.len == 1,
+    "recursive fn must gain only its own body's need"
+  doAssert fn.pParams[0].ident.ident() == "thread_index_in_threadgroup"
+  doAssert fn.pParams[0].ident.symbol.coordBuiltin == gbkThreadIndexInThreadgroup
+  doAssert callArgNames(fn, 1) == @["thread_index_in_threadgroup"],
+    "the recursive call must forward the fn's own need"
+  echo "  OK — recursive device fn terminates and rewrites consistently"
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 6. A fn registered in both tables is rewritten once
+# ═══════════════════════════════════════════════════════════════════════════
+block:
+  # Pulled-in module-level device fns land in `allFnTab` AND `genericInsts`
+  # under the same symbol; the rewrite must not double-append.
+  var fn = makeProc("both",
+    blockOf(builtinIdent("thread_position_in_grid", gbkThreadPositionInGrid)))
+  var ctx = GpuContext()
+  ctx.allFnTab[fn.pName] = fn
+  ctx.genericInsts[fn.pName] = fn
+
+  materializeIndexBuiltinParamsImpl(ctx)
+
+  doAssert fn.pParams.len == 1,
+    "builtin param must be appended once despite two table entries"
+  echo "  OK — fn in both tables rewritten once"
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 7. Barrier call is not a callee
+# ═══════════════════════════════════════════════════════════════════════════
+block:
+  let barrierSym = newSymbol("threadgroup_barrier", iSym = "barrier_isym",
+                             symKind = gsBuiltin)
+  barrierSym.synchroBuiltin = gbkThreadgroupBarrier
+  let barrierCall = GpuAst(kind: gpuCall,
+                           cName: GpuAst(kind: gpuIdent, symbol: barrierSym),
+                           cArgs: @[])
+  var fn = makeProc("bar",
+    blockOf(barrierCall,
+            builtinIdent("thread_position_in_grid", gbkThreadPositionInGrid)))
+  var ctx = GpuContext()
+  ctx.allFnTab[fn.pName] = fn
+
+  materializeIndexBuiltinParamsImpl(ctx)
+
+  doAssert fn.pParams.len == 1,
+    "the barrier must not count as a callee need"
+  doAssert fn.pParams[0].ident.ident() == "thread_position_in_grid"
+  echo "  OK — barrier call skipped as a callee"
+
+echo ""
+echo "  All materializeIndexBuiltinParams tests passed."

--- a/workspace/crucible/tests/codegen/metal/test_metal_device_fn_builtin.nim
+++ b/workspace/crucible/tests/codegen/metal/test_metal_device_fn_builtin.nim
@@ -1,0 +1,35 @@
+## Metal: a coordinate builtin referenced inside a `{.device.}` proc body.
+##
+## In Metal, `thread_index_in_threadgroup` becomes an implicit parameter
+## of the functions that reference it.
+## One threadgroup of 32 threads runs. Every slot must hold its lane index.
+##
+## Run:
+##   cd tattletale
+##   nim c -r --hints:off --warnings:off \
+##     --outdir:build/tests --nimcache:nimcache/tests \
+##     workspace/crucible/tests/codegen/metal/test_metal_device_fn_builtin.nim
+
+import std/unittest
+import workspace/crucible
+
+proc fillLane(p: ptr UncheckedArray[uint32]) {.device.} =
+  let t = thread_index_in_threadgroup
+  p[t] = t
+
+const laneIdMsl = metal:
+  proc fillLaneKernel(p: ptr UncheckedArray[uint32]) {.global.} =
+    fillLane(p)
+
+proc runTest() =
+  suite "Metal - coordinate builtin in a device fn":
+    test "per-lane values 0..31 written by the device fn":
+      var engine = bkMetal.init()
+      engine.ingest(laneIdMsl)
+      var res: array[32, uint32]
+      engine.run<<(grid: (1, 1), blk: (32, 1))>>("fillLaneKernel", res, ())
+      for i in 0 ..< 32:
+        check res[i] == uint32(i)
+
+when isMainModule:
+  runTest()

--- a/workspace/crucible/tests/codegen/metal/test_metal_device_fn_builtin_chain.nim
+++ b/workspace/crucible/tests/codegen/metal/test_metal_device_fn_builtin_chain.nim
@@ -1,0 +1,56 @@
+## Metal: coordinate builtins thread transitively through device-fn call chains.
+## `bump` reads `thread_index_in_threadgroup`; `mid` reads
+## `thread_position_in_threadgroup.x` and calls `bump`; the kernels call them.
+## The kernels receive the attribute params and forward them through every
+## level, so the body identifiers bind at each depth. The second kernel also
+## references the builtin itself: one attribute param serves both the kernel
+## body and the forwarding args (dedup) — a duplicate param would fail MSL
+## compilation at ingest.
+##
+## Run:
+##   cd tattletale
+##   nim c -r --hints:off --warnings:off \
+##     --outdir:build/tests --nimcache:nimcache/tests \
+##     workspace/crucible/tests/codegen/metal/test_metal_device_fn_builtin_chain.nim
+
+import std/unittest
+import workspace/crucible
+
+proc bump(p: ptr UncheckedArray[uint32]) {.device.} =
+  let t = thread_index_in_threadgroup
+  p[t] = p[t] + 100'u32
+
+proc mid(p: ptr UncheckedArray[uint32]) {.device.} =
+  let x = thread_position_in_threadgroup.x
+  p[x] = x
+  bump(p)
+
+const chainMsl = metal:
+  proc chainKernel(p: ptr UncheckedArray[uint32]) {.global.} =
+    mid(p)
+
+  proc directKernel(o: ptr UncheckedArray[uint32]) {.global.} =
+    let t = thread_index_in_threadgroup
+    o[t] = t
+    bump(o)
+
+proc runTest() =
+  suite "Metal - transitive builtin threading through device-fn chains":
+    test "two-level chain forwards both builtins (kernel -> mid -> bump)":
+      var engine = bkMetal.init()
+      engine.ingest(chainMsl)
+      var res: array[32, uint32]
+      engine.run<<(grid: (1, 1), blk: (32, 1))>>("chainKernel", res, ())
+      for i in 0 ..< 32:
+        check res[i] == uint32(i + 100)
+
+    test "kernel own ref and the chain share one attribute param":
+      var engine = bkMetal.init()
+      engine.ingest(chainMsl)
+      var res: array[32, uint32]
+      engine.run<<(grid: (1, 1), blk: (32, 1))>>("directKernel", res, ())
+      for i in 0 ..< 32:
+        check res[i] == uint32(i + 100)
+
+when isMainModule:
+  runTest()

--- a/workspace/crucible/tests/codegen/metal/test_metal_device_fn_builtin_param_name.nim
+++ b/workspace/crucible/tests/codegen/metal/test_metal_device_fn_builtin_param_name.nim
@@ -1,0 +1,35 @@
+## Metal: a device fn whose declared param is named like a coordinate builtin.
+## `echoParam` declares `thread_index_in_threadgroup: uint32` and writes it
+## through. The printer must distinguish the param by symbol (gbkNone) from the
+## builtin, so no hidden param is injected and the name binds to the declared
+## param. A collision would fail MSL compilation at ingest with a duplicate
+## parameter error.
+##
+## Run:
+##   cd tattletale
+##   nim c -r --hints:off --warnings:off \
+##     --outdir:build/tests --nimcache:nimcache/tests \
+##     workspace/crucible/tests/codegen/metal/test_metal_device_fn_builtin_param_name.nim
+
+import std/unittest
+import workspace/crucible
+
+proc echoParam(p: ptr UncheckedArray[uint32];
+               thread_index_in_threadgroup: uint32) {.device.} =
+  p[0] = thread_index_in_threadgroup
+
+const paramMsl = metal:
+  proc paramKernel(p: ptr UncheckedArray[uint32]) {.global.} =
+    echoParam(p, 42'u32)
+
+proc runTest() =
+  suite "Metal - device fn param named like a builtin":
+    test "the declared param binds; no hidden param collides":
+      var engine = bkMetal.init()
+      engine.ingest(paramMsl)
+      var res: array[1, uint32]
+      engine.run("paramKernel", res, ())
+      check res[0] == 42'u32
+
+when isMainModule:
+  runTest()


### PR DESCRIPTION
Metal requires the kernel and device functions to declare builtin coordinates like `thread_index_in_threadgroup` as function parameters.

Crucible supported this for global/kernels but not in device dependencies. This fixes the gap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Metal kernels and device functions now support thread-coordinate builtins as explicit parameters.
  * Builtin values are automatically forwarded through chains of device-function calls.
  * Existing parameter names and ordering are preserved, including names matching builtin identifiers.

* **Bug Fixes**
  * Prevented duplicate builtin parameters and incorrect handling of recursive or synchronized calls.

* **Tests**
  * Added coverage for builtin propagation, execution across device-function chains, parameter-name collisions, and coordinate correctness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->