### PR TITLE
[Crucible-compiler] Add native fp16↔fp32 conversion builtins

### DIFF
--- a/workspace/crucible/src/codegen/builtins/builtins_gpu_types.nim
+++ b/workspace/crucible/src/codegen/builtins/builtins_gpu_types.nim
@@ -6,6 +6,7 @@
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 import std/macros
+import std/tables
 import ../ir/gpu_types
 import ./builtins_pragmas
 
@@ -42,6 +43,53 @@ func `+`*(a: bfloat16): bfloat16 {.inline.} =
   raise newException(ValueError, "bfloat16 arithmetic is GPU-side only")
 func `-`*(a: bfloat16): bfloat16 {.inline.} =
   raise newException(ValueError, "bfloat16 arithmetic is GPU-side only")
+
+# ═══════════════════════════════════════════════════════════════════════
+#  The fp16 ↔ fp32 conversion primitives
+# ═══════════════════════════════════════════════════════════════════════
+#  Convention: `to` converts numerically, `as` reinterprets the bit pattern.
+#  The narrowing rounds to nearest even (RNE). fp16 tiles store their bits as u16.
+#  Declared `{.builtin.}` so crucible forwards the call name-only
+#  to the per-backend spelling (the table below).
+#  Host-side calls raise as the conversions are GPU-side only.
+
+func toFp16*(x: float32): float16 {.builtin.} =
+  ## Numeric fp32 → fp16 conversion (RNE).
+  raise newException(ValueError, "fp16 conversion is GPU-side only")
+
+func toFp32*(x: float16): float32 {.builtin.} =
+  ## Numeric fp16 → fp32 conversion (exact widening).
+  raise newException(ValueError, "fp16 conversion is GPU-side only")
+
+func asFp16*(x: uint16): float16 {.builtin.} =
+  ## Bit-pattern reinterpret u16 → fp16.
+  raise newException(ValueError, "fp16 reinterpret is GPU-side only")
+
+func asU16*(x: float16): uint16 {.builtin.} =
+  ## Bit-pattern reinterpret fp16 → u16.
+  raise newException(ValueError, "fp16 reinterpret is GPU-side only")
+
+let NimGpuFp16ConversionBuiltins* {.compileTime.}: Table[(BackendKind, string), string] =
+  # The per-backend spellings of the conversion builtins above, consulted
+  # by lang_utils.getFnName. The value is emitted as `name(args)`, so MSL's
+  # `as_type<half>` (a template call) is reachable. The CUDA and WGSL
+  # type printers lack the half (CUDA) and u16 (WGSL) scalar types, so
+  # those spellings cannot be emitted until the types land.
+  {(bkMetal,  "toFp16"): "half",
+   (bkMetal,  "toFp32"): "float",
+   (bkMetal,  "asFp16"): "as_type<half>",
+   (bkMetal,  "asU16"):  "as_type<ushort>",
+   (bkVulkan, "toFp16"): "float16_t",
+   (bkVulkan, "toFp32"): "float",
+   (bkVulkan, "asFp16"): "uint16BitsToFloat16",
+   (bkVulkan, "asU16"):  "float16BitsToUint16",
+   (bkCuda,   "toFp16"): "__float2half_rn",
+   (bkCuda,   "toFp32"): "__half2float",
+   (bkCuda,   "asFp16"): "__ushort_as_half",
+   (bkCuda,   "asU16"):  "__half_as_ushort",
+   (bkWGSL,   "toFp16"): "f16",
+   (bkWGSL,   "toFp32"): "f32",
+   (bkWGSL,   "asFp16"): "bitcast<f16>"}.toTable()
 
 proc builtinGpuTypeKind*(n: NimNode): GpuTypeKind =
   ## Maps a builtin GPU type symbol to its GpuTypeKind, or gtVoid otherwise.

--- a/workspace/crucible/src/codegen/targets/lang_utils.nim
+++ b/workspace/crucible/src/codegen/targets/lang_utils.nim
@@ -8,6 +8,7 @@
 import std / tables
 import ../ir/gpu_types
 import ../builtins/nim_builtins
+import ../builtins/builtins_gpu_types
 import ../passes/passes_optimizations
 
 proc getFnName*(ctx: GpuContext; backend: BackendKind; call: GpuAst): string =
@@ -20,7 +21,7 @@ proc getFnName*(ctx: GpuContext; backend: BackendKind; call: GpuAst): string =
     let t = ctx.operandType(call.cArgs[0]) # builtin min/max/abs always have 1 or 2 cArgs
     if not t.isNil:
       return getMaxMinAbsBuiltinFnName(backend, name, t.kind)
-  name
+  NimGpuFp16ConversionBuiltins.getOrDefault((backend, name), name)
 
 proc address*(a: string): string = "&" & a
 proc size*(a: string): string = "sizeof(" & a & ")"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added GPU support for converting between 16-bit and 32-bit floating-point values.
  - Added bit reinterpretation between FP16 values and 16-bit unsigned integers.
  - Added backend-specific support for Metal, Vulkan, CUDA, and WGSL.
  - These operations now report an error when attempted outside GPU execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->