### PR TITLE
Fix tuple types having different generated names in generics and constructors

### DIFF
--- a/workspace/crucible/src/codegen/ir/resolvers.nim
+++ b/workspace/crucible/src/codegen/ir/resolvers.nim
@@ -85,24 +85,44 @@ type
     typeNode: NimNode
 
 proc resolveTupleFields(node: NimNode): seq[FieldInfo] =
-  ## Shared traversal of nnkTupleTy / nnkTupleConstr.
+  ## Shared traversal of the anonymous tuple type in any of its AST spellings:
+  ## nnkTupleTy / nnkTupleConstr and the nnkBracketExpr `tuple[...]` full form.
   ## Called by both resolveRecordFields and assignTypeName.
-  node.expectKind({nnkTupleTy, nnkTupleConstr})
-  for i, ch in node:
-    case ch.kind
-    of nnkIdentDefs:
-      for j in 0 ..< ch.len - 2:
-        result.add FieldInfo(name: ch[j].strVal, typeNode: ch[ch.len - 2])
-    of nnkSym:
-      result.add FieldInfo(name: "F" & $i, typeNode: ch)
-    of nnkExprColonExpr:
-      result.add FieldInfo(name: ch[0].strVal, typeNode: ch[1])
-    of nnkBracketExpr:
-      # resolve via getTypeInst() to avoid leaking ObjectTy repr into struct name
-      result.add FieldInfo(name: "F" & $i, typeNode: ch.getTypeInst())
-    else:
-      # resolve via getTypeInst() to avoid leaking ObjectTy repr into struct name
-      result.add FieldInfo(name: "F" & $i, typeNode: ch.getTypeInst())
+  case node.kind
+  of nnkTupleTy, nnkTupleConstr:
+    for i, ch in node:
+      case ch.kind
+      of nnkIdentDefs:
+        for j in 0 ..< ch.len - 2:
+          result.add FieldInfo(name: ch[j].strVal, typeNode: ch[ch.len - 2])
+      of nnkSym:
+        result.add FieldInfo(name: "F" & $i, typeNode: ch)
+      of nnkExprColonExpr:
+        result.add FieldInfo(name: ch[0].strVal, typeNode: ch[1])
+      of nnkBracketExpr:
+        # resolve via getTypeInst() to avoid leaking ObjectTy repr into struct name
+        result.add FieldInfo(name: "F" & $i, typeNode: ch.getTypeInst())
+      else:
+        # resolve via getTypeInst() to avoid leaking ObjectTy repr into struct name
+        result.add FieldInfo(name: "F" & $i, typeNode: ch.getTypeInst())
+  of nnkBracketExpr:
+    # `tuple[Int[1], Int[2]]` is the full AST form of an anonymous tuple type
+    # (getTypeInst output, e.g. generic args of an object construction).
+    doAssert node[0].kind in {nnkSym, nnkIdent} and node[0].strVal == "tuple",
+      "unexpected tuple bracket: " & $node.treerepr
+    for i in 1 ..< node.len:
+      result.add FieldInfo(name: "F" & $(i - 1), typeNode: node[i].getTypeInst())
+  else:
+    error "Unsupported node kind for tuple fields: " & $node.kind
+
+proc tupleTypeName(fields: seq[FieldInfo]): string =
+  ## Canonical struct name for an anonymous tuple type: `Tuple_` + one
+  ## `Name_TypeName` segment per field. Every AST spelling of the same tuple
+  ## type names through this single function.
+  result = "Tuple_"
+  for i, fi in fields:
+    if i > 0: result.add "_"
+    result.add fi.name & "_" & fi.typeNode.assignTypeName()
 
 # ═══════════════════════════════════════════════════════════════════════
 #  Generic type argument / implementation resolution
@@ -205,15 +225,17 @@ proc assignTypeName*(n: NimNode, recursedSym: bool = false): string =
     # Anonymous object type — use its repr as a fallback name.
     result = n.repr
   of nnkTupleTy, nnkTupleConstr:
-    result = "Tuple_"
-    for i, fi in resolveTupleFields(n):
-      if i > 0: result.add "_"
-      let typName = fi.typeNode.assignTypeName()
-      result.add fi.name & "_" & typName
+    result = tupleTypeName(resolveTupleFields(n))
   of nnkBracketExpr:
-    # construct a type name `Foo_Bar_Baz`
-    for i, ch in n:
-      result.add ch.assignTypeName()
+    # `tuple[Int[1], Int[2]]` is the full AST form of an anonymous tuple type
+    # (getTypeInst output, e.g. generic args of an object construction).
+    # It must name identically to the nnkTupleConstr form.
+    if n.len >= 2 and n[0].kind in {nnkSym, nnkIdent} and n[0].strVal == "tuple":
+      result = tupleTypeName(resolveTupleFields(n))
+    else:
+      # construct a type name `Foo_Bar_Baz`
+      for i, ch in n:
+        result.add ch.assignTypeName()
   of nnkIntLit:
     result = $n.intVal
   of nnkUIntLit:

--- a/workspace/crucible/src/codegen/ir/resolvers.nim
+++ b/workspace/crucible/src/codegen/ir/resolvers.nim
@@ -121,7 +121,8 @@ proc tupleTypeName(fields: seq[FieldInfo]): string =
   ## type names through this single function.
   result = "Tuple_"
   for i, fi in fields:
-    if i > 0: result.add "_"
+    if i > 0:
+      result.add "_"
     result.add fi.name & "_" & fi.typeNode.assignTypeName()
 
 # ═══════════════════════════════════════════════════════════════════════

--- a/workspace/crucible/tests/codegen/metal/test_metal_generic_proc_tuple_args.nim
+++ b/workspace/crucible/tests/codegen/metal/test_metal_generic_proc_tuple_args.nim
@@ -1,0 +1,42 @@
+## Tuples: ensure anonymous tuples in generics generate the expected type name
+##
+## Run:
+##   cd tattletale
+##   nim c -r --hints:off --warnings:off \
+##     --outdir:build/tests --nimcache:nimcache/tests \
+##     workspace/crucible/tests/codegen/metal/test_metal_generic_proc_tuple_args.nim
+
+import std/unittest
+import workspace/crucible
+
+type Int*[V: static int] = object
+
+type Box*[T; Sh] = object
+  data: array[2, T]
+
+proc scaleBox*[V: static int](dst: var Box[float32, (Int[V], Int[2])],
+                              src: Box[float32, (Int[V], Int[2])],
+                              s: float32) {.inline.} =
+  dst.data[0] = src.data[0] * s
+  dst.data[1] = src.data[1] * s
+
+const kernelMsl = metal:
+  proc repro(outp: ptr UncheckedArray[float32]) {.global.} =
+    var d: Box[float32, (Int[1], Int[2])]
+    let a = Box[float32, (Int[1], Int[2])](data: [2.0'f32, 3.0'f32])
+    d.scaleBox(a, 3.0'f32)
+    outp[0] = d.data[0]
+    outp[1] = d.data[1]
+
+proc runTest() =
+  suite "Metal - generic proc with tuple-of-static-int type args":
+    test "scaleBox lowers with one type name for the tuple args":
+      var engine = bkMetal.init()
+      engine.ingest(kernelMsl)
+      var res: array[2, float32]
+      engine.run("repro", res, ())
+      check res[0] == 6.0'f32
+      check res[1] == 9.0'f32
+
+when isMainModule:
+  runTest()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved code generation for anonymous tuple types used in generic procedures.
  * Preserved consistent naming for tuple-based type arguments.
  * Prevented incorrect naming of non-tuple bracket expressions.

* **Tests**
  * Added regression coverage for Metal kernels using generic procedures with anonymous tuples and static integer types.
  * Verified generated kernels produce expected scaled results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->