### PR TITLE
[Crucible] Array constant eval

### DIFF
--- a/workspace/crucible/src/codegen/ir/resolvers.nim
+++ b/workspace/crucible/src/codegen/ir/resolvers.nim
@@ -40,32 +40,39 @@ proc toGpuTypeKind*(t: NimNode): GpuTypeKind =
 #  Array length resolution
 # ═══════════════════════════════════════════════════════════════════════
 
+proc evalConstInt(n: NimNode): int =
+  ## Evaluates a compile-time integer expression (the array-length forms
+  ## `getTypeInst` produces: literals, const syms, and infix arithmetic
+  ## like `32 * 16` or the `0 .. 15` range).
+  case n.kind
+  of nnkIntLit, nnkUIntLit:
+    result = n.intVal
+  of nnkSym:
+    # const symbol — value from its implementation
+    result = n.getImpl.intVal
+  of nnkInfix:
+    let a = evalConstInt(n[1])
+    let b = evalConstInt(n[2])
+    case n[0].strVal
+    of "*":  result = a * b
+    of "+":  result = a + b
+    of "-":  result = a - b
+    of "div": result = a div b
+    of "mod": result = a mod b
+    of "shl": result = a shl b
+    of "shr": result = a shr b
+    of "and": result = a and b
+    of "..":  result = b - a + 1
+    of "..<": result = b - a
+    else:
+      error "Unsupported operator in array length: " & n[0].strVal & " in " & n.treerepr
+  else:
+    error "Unsupported node in array length: " & n.treerepr
+
 proc resolveArrayLength*(n: NimNode): int =
   ## Returns the length of a static array type.
   ## Callers must pass `getTypeInst()` output — idents are never expected.
-  case n[1].kind
-  of nnkSym:
-    # resolved symbol — get the constant int value from its implementation
-    result = n[1].getImpl.intVal
-  of nnkIdent:
-    # Should never happen with getTypeInst() output
-    error "Unresolved ident in array length: " & $n[1].strVal
-  else:
-    case n[1].kind
-    of nnkIntLit: result = n[1].intVal
-    else:
-      # E.g.
-      # BracketExpr
-      #   Sym "array"
-      #   Infix
-      #     Ident ".."
-      #     IntLit 0
-      #     IntLit 11
-      #   Sym "BigInt"
-      doAssert n[1].kind == nnkInfix, "No is: " & $n.treerepr
-      doAssert n[1][1].kind == nnkIntLit, "No is: " & $n.treerepr
-      doAssert n[1][1].intVal == 0, "No is: " & $n.treerepr
-      result = n[1][2].intVal + 1
+  result = evalConstInt(n[1])
 
 # ═══════════════════════════════════════════════════════════════════════
 #  Forward declarations (defined below)
@@ -233,6 +240,11 @@ proc assignTypeName*(n: NimNode, recursedSym: bool = false): string =
     # It must name identically to the nnkTupleConstr form.
     if n.len >= 2 and n[0].kind in {nnkSym, nnkIdent} and n[0].strVal == "tuple":
       result = tupleTypeName(resolveTupleFields(n))
+    elif n[0].kind == nnkSym and n[0].strVal == "array":
+      # `array[N, T]`: name from the length and the element type. Never
+      # recurse through the `array` symbol — its type inst is the array
+      # itself, which would loop.
+      result = "Array_" & $resolveArrayLength(n) & "_" & n[2].assignTypeName()
     else:
       # construct a type name `Foo_Bar_Baz`
       for i, ch in n:

--- a/workspace/crucible/tests/codegen/metal/test_metal_array_length_arith.nim
+++ b/workspace/crucible/tests/codegen/metal/test_metal_array_length_arith.nim
@@ -1,0 +1,41 @@
+## Arithmetic array lengths: `array[A * B, T]` resolves its length.
+##
+## Anti-regression for `resolveArrayLength` (the `evalConstInt` rewrite):
+## the length node of a statically sized array is not always a `0..N` range —
+## `getTypeInst` keeps product expressions like `2 * 2` unfolded, and the
+## old resolver doAsserted on any length whose range start was not 0.
+## The pulled-in-proc signature typing reaches the array type, so the
+## arithmetic length must evaluate.
+##
+## Run:
+##   cd tattletale
+##   nim c -r --hints:off --warnings:off \
+##     --outdir:build/tests --nimcache:nimcache/tests \
+##     workspace/crucible/tests/codegen/metal/test_metal_array_length_arith.nim
+
+import std/unittest
+import workspace/crucible
+
+proc sumCorners*(xs: array[2 * 2, float32]): float32 =
+  ## Pulled into device code: its signature carries the arithmetic-length
+  ## array type, so resolving the signature resolves `array[2 * 2, float32]`.
+  xs[0] + xs[3]
+
+const kernelMsl = metal:
+  proc repro(outp: ptr UncheckedArray[float32]) {.global.} =
+    var xs: array[2 * 2, float32]
+    xs[0] = 1.0'f32
+    xs[3] = 2.0'f32
+    outp[0] = sumCorners(xs)
+
+proc runTest() =
+  suite "Metal - arithmetic array lengths":
+    test "array[2 * 2, T] resolves its length in a pulled-in proc signature":
+      var engine = bkMetal.init()
+      engine.ingest(kernelMsl)
+      var res: array[1, float32]
+      engine.run("repro", res, ())
+      check res[0] == 3.0'f32
+
+when isMainModule:
+  runTest()

--- a/workspace/crucible/tests/codegen/metal/test_metal_array_type_name.nim
+++ b/workspace/crucible/tests/codegen/metal/test_metal_array_type_name.nim
@@ -1,0 +1,40 @@
+## Array types inside pulled-in proc signatures name without recursing.
+##
+## Anti-regression for the `assignTypeName` array case (`Array_N_T`):
+## naming a type that contains an array (here a tuple field) recursed
+## through the `array` symbol — whose type inst is the array itself — until
+## the VM call-depth limit. Array types must name from their length and
+## element type instead.
+##
+## Run:
+##   cd tattletale
+##   nim c -r --hints:off --warnings:off \
+##     --outdir:build/tests --nimcache:nimcache/tests \
+##     workspace/crucible/tests/codegen/metal/test_metal_array_type_name.nim
+
+import std/unittest
+import workspace/crucible
+
+proc probeTuple*(p: tuple[a: array[5, int32], b: int32]): int32 =
+  ## Pulled into device code: naming its signature names the anonymous
+  ## tuple, whose `a` field is the array type.
+  p.a[0] + p.b
+
+const kernelMsl = metal:
+  proc repro(outp: ptr UncheckedArray[int32]) {.global.} =
+    var p: tuple[a: array[5, int32], b: int32]
+    p.a[0] = 7
+    p.b = 1
+    outp[0] = probeTuple(p)
+
+proc runTest() =
+  suite "Metal - array types in proc signatures":
+    test "a tuple-of-array param names without recursion":
+      var engine = bkMetal.init()
+      engine.ingest(kernelMsl)
+      var res: array[1, int32]
+      engine.run("repro", res, ())
+      check res[0] == 8'i32
+
+when isMainModule:
+  runTest()


### PR DESCRIPTION
- resolveArrayLength only knew 0..N ranges. getTypeInst leaves product lengths (32 * 16) unfolded, which doAsserted. Now can handle literals, const syms and infix arithmetic (incl. .. and ..< ranges).
- assignTypeName recursed forever on array types (the array symbol's type inst is the array itself). Arrays now name Array_N_T from their length and element type.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved array-length resolution for arithmetic, bitwise operations, constants, literals, and ranges.
  * Corrected generated names for anonymous array types, including their resolved length and element type.

* **Tests**
  * Added regression coverage for computed array lengths in Metal kernels.
  * Added coverage for array fields within tuple parameters and generated type names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->