### PR TITLE
[ARM GEMM] Scalable Matrix Extension v2 based CPU GEMM - 1.7TFlops per SME unit

### DIFF
--- a/workspace/ceramic/benchmark/bench_ex02_matmul_sme.nim
+++ b/workspace/ceramic/benchmark/bench_ex02_matmul_sme.nim
@@ -30,24 +30,6 @@ const
   WarmupSamples = 1
   Tol = 1e-4'f32
 
-proc gemm_reference_naive(M, N, K: int; alpha: float32;
-    A: openArray[float32]; rsA, csA: int;
-    B: openArray[float32]; rsB, csB: int;
-    beta: float32; C: var openArray[float32]; rsC, csC: int) =
-  ## Scalar triple-loop GEMM: correctness reference and generic-path baseline.
-  for j in 0 ..< N:
-    for i in 0 ..< M:
-      let ci = i * rsC + j * csC
-      C[ci] = if beta == 0.0'f32: 0.0'f32
-              elif beta != 1.0'f32: C[ci] * beta
-              else: C[ci]
-  for j in 0 ..< N:
-    for k in 0 ..< K:
-      let bv = B[k * rsB + j * csB]
-      if bv != 0.0'f32:
-        for i in 0 ..< M:
-          C[i * rsC + j * csC] += alpha * A[i * rsA + k * csA] * bv
-
 proc gflops(elapsed: float64; ops: float64): float64 =
   (ops / 1e9) / elapsed
 
@@ -91,7 +73,7 @@ when isMainModule:
     var
       C_naive = newSeq[float32](N * N)
       C_sme = newSeq[float32](N * N)
-    gemm_reference_naive(N, N, N, 1.0'f32, A, rs, cs, B, rs, cs, 0.0'f32, C_naive, rs, cs)
+    gemm_reference(N, N, N, 1.0'f32, A, rs, cs, B, rs, cs, 0.0'f32, C_naive, rs, cs)
     v_a.gemm_strided(N, N, N, 1.0'f32, A, rs, cs, B, rs, cs, 0.0'f32, C_sme, rs, cs)
     let chk = allClose(C_sme, C_naive, rtol = Tol, atol = Tol)
     doAssert chk.ok, &"N={N}: SME vs naive maxAbsErr={chk.maxAbsErr:.2e}"
@@ -102,10 +84,13 @@ when isMainModule:
       var C = newSeq[float32](N * N)
       proc run() = v_a.gemm_strided(N, N, N, 1.0'f32, A, rs, cs, B, rs, cs, 0.0'f32, C, rs, cs)
       results.add bench("sme (ex02a-sme)", run, ops)
-    block:
-      var C = newSeq[float32](N * N)
-      proc run() = gemm_reference_naive(N, N, N, 1.0'f32, A, rs, cs, B, rs, cs, 0.0'f32, C, rs, cs)
-      results.add bench("generic (naive)", run, ops)
+    if N < 512:
+      # Naive baseline is cache-missing at 512³: five passes would dominate
+      # the budget, so time it only up to 256³.
+      block:
+        var C = newSeq[float32](N * N)
+        proc run() = gemm_reference(N, N, N, 1.0'f32, A, rs, cs, B, rs, cs, 0.0'f32, C, rs, cs)
+        results.add bench("generic (naive)", run, ops)
 
     echo &"  N={N:4d}  correctness vs naive: maxAbsErr={chk.maxAbsErr:.2e} ✅"
     for r in results:

--- a/workspace/ceramic/benchmark/bench_ex02_matmul_sme.nim
+++ b/workspace/ceramic/benchmark/bench_ex02_matmul_sme.nim
@@ -9,10 +9,11 @@
 ## Square float32 matrices, one warmup plus three timed samples per size, total
 ## runtime ≤ 5 s. Each variant is checked against the naive reference before timing.
 ##
-## The "generic" baseline is a naive triple-loop GEMM embedded here because the
-## x86 ex02a (which falls back to the generic ukernel on non-x86) cannot compile on
-## arm64: workspace/cpuplatforms/x86/simd_x86.nim defines builtin_prefetch only
-## under `defined(i386) or defined(amd64)`.
+## The "generic" baseline is the shared naive triple-loop `gemm_reference` from
+## workspace/ceramic/benchmark/bench_utils. The x86 ex02a (which falls back to the
+## generic ukernel on non-x86) cannot compile on arm64:
+## workspace/cpuplatforms/x86/simd_x86.nim defines builtin_prefetch only under
+## `defined(i386) or defined(amd64)`. The naive baseline is timed for N < 512 only.
 ##
 ## Usage:
 ##   nim cpp -r -d:release --hints:off --warnings:off \

--- a/workspace/ceramic/benchmark/bench_ex02_matmul_sme.nim
+++ b/workspace/ceramic/benchmark/bench_ex02_matmul_sme.nim
@@ -1,0 +1,115 @@
+## Tattletale
+## Copyright (c) 2026 Mamy André-Ratsimbazafy
+## Licensed and distributed under either of
+##   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+##   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+## at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+## POC benchmark: ARM SME2 GEMM (ex02a_matmul_handtuned_arm64_sme2) vs a scalar reference.
+## Square float32 matrices, one warmup plus three timed samples per size, total
+## runtime ≤ 5 s. Each variant is checked against the naive reference before timing.
+##
+## The "generic" baseline is a naive triple-loop GEMM embedded here because the
+## x86 ex02a (which falls back to the generic ukernel on non-x86) cannot compile on
+## arm64: workspace/cpuplatforms/x86/simd_x86.nim defines builtin_prefetch only
+## under `defined(i386) or defined(amd64)`.
+##
+## Usage:
+##   nim cpp -r -d:release --hints:off --warnings:off \
+##     --outdir:build/wip/arm-sme-matmul --nimcache:nimcache/wip/arm-sme-matmul \
+##     workspace/ceramic/benchmark/bench_ex02_matmul_sme.nim
+
+import std/[algorithm, monotimes, random, strutils, strformat]
+
+import workspace/ceramic/examples/ex02a_matmul_handtuned_arm64_sme2 as v_a
+import workspace/ceramic/benchmark/bench_utils
+
+const
+  ProblemSizes = [128, 256, 512]
+  NbSamples = 3
+  WarmupSamples = 1
+  Tol = 1e-4'f32
+
+proc gemm_reference_naive(M, N, K: int; alpha: float32;
+    A: openArray[float32]; rsA, csA: int;
+    B: openArray[float32]; rsB, csB: int;
+    beta: float32; C: var openArray[float32]; rsC, csC: int) =
+  ## Scalar triple-loop GEMM: correctness reference and generic-path baseline.
+  for j in 0 ..< N:
+    for i in 0 ..< M:
+      let ci = i * rsC + j * csC
+      C[ci] = if beta == 0.0'f32: 0.0'f32
+              elif beta != 1.0'f32: C[ci] * beta
+              else: C[ci]
+  for j in 0 ..< N:
+    for k in 0 ..< K:
+      let bv = B[k * rsB + j * csB]
+      if bv != 0.0'f32:
+        for i in 0 ..< M:
+          C[i * rsC + j * csC] += alpha * A[i * rsA + k * csA] * bv
+
+proc gflops(elapsed: float64; ops: float64): float64 =
+  (ops / 1e9) / elapsed
+
+proc bench(name: string; run: proc(); ops: float64): tuple[name: string; gflops, medianUs: float64] =
+  ## Runs one warmup pass (discarded), then the timed samples, and reports the median.
+  for _ in 0 ..< WarmupSamples:
+    run()
+  var times = newSeq[float64](NbSamples)
+  for s in 0 ..< NbSamples:
+    let t0 = getMonoTime()
+    run()
+    let t1 = getMonoTime()
+    times[s] = float64(ticks(t1) - ticks(t0)) / 1e9
+  let med = median(sorted(times))
+  (name, gflops(med, ops), med * 1e6)
+
+when isMainModule:
+  randomize(42)
+
+  echo "=".repeat(64)
+  echo &"  SME GEMM benchmark — float32, row-major, single-threaded"
+  echo &"  SIMD arch: {v_a.simdArchString()}"
+  echo &"  sizes {ProblemSizes}, {WarmupSamples} warmup + {NbSamples} samples each"
+  echo "=".repeat(64)
+  echo ""
+
+  for N in ProblemSizes:
+    let
+      shape: MatrixShape = (M: N, N: N)
+      ops = float64(gemm_required_ops(shape, shape))
+      rs = N
+      cs = 1
+
+    var
+      A = newSeq[float32](N * N)
+      B = newSeq[float32](N * N)
+    for i in 0 ..< A.len: A[i] = rand(1.0'f32)
+    for i in 0 ..< B.len: B[i] = rand(1.0'f32)
+
+    # ── Correctness: SME path vs naive reference ──
+    var
+      C_naive = newSeq[float32](N * N)
+      C_sme = newSeq[float32](N * N)
+    gemm_reference_naive(N, N, N, 1.0'f32, A, rs, cs, B, rs, cs, 0.0'f32, C_naive, rs, cs)
+    v_a.gemm_strided(N, N, N, 1.0'f32, A, rs, cs, B, rs, cs, 0.0'f32, C_sme, rs, cs)
+    let chk = allClose(C_sme, C_naive, rtol = Tol, atol = Tol)
+    doAssert chk.ok, &"N={N}: SME vs naive maxAbsErr={chk.maxAbsErr:.2e}"
+
+    # ── Timed runs (beta=0: C's input value is irrelevant, no re-zero needed) ──
+    var results: seq[tuple[name: string; gflops, medianUs: float64]] = @[]
+    block:
+      var C = newSeq[float32](N * N)
+      proc run() = v_a.gemm_strided(N, N, N, 1.0'f32, A, rs, cs, B, rs, cs, 0.0'f32, C, rs, cs)
+      results.add bench("sme (ex02a-sme)", run, ops)
+    block:
+      var C = newSeq[float32](N * N)
+      proc run() = gemm_reference_naive(N, N, N, 1.0'f32, A, rs, cs, B, rs, cs, 0.0'f32, C, rs, cs)
+      results.add bench("generic (naive)", run, ops)
+
+    echo &"  N={N:4d}  correctness vs naive: maxAbsErr={chk.maxAbsErr:.2e} ✅"
+    for r in results:
+      echo &"    {r.name:<20} {r.gflops:>9.2f} GFLOP/s   {int(r.medianUs):>7d} μs"
+    echo ""
+
+  echo "Done."

--- a/workspace/ceramic/benchmark/bench_utils.nim
+++ b/workspace/ceramic/benchmark/bench_utils.nim
@@ -38,6 +38,38 @@ proc allClose*(
   result.ok = result.maxAbsErr <= atol and result.maxRelErr <= rtol
 
 # ═══════════════════════════════════════════════════════════════════════════
+#  Scalar GEMM reference
+# ═══════════════════════════════════════════════════════════════════════════
+
+proc gemm_reference*(
+    M, N, K: int, alpha: float32,
+    A: openArray[float32], rsA, csA: int,
+    B: openArray[float32], rsB, csB: int,
+    beta: float32, C: var openArray[float32], rsC, csC: int) =
+  ## Scalar triple-loop GEMM: `C = beta*C + alpha*A·B` for strided f32
+  ## views, the correctness reference for the tuned kernels.
+  ##
+  ## Expected input:
+  ##   - A: M×K view, element strides (rsA, csA)
+  ##   - B: K×N view, element strides (rsB, csB)
+  ##   - C: M×N view, element strides (rsC, csC), prior values read
+  ##
+  ## Output: C updated in place to `beta*C + alpha*A·B`. B elements equal
+  ## to 0 skip their rank-1 update.
+  for j in 0 ..< N:
+    for i in 0 ..< M:
+      let ci = i * rsC + j * csC
+      C[ci] = if beta == 0.0'f32: 0.0'f32
+              elif beta != 1.0'f32: C[ci] * beta
+              else: C[ci]
+  for j in 0 ..< N:
+    for k in 0 ..< K:
+      let bv = B[k * rsB + j * csB]
+      if bv != 0.0'f32:
+        for i in 0 ..< M:
+          C[i * rsC + j * csC] += alpha * A[i * rsA + k * csA] * bv
+
+# ═══════════════════════════════════════════════════════════════════════════
 #  Median
 # ═══════════════════════════════════════════════════════════════════════════
 

--- a/workspace/ceramic/examples/ex02_matmul_microkernels/gemm_packing_arm64_sme2.nim
+++ b/workspace/ceramic/examples/ex02_matmul_microkernels/gemm_packing_arm64_sme2.nim
@@ -15,11 +15,6 @@
 
 import workspace/cpuplatforms/arm/macro_assembler_arm64
 
-func memStep(base: XReg, imm: int): MemAddr =
-  ## Memory operand for a vector load at `imm` vector lengths:
-  ## `[base]` when `imm == 0`, `[base, #imm, MUL VL]` otherwise.
-  if imm == 0: mem(base) else: memVL(base, imm)
-
 proc emitTrnStore8x8(ctx: var AssemblerSME) =
   for cell in 0 .. 3:
     let a = 8 * (cell div 2) + cell mod 2
@@ -41,7 +36,7 @@ proc emitTrnStore8x8(ctx: var AssemblerSME) =
 proc buildNeonPackATranspose8rows(
     ctx: var AssemblerSME,
     dst, src, rowStrideOp, nGroupsOp, validOp: NimNode) =
-  ## Records the `neon_packA_transpose_8rows` instruction stream into
+  ## Records the `neonPackATranspose8rows` instruction stream into
   ## `ctx` in source order: the eight row pointers, the full 8-row transpose loop,
   ## then the cold partial-row loop. Operand bindings:
   ## pointers via `"r"`, the stride and counts via `"r"((long)...)`.
@@ -95,13 +90,13 @@ proc buildNeonPackATranspose8rows(
 macro genNeonPackATranspose8rows(
     dst, src, rowStrideOp, nGroupsOp, validOp: typed): untyped =
   ## Expands to the `{.emit: ...}` pragma for
-  ## `neon_packA_transpose_8rows`.
+  ## `neonPackATranspose8rows`.
   var ctx = init(AssemblerSME)
   buildNeonPackATranspose8rows(ctx, dst, src, rowStrideOp, nGroupsOp,
                                validOp)
   result = ctx.generate()
 
-proc neon_packA_transpose_8rows*(
+proc neonPackATranspose8rows*(
     dst: ptr float32,      # packA + ir*kc*mr + g*8 (8-row group g, k = 0)
     src: ptr float32,      # pA_ptr + (srcRow + g*8) * pA_rs (group's first row, k = 0)
     srcRowStride: cint,    # pA_rs: elements between consecutive A rows
@@ -151,7 +146,7 @@ proc emitA16TransposeStore(ctx: var AssemblerSME) =
 proc buildSmePackATranspose16rows(
     ctx: var AssemblerSME,
     dst, src, rowStrideOp, nColBlocksOp, validOp: NimNode) =
-  ## Records the `sme_packA_transpose_16rows` instruction stream into
+  ## Records the `smePackATranspose16rows` instruction stream into
   ## `ctx` in source order: the smstart bracket, the 16 row pointers,
   ## the full 16-row transpose loop, then the cold partial-row loop.
   ## Operand bindings: pointers via `"r"`, the stride and counts via `"r"((long)...)`.
@@ -229,13 +224,13 @@ proc buildSmePackATranspose16rows(
 macro genSmePackATranspose16rows(
     dst, src, rowStrideOp, nColBlocksOp, validOp: typed): untyped =
   ## Expands to the `{.emit: ...}` pragma for
-  ## `sme_packA_transpose_16rows`.
+  ## `smePackATranspose16rows`.
   var ctx = init(AssemblerSME)
   buildSmePackATranspose16rows(ctx, dst, src, rowStrideOp, nColBlocksOp,
                                validOp)
   result = ctx.generate()
 
-proc sme_packA_transpose_16rows*(
+proc smePackATranspose16rows*(
     dst: ptr float32,      # packA + ir*kc*mr + g*16 (16-row group g, k = 0)
     src: ptr float32,      # pA_ptr + (srcRow + g*16) * pA_rs (group's first row, k = 0)
     srcRowStride: cint,    # pA_rs: elements between consecutive A rows
@@ -270,7 +265,7 @@ proc sme_packA_transpose_16rows*(
 proc buildSmePackBCopy32f32X4(
     ctx: var AssemblerSME,
     dst0, dst1, dst2, dst3, src, rowStrideOp, nRowsOp: NimNode) =
-  ## Records the `sme_packB_copy_32f32_x4` instruction stream into
+  ## Records the `smePackBCopy32f32x4` instruction stream into
   ## `ctx` in source order: the smstart bracket, then the row loop of eight `ld1w` loads
   ## and eight `st1w` stores. Operand bindings:
   ## pointers via `"r"`, the stride and row count via `"r"((long)...)`.
@@ -290,6 +285,7 @@ proc buildSmePackBCopy32f32X4(
   ctx.mov(x(12), view(d3Op))
   ctx.lsl(x(25), xview(rsOp), 2)
   ctx.mov(w(27), wview(nOp))
+  ctx.cbz(w(27), "9f")
   ctx.label("1")
   for lane in 0 .. 7:
     ctx.ld1w(z(lane), "s", p(0), memStep(x(26), lane))
@@ -301,6 +297,7 @@ proc buildSmePackBCopy32f32X4(
     ctx.add(x(9 + panel), x(9 + panel), 128)
   ctx.subs(w(27), w(27), 1)
   ctx.bne("1b")
+  ctx.label("9")
   ctx.smstop()
   ctx.clobber("x9", "x10", "x11", "x12", "x25", "x26", "w27")
   ctx.clobberZ()
@@ -311,13 +308,13 @@ proc buildSmePackBCopy32f32X4(
 macro genSmePackBCopy32f32X4(
     dst0, dst1, dst2, dst3, src, rowStrideOp, nRowsOp: typed): untyped =
   ## Expands to the `{.emit: ...}` pragma for
-  ## `sme_packB_copy_32f32_x4`.
+  ## `smePackBCopy32f32x4`.
   var ctx = init(AssemblerSME)
   buildSmePackBCopy32f32X4(ctx, dst0, dst1, dst2, dst3, src,
                            rowStrideOp, nRowsOp)
   result = ctx.generate()
 
-proc sme_packB_copy_32f32_x4*(
+proc smePackBCopy32f32x4*(
     dst0, dst1, dst2, dst3: ptr float32,  # packB + (jr0+i)*kc*nr for i in 0..3
     src: ptr float32,                     # pB_ptr + jr0*nr (k = 0)
     srcRowStride: cint,                   # pB_rs: elements between consecutive B rows
@@ -351,7 +348,7 @@ proc sme_packB_copy_32f32_x4*(
 proc buildNeonPackBCopy32f32(
     ctx: var AssemblerSME,
     dst, src, rowStrideOp, nRowsOp: NimNode) =
-  ## Records the `neon_packB_copy_32f32` instruction stream into `ctx`
+  ## Records the `neonPackBCopy32f32` instruction stream into `ctx`
   ## in source order: the row loop of two 4-register `ld1`/`st1` pairs
   ## with the post-copy row advance. Operand bindings: pointers via `"r"`,
   ## the stride and row count via `"r"((long)...)`.
@@ -364,6 +361,7 @@ proc buildNeonPackBCopy32f32(
   ctx.lsl(x(22), xview(rsOp), 2)
   ctx.sub(x(22), x(22), 128)
   ctx.mov(w(23), wview(nOp))
+  ctx.cbz(w(23), "9f")
   ctx.label("1")
   ctx.ld1(vlist(0, 3, "4s"), memPost(x(21), 64))
   ctx.ld1(vlist(4, 7, "4s"), memPost(x(21), 64))
@@ -372,6 +370,7 @@ proc buildNeonPackBCopy32f32(
   ctx.st1(vlist(4, 7, "4s"), memPost(x(20), 64))
   ctx.subs(w(23), w(23), 1)
   ctx.bne("1b")
+  ctx.label("9")
   ctx.clobber("x20", "x21", "x22", "w23")
   ctx.clobber("v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7")
   ctx.clobberCC()
@@ -379,12 +378,12 @@ proc buildNeonPackBCopy32f32(
 
 macro genNeonPackBCopy32f32(
     dst, src, rowStrideOp, nRowsOp: typed): untyped =
-  ## Expands to the `{.emit: ...}` pragma for `neon_packB_copy_32f32`.
+  ## Expands to the `{.emit: ...}` pragma for `neonPackBCopy32f32`.
   var ctx = init(AssemblerSME)
   buildNeonPackBCopy32f32(ctx, dst, src, rowStrideOp, nRowsOp)
   result = ctx.generate()
 
-proc neon_packB_copy_32f32*(
+proc neonPackBCopy32f32*(
     dst: ptr float32,      # packB + jr*kc*nr (k = 0)
     src: ptr float32,      # pB_ptr + jr*nr (k = 0)
     srcRowStride: cint,    # pB_rs: elements between consecutive B rows

--- a/workspace/ceramic/examples/ex02_matmul_microkernels/gemm_packing_arm64_sme2.nim
+++ b/workspace/ceramic/examples/ex02_matmul_microkernels/gemm_packing_arm64_sme2.nim
@@ -322,22 +322,24 @@ proc smePackBCopy32f32x4*(
   ## Streaming SME2 B-pack for four consecutive full `jr` panels.
   ##
   ## Expected input:
-  ##   - src: first row of panel `jr0` (row-major f32, rows
-  ##     `srcRowStride` elements apart, 32 contiguous f32 per row)
+  ##   - src: first row of the four-panel group (row-major f32, rows
+  ##     `srcRowStride` elements apart, 128 contiguous f32 per row:
+  ##     four consecutive 32-f32 panels)
   ##   - srcRowStride: elements between consecutive source rows
   ##   - nRows: source rows per panel (k)
   ##   - dst0..dst3: panel bases (packB + (jr0+i)*kc*nr for i in 0..3)
   ##
   ## Output: row `k` of each panel copied into its packed slot:
-  ##   rows 32 f32 apart: `dst_i[k*32 ..< k*32+32] = src[k*rs ..< k*rs+32]`
+  ##   `dst_i[k*32 ..< k*32+32] =
+  ##     src[k*rs + i*32 ..< k*rs + (i+1)*32]`
   ##   for each panel `i` in `0 .. 3`, `k in 0 ..< nRows` (bases dst0..dst3).
   ##   No zero-fill: every lane is copied.
   ##
-  ## before (src, one panel):              after (dst_i, packed):
-  ##   k0: [32 f32] at src + 0*rs           k0: [32 f32] at dst_i + 0*32
-  ##   k1: [32 f32] at src + 1*rs           k1: [32 f32] at dst_i + 1*32
-  ##   k2: [32 f32] at src + 2*rs           k2: [32 f32] at dst_i + 2*32
-  ##   rows `rs` f32 apart                  rows 32 f32 apart
+  ## before (src, four panels):            after (dst_i, packed):
+  ##   k0: [32][32][32][32] at src         k0: [32 f32] at dst_i + 0*32
+  ##   k1: [32][32][32][32] at src+rs      k1: [32 f32] at dst_i + 1*32
+  ##   k2: [32][32][32][32] at src+2*rs    k2: [32 f32] at dst_i + 2*32
+  ##   rows `rs` f32 apart                 rows 32 f32 apart
   ##
   ## Contract: all four panels have 32 valid lanes per row and the panel
   ## count is a multiple of 4.

--- a/workspace/ceramic/examples/ex02_matmul_microkernels/gemm_packing_arm64_sme2.nim
+++ b/workspace/ceramic/examples/ex02_matmul_microkernels/gemm_packing_arm64_sme2.nim
@@ -1,0 +1,411 @@
+## SIMD-accelerated pack kernels for the ex02a hand-tuned GEMM example.
+##
+## Packs transpose or copy row-major A/B panels into the `(ir, kc, 32)` layout
+## consumed by the SME2 ukernels in `gemm_ukernel_arm64_sme2.nim`.
+## `sme_` packs run inside an smstart/smstop bracket (streaming mode, SVE/SME2 only).
+## NEON packs run outside the bracket, since NEON faults
+## inside streaming mode. Requires ARMv9.2 with FEAT_SME2 and assumes
+## SVL = 64 B (16 f32 lanes per vector).
+##
+## Every pack emits its instruction text through the compile-time macro
+## assembler: a builder proc records the stream into an `AssemblerSME`,
+## and a `gen*` macro expands `generate()` to one in-body `{.emit: "asm volatile(...)".}` pragma.
+
+{.localpassC: "-march=armv9-a+sme2 -fno-vectorize -fno-slp-vectorize".}
+
+import workspace/cpuplatforms/arm/macro_assembler_arm64
+
+func memStep(base: XReg, imm: int): MemAddr =
+  ## Memory operand for a vector load at `imm` vector lengths:
+  ## `[base]` when `imm == 0`, `[base, #imm, MUL VL]` otherwise.
+  if imm == 0: mem(base) else: memVL(base, imm)
+
+proc emitTrnStore8x8(ctx: var AssemblerSME) =
+  for cell in 0 .. 3:
+    let a = 8 * (cell div 2) + cell mod 2
+    ctx.trn1(v(24), "4s", v(a), v(a + 2))
+    ctx.trn2(v(a + 2), "4s", v(a), v(a + 2))
+    ctx.trn1(v(25), "4s", v(a + 4), v(a + 6))
+    ctx.trn2(v(a + 6), "4s", v(a + 4), v(a + 6))
+    ctx.trn1(v(a), "2d", v(24), v(25))
+    ctx.trn2(v(a + 4), "2d", v(24), v(25))
+    ctx.trn1(v(16 + cell), "2d", v(a + 2), v(a + 6))
+    ctx.trn2(v(a + 6), "2d", v(a + 2), v(a + 6))
+  # Each pair (lo, hi) holds one output column's rows 0-3 and 4-7.
+  const storePairs = [(0, 8), (16, 18), (4, 12), (6, 14),
+                      (1, 9), (17, 19), (5, 13), (7, 15)]
+  for i, (lo, hi) in storePairs:
+    ctx.stp(v(lo), v(hi), x(20), 128 * i)
+  ctx.add(x(20), x(20), 1024)
+
+proc buildNeonPackATranspose8rows(
+    ctx: var AssemblerSME,
+    dst, src, rowStrideOp, nGroupsOp, validOp: NimNode) =
+  ## Records the `neon_packA_transpose_8rows` instruction stream into
+  ## `ctx` in source order: the eight row pointers, the full 8-row transpose loop,
+  ## then the cold partial-row loop. Operand bindings:
+  ## pointers via `"r"`, the stride and counts via `"r"((long)...)`.
+  let dstOp = ctx.input("dst", dst)
+  let srcOp = ctx.input("src", src)
+  let rsOp = ctx.inputLong("rowStride", rowStrideOp)
+  let ngOp = ctx.inputLong("nGroups", nGroupsOp)
+  let validOp2 = ctx.inputLong("valid", validOp)
+  ctx.mov(x(20), view(dstOp))
+  ctx.mov(x(21), view(srcOp))
+  ctx.mov(x(22), xview(rsOp))
+  ctx.mov(w(23), wview(ngOp))
+  ctx.mov(w(24), wview(validOp2))
+  ctx.lsl(x(22), $x(22), 2)
+  ctx.mov(x(9), x(21))
+  for r in 1 .. 7:
+    ctx.add(x(9 + r), x(8 + r), x(22))
+  ctx.cmp(w(24), 8)
+  ctx.bne("4f")
+  ctx.cbz(w(23), "8f")
+  ctx.label("2")
+  for r in 0 .. 7:
+    ctx.ld1(vlist(2 * r, 2 * r + 1, "4s"), mem(x(9 + r)))
+  for r in 0 .. 7:
+    ctx.add(x(9 + r), x(9 + r), 32)
+  emitTrnStore8x8(ctx)
+  ctx.subs(w(23), w(23), 1)
+  ctx.bne("2b")
+  ctx.b("8f")
+  ctx.label("4")
+  ctx.cbz(w(23), "8f")
+  for i in 0 .. 15:
+    ctx.movi(v(i), "16b", 0)
+  for r in 0 .. 7:
+    ctx.cmp(w(24), r + 1)
+    ctx.blt("5f")
+    ctx.ld1(vlist(2 * r, 2 * r + 1, "4s"), mem(x(9 + r)))
+  ctx.label("5")
+  for r in 0 .. 7:
+    ctx.add(x(9 + r), x(9 + r), 32)
+  emitTrnStore8x8(ctx)
+  ctx.subs(w(23), w(23), 1)
+  ctx.bne("4b")
+  ctx.label("8")
+  ctx.clobber("x9", "x10", "x11", "x12", "x13", "x14", "x15", "x16",
+              "x20", "x21", "x22", "w23", "w24")
+  ctx.clobberV()
+  ctx.clobberCC()
+  ctx.clobberMemory()
+
+macro genNeonPackATranspose8rows(
+    dst, src, rowStrideOp, nGroupsOp, validOp: typed): untyped =
+  ## Expands to the `{.emit: ...}` pragma for
+  ## `neon_packA_transpose_8rows`.
+  var ctx = init(AssemblerSME)
+  buildNeonPackATranspose8rows(ctx, dst, src, rowStrideOp, nGroupsOp,
+                               validOp)
+  result = ctx.generate()
+
+proc neon_packA_transpose_8rows*(
+    dst: ptr float32,      # packA + ir*kc*mr + g*8 (8-row group g, k = 0)
+    src: ptr float32,      # pA_ptr + (srcRow + g*8) * pA_rs (group's first row, k = 0)
+    srcRowStride: cint,    # pA_rs: elements between consecutive A rows
+    nColGroups: cint,      # current_kc div 8: 8-column blocks to transpose
+    validRows: cint) =
+  ## NEON block-transpose pack for one 8-row group of the 32-row A tile.
+  ##
+  ## Expected input:
+  ##   - src: first row of the 8-row group (row-major f32, rows
+  ##     `srcRowStride` elements apart, `8 * nColGroups` contiguous f32 per row)
+  ##   - srcRowStride: elements between consecutive source rows
+  ##   - nColGroups: 8-column blocks to transpose (kc / 8)
+  ##   - validRows: valid rows in `0..8`, rows past it zero-filled
+  ##   - dst: group's packed slot (packA + ir*kc*mr + g*8)
+  ##
+  ## Output: one transposed 8×8 block per column group, columns 32 f32
+  ##   apart: `dst[c*32 + r] = (r < validRows) ? src[r*rs + c] : 0`
+  ##   for `c in 0 ..< 8 * nColGroups`, `r in 0 .. 7`. A zero group count
+  ##   packs nothing.
+  ##
+  ## before (src, row-major):              after (dst, one 8×8 block):
+  ##   r0: a b c d                           c0: a e i m      dst[0..7]
+  ##   r1: e f g h                           c1: b f j n      dst[32..39]
+  ##   r2: i j k l                           c2: c g k o      dst[64..71]
+  ##   r3: m n o p                           c3: d h l p      dst[96..103]
+  ##   (4×4 excerpt of each 8×8 block, whose columns land 32 f32 apart in dst)
+  genNeonPackATranspose8rows(dst, src, srcRowStride, nColGroups,
+                             validRows)
+
+proc emitA16TransposeStore(ctx: var AssemblerSME) =
+  for g in 0 .. 3:
+    ctx.mov(w(12), "#" & $(4 * g))
+    ctx.mova(zaSlice("za0h", "s", "w12", 0, 3),
+             zrng(4 * g, 4 * g + 3, "s"))
+  for g in 0 .. 3:
+    ctx.mov(w(12), "#" & $(4 * g))
+    ctx.mova(zrng(4 * g, 4 * g + 3, "s"),
+             zaSlice("za0v", "s", "w12", 0, 3))
+  const stBases = [16, 17, 23, 24]
+  for g in 0 .. 3:
+    for lane in 0 .. 3:
+      ctx.st1w(z(4 * g + lane), "s", p(0),
+               memVL(x(stBases[g]), 2 * lane))
+  for base in stBases:
+    ctx.add(x(base), x(base), 2048)
+
+proc buildSmePackATranspose16rows(
+    ctx: var AssemblerSME,
+    dst, src, rowStrideOp, nColBlocksOp, validOp: NimNode) =
+  ## Records the `sme_packA_transpose_16rows` instruction stream into
+  ## `ctx` in source order: the smstart bracket, the 16 row pointers,
+  ## the full 16-row transpose loop, then the cold partial-row loop.
+  ## Operand bindings: pointers via `"r"`, the stride and counts via `"r"((long)...)`.
+  let srcOp = ctx.input("src", src)
+  let dstOp = ctx.input("dst", dst)
+  let rsOp = ctx.inputLong("rs", rowStrideOp)
+  let nbOp = ctx.inputLong("nb", nColBlocksOp)
+  let validOp2 = ctx.inputLong("valid", validOp)
+  ctx.smstart()
+  ctx.ptrue(p(0), "s")
+  ctx.mov(x(0), view(srcOp))
+  ctx.lsl(x(11), xview(rsOp), 2)
+  ctx.add(x(1), x(0), x(11))
+  ctx.add(x(2), x(1), x(11))
+  ctx.add(x(3), x(2), x(11))
+  ctx.add(x(4), x(3), x(11))
+  ctx.add(x(5), x(4), x(11))
+  ctx.add(x(6), x(5), x(11))
+  ctx.add(x(7), x(6), x(11))
+  ctx.lsl(x(9), $x(11), 3)  # x9 = 8 rows in bytes
+  ctx.sub(x(10), x(9), 64)  # x10 = x9 - one 16-col block
+  ctx.mov(x(16), view(dstOp))
+  ctx.add(x(17), x(16), 512)
+  ctx.add(x(23), x(17), 512)
+  ctx.add(x(24), x(23), 512)
+  ctx.mov(w(27), wview(nbOp))
+  ctx.mov(w(28), wview(validOp2))
+  ctx.cmp(w(28), 16)
+  ctx.bne("4f")
+  ctx.cbz(w(27), "8f")
+  ctx.label("2")
+  for r in 0 .. 7:
+    ctx.ld1w(z(r), "s", p(0), mem(x(r)))
+  for r in 0 .. 7:
+    ctx.add(x(r), x(r), x(9))
+  for r in 8 .. 15:
+    ctx.ld1w(z(r), "s", p(0), mem(x(r - 8)))
+  for r in 0 .. 7:
+    ctx.sub(x(r), x(r), x(10))
+  emitA16TransposeStore(ctx)
+  ctx.subs(w(27), w(27), 1)
+  ctx.bne("2b")
+  ctx.b("8f")
+  ctx.label("4")
+  ctx.cbz(w(27), "8f")
+  for r in 0 .. 15:
+    ctx.mov(z(r), "s", 0)
+  for r in 0 .. 7:
+    ctx.cmp(w(28), r + 1)
+    ctx.blt("5f")
+    ctx.ld1w(z(r), "s", p(0), mem(x(r)))
+  ctx.label("5")
+  for r in 0 .. 7:
+    ctx.add(x(r), x(r), x(9))
+  for r in 8 .. 15:
+    ctx.cmp(w(28), r + 1)
+    ctx.blt("6f")
+    ctx.ld1w(z(r), "s", p(0), mem(x(r - 8)))
+  ctx.label("6")
+  for r in 0 .. 7:
+    ctx.sub(x(r), x(r), x(10))
+  emitA16TransposeStore(ctx)
+  ctx.subs(w(27), w(27), 1)
+  ctx.bne("4b")
+  ctx.label("8")
+  ctx.smstop()
+  ctx.clobber("x0", "x1", "x2", "x3", "x4", "x5", "x6", "x7",
+              "x9", "x10", "x11", "x16", "x17", "x23", "x24",
+              "w12", "w27", "w28")
+  ctx.clobberZ()
+  ctx.clobberP()
+  ctx.clobberCC()
+  ctx.clobberMemory()
+
+macro genSmePackATranspose16rows(
+    dst, src, rowStrideOp, nColBlocksOp, validOp: typed): untyped =
+  ## Expands to the `{.emit: ...}` pragma for
+  ## `sme_packA_transpose_16rows`.
+  var ctx = init(AssemblerSME)
+  buildSmePackATranspose16rows(ctx, dst, src, rowStrideOp, nColBlocksOp,
+                               validOp)
+  result = ctx.generate()
+
+proc sme_packA_transpose_16rows*(
+    dst: ptr float32,      # packA + ir*kc*mr + g*16 (16-row group g, k = 0)
+    src: ptr float32,      # pA_ptr + (srcRow + g*16) * pA_rs (group's first row, k = 0)
+    srcRowStride: cint,    # pA_rs: elements between consecutive A rows
+    nColBlocks: cint,      # current_kc div 16: 16-column blocks to transpose
+    validRows: cint) =
+  ## Streaming SME2 A-transpose pack for one 16-row group of the 32-row A tile.
+  ##
+  ## Expected input:
+  ##   - src: first row of the 16-row group (row-major f32, rows
+  ##     `srcRowStride` elements apart, `16 * nColBlocks` contiguous f32 per row)
+  ##   - srcRowStride: elements between consecutive source rows
+  ##   - nColBlocks: 16-column blocks to transpose (kc / 16)
+  ##   - validRows: valid rows in `0..16`, rows past it zero-filled
+  ##   - dst: group's packed slot (packA + ir*kc*mr + g*16)
+  ##
+  ## Output: one transposed 16×16 block per column group, columns 32 f32
+  ##   apart: `dst[c*32 + r] = (r < validRows) ? src[r*rs + c] : 0`
+  ##   for `c in 0 ..< 16 * nColBlocks`, `r in 0 .. 15`. A zero block count
+  ##   packs nothing.
+  ##
+  ## before (src, row-major):              after (dst, one 16×16 block):
+  ##   r0: a b c d                           c0: a e i m      dst[0..15]
+  ##   r1: e f g h                           c1: b f j n      dst[32..47]
+  ##   r2: i j k l                           c2: c g k o      dst[64..79]
+  ##   r3: m n o p                           c3: d h l p      dst[96..111]
+  ##   (4×4 excerpt of each 16×16 block, whose columns land 32 f32 apart in dst)
+  ##
+  ## Runs inside an smstart/smstop bracket (streaming mode, SVE/SME2 only).
+  genSmePackATranspose16rows(dst, src, srcRowStride, nColBlocks,
+                             validRows)
+
+proc buildSmePackBCopy32f32X4(
+    ctx: var AssemblerSME,
+    dst0, dst1, dst2, dst3, src, rowStrideOp, nRowsOp: NimNode) =
+  ## Records the `sme_packB_copy_32f32_x4` instruction stream into
+  ## `ctx` in source order: the smstart bracket, then the row loop of eight `ld1w` loads
+  ## and eight `st1w` stores. Operand bindings:
+  ## pointers via `"r"`, the stride and row count via `"r"((long)...)`.
+  let d0Op = ctx.input("d0", dst0)
+  let d1Op = ctx.input("d1", dst1)
+  let d2Op = ctx.input("d2", dst2)
+  let d3Op = ctx.input("d3", dst3)
+  let srcOp = ctx.input("src", src)
+  let rsOp = ctx.inputLong("rs", rowStrideOp)
+  let nOp = ctx.inputLong("n", nRowsOp)
+  ctx.smstart()
+  ctx.ptrue(p(0), "s")
+  ctx.mov(x(26), view(srcOp))
+  ctx.mov(x(9), view(d0Op))
+  ctx.mov(x(10), view(d1Op))
+  ctx.mov(x(11), view(d2Op))
+  ctx.mov(x(12), view(d3Op))
+  ctx.lsl(x(25), xview(rsOp), 2)
+  ctx.mov(w(27), wview(nOp))
+  ctx.label("1")
+  for lane in 0 .. 7:
+    ctx.ld1w(z(lane), "s", p(0), memStep(x(26), lane))
+  ctx.add(x(26), x(26), x(25))
+  for panel in 0 .. 3:
+    ctx.st1w(z(2 * panel), "s", p(0), mem(x(9 + panel)))
+    ctx.st1w(z(2 * panel + 1), "s", p(0), memVL(x(9 + panel), 1))
+  for panel in 0 .. 3:
+    ctx.add(x(9 + panel), x(9 + panel), 128)
+  ctx.subs(w(27), w(27), 1)
+  ctx.bne("1b")
+  ctx.smstop()
+  ctx.clobber("x9", "x10", "x11", "x12", "x25", "x26", "w27")
+  ctx.clobberZ()
+  ctx.clobberP()
+  ctx.clobberCC()
+  ctx.clobberMemory()
+
+macro genSmePackBCopy32f32X4(
+    dst0, dst1, dst2, dst3, src, rowStrideOp, nRowsOp: typed): untyped =
+  ## Expands to the `{.emit: ...}` pragma for
+  ## `sme_packB_copy_32f32_x4`.
+  var ctx = init(AssemblerSME)
+  buildSmePackBCopy32f32X4(ctx, dst0, dst1, dst2, dst3, src,
+                           rowStrideOp, nRowsOp)
+  result = ctx.generate()
+
+proc sme_packB_copy_32f32_x4*(
+    dst0, dst1, dst2, dst3: ptr float32,  # packB + (jr0+i)*kc*nr for i in 0..3
+    src: ptr float32,                     # pB_ptr + jr0*nr (k = 0)
+    srcRowStride: cint,                   # pB_rs: elements between consecutive B rows
+    nRows: cint) =
+  ## Streaming SME2 B-pack for four consecutive full `jr` panels.
+  ##
+  ## Expected input:
+  ##   - src: first row of panel `jr0` (row-major f32, rows
+  ##     `srcRowStride` elements apart, 32 contiguous f32 per row)
+  ##   - srcRowStride: elements between consecutive source rows
+  ##   - nRows: source rows per panel (k)
+  ##   - dst0..dst3: panel bases (packB + (jr0+i)*kc*nr for i in 0..3)
+  ##
+  ## Output: row `k` of each panel copied into its packed slot:
+  ##   rows 32 f32 apart: `dst_i[k*32 ..< k*32+32] = src[k*rs ..< k*rs+32]`
+  ##   for each panel `i` in `0 .. 3`, `k in 0 ..< nRows` (bases dst0..dst3).
+  ##   No zero-fill: every lane is copied.
+  ##
+  ## before (src, one panel):              after (dst_i, packed):
+  ##   k0: [32 f32] at src + 0*rs           k0: [32 f32] at dst_i + 0*32
+  ##   k1: [32 f32] at src + 1*rs           k1: [32 f32] at dst_i + 1*32
+  ##   k2: [32 f32] at src + 2*rs           k2: [32 f32] at dst_i + 2*32
+  ##   rows `rs` f32 apart                  rows 32 f32 apart
+  ##
+  ## Contract: all four panels have 32 valid lanes per row and the panel
+  ## count is a multiple of 4.
+  ## Runs inside an smstart/smstop bracket (streaming mode, SVE/SME2 only).
+  genSmePackBCopy32f32X4(dst0, dst1, dst2, dst3, src, srcRowStride,
+                         nRows)
+
+proc buildNeonPackBCopy32f32(
+    ctx: var AssemblerSME,
+    dst, src, rowStrideOp, nRowsOp: NimNode) =
+  ## Records the `neon_packB_copy_32f32` instruction stream into `ctx`
+  ## in source order: the row loop of two 4-register `ld1`/`st1` pairs
+  ## with the post-copy row advance. Operand bindings: pointers via `"r"`,
+  ## the stride and row count via `"r"((long)...)`.
+  let dstOp = ctx.input("dst", dst)
+  let srcOp = ctx.input("src", src)
+  let rsOp = ctx.inputLong("rs", rowStrideOp)
+  let nOp = ctx.inputLong("n", nRowsOp)
+  ctx.mov(x(20), view(dstOp))
+  ctx.mov(x(21), view(srcOp))
+  ctx.lsl(x(22), xview(rsOp), 2)
+  ctx.sub(x(22), x(22), 128)
+  ctx.mov(w(23), wview(nOp))
+  ctx.label("1")
+  ctx.ld1(vlist(0, 3, "4s"), memPost(x(21), 64))
+  ctx.ld1(vlist(4, 7, "4s"), memPost(x(21), 64))
+  ctx.add(x(21), x(21), x(22))
+  ctx.st1(vlist(0, 3, "4s"), memPost(x(20), 64))
+  ctx.st1(vlist(4, 7, "4s"), memPost(x(20), 64))
+  ctx.subs(w(23), w(23), 1)
+  ctx.bne("1b")
+  ctx.clobber("x20", "x21", "x22", "w23")
+  ctx.clobber("v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7")
+  ctx.clobberCC()
+  ctx.clobberMemory()
+
+macro genNeonPackBCopy32f32(
+    dst, src, rowStrideOp, nRowsOp: typed): untyped =
+  ## Expands to the `{.emit: ...}` pragma for `neon_packB_copy_32f32`.
+  var ctx = init(AssemblerSME)
+  buildNeonPackBCopy32f32(ctx, dst, src, rowStrideOp, nRowsOp)
+  result = ctx.generate()
+
+proc neon_packB_copy_32f32*(
+    dst: ptr float32,      # packB + jr*kc*nr (k = 0)
+    src: ptr float32,      # pB_ptr + jr*nr (k = 0)
+    srcRowStride: cint,    # pB_rs: elements between consecutive B rows
+    nRows: cint) =
+  ## NEON B-pack for contiguous B rows.
+  ##
+  ## Expected input:
+  ##   - src: first row of panel `jr` (row-major f32, rows
+  ##     `srcRowStride` elements apart, 32 contiguous f32 per row)
+  ##   - srcRowStride: elements between consecutive source rows
+  ##   - nRows: source rows to copy (k)
+  ##   - dst: panel base (packB + jr*nr)
+  ##
+  ## Output: row `k` copied into its packed slot, rows 32 f32 apart:
+  ##   `dst[k*32 ..< k*32+32] = src[k*rs ..< k*rs+32]`, `k in 0 ..< nRows`.
+  ##
+  ## before (src):                         after (dst, packed):
+  ##   k0: [32 f32] at src + 0*rs           k0: [32 f32] at dst + 0*32
+  ##   k1: [32 f32] at src + 1*rs           k1: [32 f32] at dst + 1*32
+  ##   rows `rs` f32 apart                  rows 32 f32 apart
+  ##
+  ## Caller guarantees 32 valid lanes per source row and routes panels
+  ## with `eff < 32` lanes to the scalar copyMem path.
+  genNeonPackBCopy32f32(dst, src, srcRowStride, nRows)

--- a/workspace/ceramic/examples/ex02_matmul_microkernels/gemm_ukernel_arm64_sme2.nim
+++ b/workspace/ceramic/examples/ex02_matmul_microkernels/gemm_ukernel_arm64_sme2.nim
@@ -15,7 +15,7 @@
 ##
 ## Two fmopa conventions live in this file:
 ##   - AB-store kernels (16×16, 32×32): operands (B, A)
-##   - epi kernels: operands (A, B), required by their column-wise mova extract
+##   - epi kernels: operands (A, B), required by their row-wise mova extract
 ## Swapping the order silently transposes every tile. Only asymmetric data detects it.
 
 {.localpassC: "-march=armv9-a+sme2 -fno-vectorize -fno-slp-vectorize".}
@@ -23,14 +23,9 @@
 # disabled because emitted SVE instructions fault outside streaming mode.
 import workspace/cpuplatforms/arm/macro_assembler_arm64
 
-func memStep(base: XReg, imm: int): MemAddr =
-  ## Memory operand for a k-step vector load: `[base]` when `imm == 0`,
-  ## `[base, #imm, MUL VL]` otherwise.
-  if imm == 0: mem(base) else: memVL(base, imm)
-
 proc buildSme16x16(
     ctx: var AssemblerSME, pa, pb, ab, kcOp: NimNode) =
-  ## Records the `sme_gemm_ukernel_16x16` instruction stream into `ctx`
+  ## Records the `smeGemmUkernel16x16` instruction stream into `ctx`
   ## in source order: the k-loop over 16-lane vectors, then the 16-row
   ## tile-slice store. Operand bindings: pointers via `"r"`, the k counter
   ## via `"r"((long)...)`.
@@ -69,12 +64,12 @@ proc buildSme16x16(
   ctx.clobberMemory()
 
 macro genSme16x16(pa, pb, ab, kcOp: typed): untyped =
-  ## Expands to the `{.emit: ...}` pragma for `sme_gemm_ukernel_16x16`
+  ## Expands to the `{.emit: ...}` pragma for `smeGemmUkernel16x16`
   var ctx = init(AssemblerSME)
   buildSme16x16(ctx, pa, pb, ab, kcOp)
   result = ctx.generate()
 
-proc sme_gemm_ukernel_16x16*(
+proc smeGemmUkernel16x16*(
     packA, packB: ptr float32, AB: ptr float32, kc: cint) =
   ## 16×16 f32 SME outer-product micro-kernel:
   ## `AB[i][j] = Σ_k packA[k*16+i] * packB[k*16+j]`.
@@ -116,7 +111,7 @@ proc storeQuadrant(
 
 proc buildSme32x32(
     ctx: var AssemblerSME, pa, pb, ab, kcOp: NimNode) =
-  ## Records the `sme_gemm_ukernel_32x32` instruction stream into `ctx`
+  ## Records the `smeGemmUkernel32x32` instruction stream into `ctx`
   ## in source order: the block-pipelined k-loop over four ZA
   ## accumulators, the oddments tail, then the four quadrant stores.
   ## Operand bindings: pointers via `"r"`, the k counter via
@@ -214,12 +209,12 @@ proc buildSme32x32(
   ctx.clobberMemory()
 
 macro genSme32x32(pa, pb, ab, kcOp: typed): untyped =
-  ## Expands to the `{.emit: ...}` pragma for `sme_gemm_ukernel_32x32`
+  ## Expands to the `{.emit: ...}` pragma for `smeGemmUkernel32x32`
   var ctx = init(AssemblerSME)
   buildSme32x32(ctx, pa, pb, ab, kcOp)
   result = ctx.generate()
 
-proc sme_gemm_ukernel_32x32*(
+proc smeGemmUkernel32x32*(
     packA, packB: ptr float32, AB: ptr float32, kc: cint) =
   ## 32×32 f32 SME outer-product micro-kernel with four independent ZA
   ## accumulators (ZA0..ZA3), one per 16×16 quadrant of the output tile:
@@ -282,9 +277,10 @@ proc extractRows8(
   ## Emits the fused 8-row C-extract body for one ZA tile half: four SME2
   ## `mova` slice reads (2 output rows each), then per row the epilogue
   ## math and a streaming 2-vector store. `tile` is `za0h` (output rows
-  ## 0-15) or `za1h` (rows 16-31). In the transposed tile a mova column
-  ## equals the output row. The paired vectors of each mova hold that
-  ## row's left and right halves (za0/za2 for `za0h`, za1/za3 for `za1h`).
+  ## 0-15) or `za1h` (rows 16-31). Mova slice rows equal output rows
+  ## (the accumulator is untransposed). The paired vectors of each mova
+  ## hold that row's left and right halves (za0/za2 for `za0h`,
+  ## za1/za3 for `za1h`).
   ##
   ## Caller owns the loop counters: emits `mov w11, #2` and `mov w12, #0`
   ## before the `3:`/`4:` head and brackets the body with `b.ne`,
@@ -309,7 +305,7 @@ proc extractRows8(
 proc buildSme32x32Epi(
     ctx: var AssemblerSME,
     pa, pb, cOp, cs, kcOp, abits, bbits, reluOp, aone, bzero, bone: NimNode) =
-  ## Records the `sme_gemm_ukernel_32x32_epi` instruction stream into
+  ## Records the `smeGemmUkernel32x32Epi` instruction stream into
   ## `ctx` in source order: the single-vector k-loop over four ZA
   ## accumulators, the oddments tail, then the two fused extracts. Operand
   ## bindings. Stream shape equals
@@ -321,7 +317,7 @@ proc buildSme32x32Epi(
   let kcOp2 = ctx.inputLong("kc", kcOp)
   let abitsOp = ctx.inputLongParen("abits", abits)
   let bbitsOp = ctx.inputLongParen("bbits", bbits)
-  let infbitsOp = ctx.inputLit("infbits", 2143289344)
+  let clampHiBitsOp = ctx.inputLit("clampHiBits", 2143289344)
   let reluOp2 = ctx.inputLong("relu", reluOp)
   let aoneOp = ctx.inputLong("aone", aone)
   let bzeroOp = ctx.inputLong("bzero", bzero)
@@ -335,7 +331,7 @@ proc buildSme32x32Epi(
   ctx.dup(z(14), "s", wview(abitsOp))
   ctx.dup(z(15), "s", wview(bbitsOp))
   ctx.mov(z(4), "s", 0)
-  ctx.dup(z(5), "s", wview(infbitsOp))
+  ctx.dup(z(5), "s", wview(clampHiBitsOp))
   ctx.cbz(w(14), "9f")
   ctx.lsr(w(16), w(14), 2)
   ctx.cbz(w(16), "5f")
@@ -424,18 +420,18 @@ proc buildSme32x32Epi(
 
 macro genSme32x32Epi(
     pa, pb, cOp, cs, kcOp, abits, bbits, reluOp, aone, bzero, bone: typed): untyped =
-  ## Expands to the `{.emit: ...}` pragma for `sme_gemm_ukernel_32x32_epi`
+  ## Expands to the `{.emit: ...}` pragma for `smeGemmUkernel32x32Epi`
   var ctx = init(AssemblerSME)
   buildSme32x32Epi(ctx, pa, pb, cOp, cs, kcOp, abits, bbits,
                    reluOp, aone, bzero, bone)
   result = ctx.generate()
 
-proc sme_gemm_ukernel_32x32_epi*(
+proc smeGemmUkernel32x32Epi*(
     packA, packB: ptr float32, C: ptr float32, cRowStride: cint, kc: cint,
     alpha, beta: float32, relu, alphaOne, betaZero, betaOne: cint) =
   ## 32×32 f32 SME micro-kernel with a fused in-streaming extract to C
   ## (single-vector inner loop). The dual-vector variant
-  ## `sme_gemm_ukernel_32x32_epi_dv` is the hot path with the same
+  ## `smeGemmUkernel32x32EpiDv` is the hot path with the same
   ## contract.
   ##
   ## Expected input:
@@ -446,13 +442,13 @@ proc sme_gemm_ukernel_32x32_epi*(
   ##   - relu, alphaOne, betaZero, betaOne: flags mirroring the scalar epilogue's comparisons
   ##
   ## Output: `C[i][j] = beta*C[i][j] + alpha*f(AB[i][j])`, f = identity
-  ## or ReLU. The accumulator sits in ZA transposed (za row j = output col j),
-  ## so the in-streaming mova extract reads output rows
-  ## while applying the epilogue math:
+  ## or ReLU. The accumulator is untransposed (`ZA[i][j] = AB[i][j]`),
+  ## so the in-streaming mova extract reads horizontal slices
+  ## (output rows) while applying the epilogue math:
   ##
   ##   before (ZA accumulator):            after (C, row-major):
-  ##     za[j][i] = AB[i][j]                C[i][j] = beta*C[i][j]
-  ##     (za row j = output col j)          + alpha*f(AB[i][j])
+  ##     ZA[i][j] = AB[i][j]                C[i][j] = beta*C[i][j]
+  ##     (za row i = output row i)          + alpha*f(AB[i][j])
   ##
   ## ReLU `fclamp` maps NaN to 0 on M4, like the scalar epilogue.
   ## `beta == 0` stores `alpha*f(AB)`, possibly `-0.0` where the scalar epilogue stores `+0.0`.
@@ -464,12 +460,12 @@ proc sme_gemm_ukernel_32x32_epi*(
 proc buildSme32x32EpiDv(
     ctx: var AssemblerSME,
     pa, pb, cOp, cs, kcOp, abits, bbits, reluOp, aone, bzero, bone: NimNode) =
-  ## Records the `sme_gemm_ukernel_32x32_epi_dv` instruction stream into
+  ## Records the `smeGemmUkernel32x32EpiDv` instruction stream into
   ## `ctx` in source order: SME2 dual-vector loads in the 4-k-step blocks,
   ## single-vector oddments, then the two fused extracts. Operand bindings
   ## bindings: pointers and 64-bit values via
   ## `"r"`, 32-bit flags via `"r"((long)...)`, the alpha/beta bit patterns
-  ## via `"r"((long)(...))`, and the ReLU +inf word as a literal.
+  ## via `"r"((long)(...))`, and the quiet-NaN clamp upper bound as a literal.
   let paOp = ctx.input("pa", pa)
   let pbOp = ctx.input("pb", pb)
   let cOp2 = ctx.input("C", cOp)
@@ -477,7 +473,7 @@ proc buildSme32x32EpiDv(
   let kcOp2 = ctx.inputLong("kc", kcOp)
   let abitsOp = ctx.inputLongParen("abits", abits)
   let bbitsOp = ctx.inputLongParen("bbits", bbits)
-  let infbitsOp = ctx.inputLit("infbits", 2143289344)
+  let clampHiBitsOp = ctx.inputLit("clampHiBits", 2143289344)
   let reluOp2 = ctx.inputLong("relu", reluOp)
   let aoneOp = ctx.inputLong("aone", aone)
   let bzeroOp = ctx.inputLong("bzero", bzero)
@@ -492,7 +488,7 @@ proc buildSme32x32EpiDv(
   ctx.dup(z(14), "s", wview(abitsOp))
   ctx.dup(z(15), "s", wview(bbitsOp))
   ctx.mov(z(4), "s", 0)
-  ctx.dup(z(5), "s", wview(infbitsOp))
+  ctx.dup(z(5), "s", wview(clampHiBitsOp))
   ctx.cbz(w(14), "9f")
   ctx.lsr(w(16), w(14), 2)
   ctx.mov(x(21), "#0")
@@ -574,13 +570,13 @@ proc buildSme32x32EpiDv(
 
 macro genSme32x32EpiDv(
     pa, pb, cOp, cs, kcOp, abits, bbits, reluOp, aone, bzero, bone: typed): untyped =
-  ## Expands to the `{.emit: ...}` pragma for `sme_gemm_ukernel_32x32_epi_dv`.
+  ## Expands to the `{.emit: ...}` pragma for `smeGemmUkernel32x32EpiDv`.
   var ctx = init(AssemblerSME)
   buildSme32x32EpiDv(ctx, pa, pb, cOp, cs, kcOp, abits, bbits,
                      reluOp, aone, bzero, bone)
   result = ctx.generate()
 
-proc sme_gemm_ukernel_32x32_epi_dv*(
+proc smeGemmUkernel32x32EpiDv*(
     packA, packB: ptr float32, C: ptr float32, cRowStride: cint, kc: cint,
     alpha, beta: float32, relu, alphaOne, betaZero, betaOne: cint) =
   ## 32×32 f32 SME micro-kernel with a fused in-streaming extract to C
@@ -597,13 +593,13 @@ proc sme_gemm_ukernel_32x32_epi_dv*(
   ##     `betaOne = beta == 1`
   ##
   ## Output: `C[i][j] = beta*C[i][j] + alpha*f(AB[i][j])`.
-  ## The accumulator sits in ZA transposed (za row j = output col j),
-  ## so the in-streaming mova extract reads output rows
-  ## while applying the epilogue math:
+  ## The accumulator is untransposed (`ZA[i][j] = AB[i][j]`),
+  ## so the in-streaming mova extract reads horizontal slices
+  ## (output rows) while applying the epilogue math:
   ##
   ##   before (ZA accumulator):            after (C, row-major):
-  ##     za[j][i] = AB[i][j]                C[i][j] = beta*C[i][j]
-  ##     (za row j = output col j)          + alpha*f(AB[i][j])
+  ##     ZA[i][j] = AB[i][j]                C[i][j] = beta*C[i][j]
+  ##     (za row i = output row i)          + alpha*f(AB[i][j])
   ##
   ## ReLU `fclamp` maps NaN to 0 on M4, like the scalar epilogue.
   ## `beta == 0` stores `alpha*f(AB)`, possibly `-0.0` where the scalar epilogue stores `+0.0`.
@@ -617,7 +613,7 @@ proc buildNeonEpilogue(
     ctx: var AssemblerSME,
     cOp, abOp, rowStrideOp, abits, bbits,
     reluOp, aone, bzero, bone: NimNode) =
-  ## Records the `neon_epilogue_f32_32x32` instruction stream into `ctx`
+  ## Records the `neonEpilogueF3232x32` instruction stream into `ctx`
   ## in source order: the beta==0 store loop, then the beta!=0
   ## read-modify-write loop. Operand bindings:
   ## constraint list: pointers via `"r"`, the row stride and flags via
@@ -691,13 +687,13 @@ proc buildNeonEpilogue(
 macro genNeonEpilogue(
     cOp, abOp, rowStrideOp, abits, bbits,
     reluOp, aone, bzero, bone: typed): untyped =
-  ## Expands to the `{.emit: ...}` pragma for `neon_epilogue_f32_32x32`
+  ## Expands to the `{.emit: ...}` pragma for `neonEpilogueF3232x32`
   var ctx = init(AssemblerSME)
   buildNeonEpilogue(ctx, cOp, abOp, rowStrideOp, abits, bbits,
                     reluOp, aone, bzero, bone)
   result = ctx.generate()
 
-proc neon_epilogue_f32_32x32*(
+proc neonEpilogueF3232x32*(
     C: ptr float32, cRowStride: cint,   # C tile base, row stride in f32 elements
     AB: ptr float32,                    # full 32x32 AB tile (128 B per row)
     alpha, beta: float32,
@@ -730,7 +726,7 @@ proc neon_epilogue_f32_32x32*(
 # Tile dispatch
 # ----------------------------------------------------------------------------
 
-proc gemm_ukernel_sme*[MR, NR: static int](
+proc gemmUkernelSme*[MR, NR: static int](
     packA, packB: ptr UncheckedArray[float32],
     AB: var array[MR, array[NR, float32]],
     kc: int) =
@@ -747,19 +743,19 @@ proc gemm_ukernel_sme*[MR, NR: static int](
   ## Output: `AB` = the MR×NR outer-product tile, all lanes written.
   ##
   ## Two tile shapes, backed by two asm kernels in this file:
-  ## - MR == NR == 16: one ZA0 accumulator (sme_gemm_ukernel_16x16).
+  ## - MR == NR == 16: one ZA0 accumulator (smeGemmUkernel16x16).
   ## - MR == NR == 32: four ZA0..ZA3 accumulators, one per 16×16 quadrant
-  ##   of the 32×32 output tile (sme_gemm_ukernel_32x32), 4-way ILP
+  ##   of the 32×32 output tile (smeGemmUkernel32x32), 4-way ILP
   ##   hiding the `fmopa` latency.
   static: doAssert MR == NR and MR in {16, 32},
-    "gemm_ukernel_sme requires square tiles of 16 or 32 (got MR=" & $MR & ", NR=" & $NR & ")"
-  doAssert kc >= 0, "gemm_ukernel_sme: kc must be >= 0 (got " & $kc & ")"
+    "gemmUkernelSme requires square tiles of 16 or 32 (got MR=" & $MR & ", NR=" & $NR & ")"
+  doAssert kc >= 0, "gemmUkernelSme: kc must be >= 0 (got " & $kc & ")"
   when MR == 16:
-    sme_gemm_ukernel_16x16(
+    smeGemmUkernel16x16(
       cast[ptr float32](packA), cast[ptr float32](packB),
       addr AB[0][0], kc.cint)
   else:
-    sme_gemm_ukernel_32x32(
+    smeGemmUkernel32x32(
       cast[ptr float32](packA), cast[ptr float32](packB),
       addr AB[0][0], kc.cint)
 

--- a/workspace/ceramic/examples/ex02_matmul_microkernels/gemm_ukernel_arm64_sme2.nim
+++ b/workspace/ceramic/examples/ex02_matmul_microkernels/gemm_ukernel_arm64_sme2.nim
@@ -1,0 +1,765 @@
+## SME2 and NEON asm micro-kernels + tile dispatch for the ex02 examples,
+## float32, aarch64.
+##
+## Requires ARMv9.2 with FEAT_SME2 and assumes SVL = 64 B (16 f32 lanes per vector).
+## arm64 CPUs without SME2 fault on these instructions.
+## Larger-SVL implementations corrupt results (vector length mismatch).
+## macOS SDK ships no `<arm_sme.h>`, so every SME instruction is inline asm.
+## Tile-slice stores use the `st1w {zaNv.s[w13, 0]}, p1, [x4]` form.
+## Assembler rejects the bare `[w13]` index and needs explicit `, 0`.
+##
+## Streaming-mode rules:
+##   - `smstart`/`smstop` bracket every kernel call
+##   - NEON instructions fault inside streaming mode, and M4 has no non-streaming SVE
+##   - `.inst 0xd503477f` is a full `smstart` on M4 (streaming + ZA, zeroing the Z/V register file)
+##
+## Two fmopa conventions live in this file:
+##   - AB-store kernels (16×16, 32×32): operands (B, A)
+##   - epi kernels: operands (A, B), required by their column-wise mova extract
+## Swapping the order silently transposes every tile. Only asymmetric data detects it.
+
+{.localpassC: "-march=armv9-a+sme2 -fno-vectorize -fno-slp-vectorize".}
+# SME2 is for the multi-vector `mova` extract. SVE auto-vectorization is
+# disabled because emitted SVE instructions fault outside streaming mode.
+import workspace/cpuplatforms/arm/macro_assembler_arm64
+
+func memStep(base: XReg, imm: int): MemAddr =
+  ## Memory operand for a k-step vector load: `[base]` when `imm == 0`,
+  ## `[base, #imm, MUL VL]` otherwise.
+  if imm == 0: mem(base) else: memVL(base, imm)
+
+proc buildSme16x16(
+    ctx: var AssemblerSME, pa, pb, ab, kcOp: NimNode) =
+  ## Records the `sme_gemm_ukernel_16x16` instruction stream into `ctx`
+  ## in source order: the k-loop over 16-lane vectors, then the 16-row
+  ## tile-slice store. Operand bindings: pointers via `"r"`, the k counter
+  ## via `"r"((long)...)`.
+  let paOp = ctx.input("pa", pa)
+  let pbOp = ctx.input("pb", pb)
+  let abOp = ctx.input("ab", ab)
+  let kcOp2 = ctx.inputLong("kc", kcOp)
+  ctx.smstart()
+  ctx.zeroZa0()
+  ctx.ptrue(p(0), "s")
+  ctx.ptrue(p(1), "s")
+  ctx.mov(w(14), wview(kcOp2))
+  ctx.cbz(w(14), "2f")
+  ctx.mov(x(5), view(paOp))
+  ctx.mov(x(6), view(pbOp))
+  ctx.label("1")
+  ctx.ld1w(z(0), "s", p(0), mem(x(5)))
+  ctx.ld1w(z(4), "s", p(0), mem(x(6)))
+  ctx.fmopa(zaTile(0, "s"), p(0), p(0), z(4), z(0))
+  ctx.add(x(5), x(5), 64)
+  ctx.add(x(6), x(6), 64)
+  ctx.subs(w(14), w(14), 1)
+  ctx.bne("1b")
+  ctx.label("2")
+  ctx.mov(x(4), view(abOp))
+  for row in 0 .. 15:
+    ctx.mov(w(13), "#" & $row)
+    if row > 0:
+      ctx.add(x(4), x(4), 64)
+    ctx.st1w(zaSlice("za0v", "s", "w13", 0), p(1), mem(x(4)))
+  ctx.smstop()
+  ctx.clobber("x4", "x5", "x6", "w13", "w14")
+  ctx.clobberZ()
+  ctx.clobberP()
+  ctx.clobberCC()
+  ctx.clobberMemory()
+
+macro genSme16x16(pa, pb, ab, kcOp: typed): untyped =
+  ## Expands to the `{.emit: ...}` pragma for `sme_gemm_ukernel_16x16`
+  var ctx = init(AssemblerSME)
+  buildSme16x16(ctx, pa, pb, ab, kcOp)
+  result = ctx.generate()
+
+proc sme_gemm_ukernel_16x16*(
+    packA, packB: ptr float32, AB: ptr float32, kc: cint) =
+  ## 16×16 f32 SME outer-product micro-kernel:
+  ## `AB[i][j] = Σ_k packA[k*16+i] * packB[k*16+j]`.
+  ##
+  ## Expected input:
+  ##   - packA, packB: 16 contiguous f32 per k-step
+  ##     (`packA[k*16 ..< k*16+16]`, same for B), the ex02a `(ir, kc, 16)`
+  ##     packed layout
+  ##   - kc: k-steps to contract, `kc >= 0`. A `kc == 0` call
+  ##     stores a zeroed tile.
+  ##   - AB: 16×16 f32 output tile, all 256 lanes written (overwritten,
+  ##     never accumulated into)
+  ##
+  ## Output: the outer-product tile, one `fmopa` per k-step:
+  ##
+  ##   before (each k-step):               after (AB, 16×16):
+  ##     AB += a_k ⊗ b_k                   AB[i][j] = Σ_k a_k[i] * b_k[j]
+  ##     a_k = packA[k*16 ..< k*16+16]
+  ##     b_k = packB[k*16 ..< k*16+16]
+  ##
+  ## Pointers need no alignment.
+  genSme16x16(packA, packB, AB, kc)
+
+proc storeQuadrant(
+    ctx: var AssemblerSME, tileName: string, abOp: AsmOperand,
+    baseOffset, rowAdvance: int) =
+  ## Emits one 16-row ZA tile-slice store quadrant into AB: `mov x4, %[ab]`,
+  ## an optional offset add (64/2048/2112 for the za1/za2/za3 quadrants),
+  ## then per row `mov w13, #N`, `add x4, #rowAdvance`, and the slice
+  ## store `st1w {zaNv.s[w13, 0]}, p1, [x4]`. Row 0 skips the advance.
+  ctx.mov(x(4), view(abOp))
+  if baseOffset > 0:
+    ctx.add(x(4), x(4), baseOffset)
+  for row in 0 .. 15:
+    ctx.mov(w(13), "#" & $row)
+    if row > 0:
+      ctx.add(x(4), x(4), rowAdvance)
+    ctx.st1w(zaSlice(tileName, "s", "w13", 0), p(1), mem(x(4)))
+
+proc buildSme32x32(
+    ctx: var AssemblerSME, pa, pb, ab, kcOp: NimNode) =
+  ## Records the `sme_gemm_ukernel_32x32` instruction stream into `ctx`
+  ## in source order: the block-pipelined k-loop over four ZA
+  ## accumulators, the oddments tail, then the four quadrant stores.
+  ## Operand bindings: pointers via `"r"`, the k counter via
+  ## `"r"((long)...)`.
+  let paOp = ctx.input("pa", pa)
+  let pbOp = ctx.input("pb", pb)
+  let abOp = ctx.input("ab", ab)
+  let kcOp2 = ctx.inputLong("kc", kcOp)
+  ctx.smstart()
+  ctx.zeroZad()
+  ctx.ptrue(p(0), "s")
+  ctx.ptrue(p(1), "s")
+  ctx.mov(x(5), view(paOp))
+  ctx.mov(x(6), view(pbOp))
+  ctx.mov(w(14), wview(kcOp2))
+  ctx.cbz(w(14), "4f")
+  ctx.lsr(w(16), w(14), 2)
+  ctx.`and`(w(17), w(14), 3)
+  ctx.cbz(w(16), "3f")
+  # prologue: block 0 = A rows (z31..z24) and B cols (z23..z16)
+  ctx.ld1w(z(31), "s", p(0), mem(x(5)))
+  for i in 1 .. 7:
+    ctx.ld1w(z(31 - i), "s", p(0), memVL(x(5), i))
+  ctx.addvl(x(5), x(5), 8)
+  ctx.ld1w(z(23), "s", p(0), mem(x(6)))
+  for i in 1 .. 7:
+    ctx.ld1w(z(23 - i), "s", p(0), memVL(x(6), i))
+  ctx.addvl(x(6), x(6), 8)
+  ctx.sub(w(16), w(16), 1)
+  ctx.cbz(w(16), "2f")
+  ctx.label("1")
+  for step in 0 .. 3:
+    for q in 0 .. 3:
+      # Quadrant q of one k-step: B pair (23-2s, 22-2s), A pair
+      # (31-2s, 30-2s). Each q slot refills one freed register
+      # with next-block data:
+      #   q0 (s > 0): z(24-2s) <- [x6, #2s-1]  (step 0: loop subs)
+      #   q1:         z(31-2s) <- [x5, #2s]
+      #   q2:         z(23-2s) <- [x6, #2s]
+      #   q3:         z(30-2s) <- [x5, #2s+1]
+      # The 16th block load, z16 <- [x6, #7], sits between the addvl calls.
+      ctx.fmopa(zaTile(q, "s"), p(0), p(0),
+                z(23 - 2 * step - (q mod 2)), z(31 - 2 * step - (q div 2)))
+      case q
+      of 0:
+        if step == 0:
+          ctx.subs(w(16), w(16), 1)
+        else:
+          ctx.ld1w(z(24 - 2 * step), "s", p(0), memVL(x(6), 2 * step - 1))
+      of 1:
+        ctx.ld1w(z(31 - 2 * step), "s", p(0), memStep(x(5), 2 * step))
+      of 2:
+        ctx.ld1w(z(23 - 2 * step), "s", p(0), memStep(x(6), 2 * step))
+      of 3:
+        ctx.ld1w(z(30 - 2 * step), "s", p(0), memVL(x(5), 2 * step + 1))
+      else:
+        discard
+  ctx.addvl(x(5), x(5), 8)
+  ctx.ld1w(z(16), "s", p(0), memVL(x(6), 7))
+  ctx.addvl(x(6), x(6), 8)
+  ctx.bne("1b")
+  ctx.label("2")
+  for step in 0 .. 3:
+    for q in 0 .. 3:
+      ctx.fmopa(zaTile(q, "s"), p(0), p(0),
+                z(23 - 2 * step - (q mod 2)), z(31 - 2 * step - (q div 2)))
+  ctx.label("3")
+  ctx.cbz(w(17), "4f")
+  ctx.label("5")
+  # Oddments (kc % 4): loads put A in z16/z17 and B in z18/z19.
+  # za<q> takes (B, A) = (z(18 + q mod 2), z(16 + q div 2)).
+  for i in 0 .. 1:
+    ctx.ld1w(z(16 + i), "s", p(0), memStep(x(5), i))
+  for i in 0 .. 1:
+    ctx.ld1w(z(18 + i), "s", p(0), memStep(x(6), i))
+  for q in 0 .. 3:
+    ctx.fmopa(zaTile(q, "s"), p(0), p(0),
+              z(18 + q mod 2), z(16 + q div 2))
+  ctx.add(x(5), x(5), 128)
+  ctx.add(x(6), x(6), 128)
+  ctx.subs(w(17), w(17), 1)
+  ctx.bne("5b")
+  ctx.label("4")
+  # Quadrant tiles: za<q> covers rows 16*(q div 2) and cols 16*(q mod 2)
+  # of the 32x32 AB tile, so its base offset is (q div 2)*2048 +
+  # (q mod 2)*64 (row stride 128 B, col stride 4 B).
+  for q in 0 .. 3:
+    storeQuadrant(ctx, "za" & $q & "v", abOp,
+                  (q div 2) * 2048 + (q mod 2) * 64, 128)
+  ctx.smstop()
+  ctx.clobber("x4", "x5", "x6", "w13", "w14", "x16", "x17")
+  ctx.clobberZ()
+  ctx.clobberP()
+  ctx.clobberCC()
+  ctx.clobberMemory()
+
+macro genSme32x32(pa, pb, ab, kcOp: typed): untyped =
+  ## Expands to the `{.emit: ...}` pragma for `sme_gemm_ukernel_32x32`
+  var ctx = init(AssemblerSME)
+  buildSme32x32(ctx, pa, pb, ab, kcOp)
+  result = ctx.generate()
+
+proc sme_gemm_ukernel_32x32*(
+    packA, packB: ptr float32, AB: ptr float32, kc: cint) =
+  ## 32×32 f32 SME outer-product micro-kernel with four independent ZA
+  ## accumulators (ZA0..ZA3), one per 16×16 quadrant of the output tile:
+  ## `AB[i][j] = Σ_k packA[k*32+i] * packB[k*32+j]`.
+  ##
+  ## Expected input:
+  ##   - packA, packB: 32 contiguous f32 per k-step
+  ##     (`packA[k*32 ..< k*32+32]`, same for B), the ex02a `(ir, kc, 32)`
+  ##     packed layout
+  ##   - kc: k-steps to contract, `kc >= 0`. A `kc == 0` call stores
+  ##     zeroed tiles.
+  ##   - AB: 32×32 f32 output tile, all 1024 lanes written (overwritten,
+  ##     never accumulated into)
+  ##
+  ## Output: the 32×32 outer-product tile, one `fmopa` per quadrant per k-step.
+  ## Quadrant mapping:
+  ##
+  ##   za0: rows 0-15,  cols 0-15     za1: rows 0-15,  cols 16-31
+  ##   za2: rows 16-31, cols 0-15     za3: rows 16-31, cols 16-31
+  ##
+  ## Four independent quadrants give 4-way ILP, hiding the `fmopa`
+  ## latency. The k-loop is block-double-buffered: 4-step blocks
+  ## (16 loads + 16 fmopa), next-block loads interleaved
+  ## after each register's last use. `kc % 4` leftover steps run
+  ## unpipelined.
+  ## Pointers need no alignment.
+  genSme32x32(packA, packB, AB, kc)
+
+proc emitRowPair(
+    ctx: var AssemblerSME, lo, hi, dec: int,
+    relu, aone, bzero, bone: AsmOperand) =
+  ## Emits one 2-vector extract row (`z<lo>`, `z<hi>`) with label base `dec`:
+  ## ReLU clamp, alpha scaling, C read-modify-write, then the streaming
+  ## 2-vector store. The label order (dec, dec+1, dec+3, dec+2) is
+  ## load-bearing for the forward branches.
+  ctx.cbz(wview(relu), $dec & "f")
+  ctx.fclamp(zrng(lo, hi, "s"), z(4), z(5))
+  ctx.label($dec)
+  ctx.cbnz(wview(aone), $(dec + 1) & "f")
+  ctx.fmul(z(lo), "s", p(0), z(lo), z(14))
+  ctx.fmul(z(hi), "s", p(0), z(hi), z(14))
+  ctx.label($(dec + 1))
+  ctx.cbnz(wview(bzero), $(dec + 2) & "f")
+  ctx.ld1w(z(12), "s", p(0), mem(x(22)))
+  ctx.ld1w(z(13), "s", p(0), memVL(x(22), 1))
+  ctx.cbnz(wview(bone), $(dec + 3) & "f")
+  ctx.fmul(z(12), "s", p(0), z(12), z(15))
+  ctx.fmul(z(13), "s", p(0), z(13), z(15))
+  ctx.label($(dec + 3))
+  ctx.fadd(z(lo), "s", p(0), z(lo), z(12))
+  ctx.fadd(z(hi), "s", p(0), z(hi), z(13))
+  ctx.label($(dec + 2))
+  ctx.st1w(z(lo), "s", p(0), mem(x(22)))
+  ctx.st1w(z(hi), "s", p(0), memVL(x(22), 1))
+  ctx.add(x(22), x(22), x(10))
+
+proc extractRows8(
+    ctx: var AssemblerSME, tile: static string,
+    relu, aone, bzero, bone: AsmOperand) =
+  ## Emits the fused 8-row C-extract body for one ZA tile half: four SME2
+  ## `mova` slice reads (2 output rows each), then per row the epilogue
+  ## math and a streaming 2-vector store. `tile` is `za0h` (output rows
+  ## 0-15) or `za1h` (rows 16-31). In the transposed tile a mova column
+  ## equals the output row. The paired vectors of each mova hold that
+  ## row's left and right halves (za0/za2 for `za0h`, za1/za3 for `za1h`).
+  ##
+  ## Caller owns the loop counters: emits `mov w11, #2` and `mov w12, #0`
+  ## before the `3:`/`4:` head and brackets the body with `b.ne`,
+  ## decrementing w11 and advancing w12 by 8 after each mova pair
+  ## (extracted row index = w12/2). Row pairs own label decades
+  ## (z16/z17 → 40s, ..., z30/z31 → 110s), reused by both halves.
+  ctx.mov(zrng(16, 19, "h"), zaSlice(tile, "h", "w12", 0, 3))
+  ctx.mov(zrng(24, 27, "h"), zaSlice(tile, "h", "w12", 4, 7))
+  ctx.add(w(12), w(12), 8)
+  ctx.subs(w(11), w(11), 1)
+  ctx.mov(zrng(8, 11, "h"), zaSlice(tile, "h", "w12", 0, 3))
+  ctx.mov(zrng(28, 31, "h"), zaSlice(tile, "h", "w12", 4, 7))
+  ctx.add(w(12), w(12), 8)
+  # Row-pair groups, one per mova range in emission order: (range base,
+  # first label decade). Two pairs per range. The decades step by 10.
+  const extractGroups = [(16, 40), (24, 60), (8, 80), (28, 100)]
+  for (loBase, decBase) in extractGroups:
+    for pair in 0 .. 1:
+      emitRowPair(ctx, loBase + 2 * pair, loBase + 2 * pair + 1,
+                  decBase + 10 * pair, relu, aone, bzero, bone)
+
+proc buildSme32x32Epi(
+    ctx: var AssemblerSME,
+    pa, pb, cOp, cs, kcOp, abits, bbits, reluOp, aone, bzero, bone: NimNode) =
+  ## Records the `sme_gemm_ukernel_32x32_epi` instruction stream into
+  ## `ctx` in source order: the single-vector k-loop over four ZA
+  ## accumulators, the oddments tail, then the two fused extracts. Operand
+  ## bindings. Stream shape equals
+  ## the dual-vector kernel's minus its dual-load offsets.
+  let paOp = ctx.input("pa", pa)
+  let pbOp = ctx.input("pb", pb)
+  let cOp2 = ctx.input("C", cOp)
+  let csOp = ctx.inputLong("cs", cs)
+  let kcOp2 = ctx.inputLong("kc", kcOp)
+  let abitsOp = ctx.inputLongParen("abits", abits)
+  let bbitsOp = ctx.inputLongParen("bbits", bbits)
+  let infbitsOp = ctx.inputLit("infbits", 2143289344)
+  let reluOp2 = ctx.inputLong("relu", reluOp)
+  let aoneOp = ctx.inputLong("aone", aone)
+  let bzeroOp = ctx.inputLong("bzero", bzero)
+  let boneOp = ctx.inputLong("bone", bone)
+  ctx.smstart()
+  ctx.zeroZad()
+  ctx.ptrue(p(0), "s")
+  ctx.mov(x(5), view(paOp))
+  ctx.mov(x(6), view(pbOp))
+  ctx.mov(w(14), wview(kcOp2))
+  ctx.dup(z(14), "s", wview(abitsOp))
+  ctx.dup(z(15), "s", wview(bbitsOp))
+  ctx.mov(z(4), "s", 0)
+  ctx.dup(z(5), "s", wview(infbitsOp))
+  ctx.cbz(w(14), "9f")
+  ctx.lsr(w(16), w(14), 2)
+  ctx.cbz(w(16), "5f")
+  ctx.ld1w(z(31), "s", p(0), mem(x(5)))
+  for i in 1 .. 7:
+    ctx.ld1w(z(31 - i), "s", p(0), memVL(x(5), i))
+  ctx.addvl(x(5), x(5), 8)
+  ctx.ld1w(z(23), "s", p(0), mem(x(6)))
+  for i in 1 .. 7:
+    ctx.ld1w(z(23 - i), "s", p(0), memVL(x(6), i))
+  ctx.addvl(x(6), x(6), 8)
+  ctx.sub(w(16), w(16), 1)
+  ctx.cbz(w(16), "2f")
+  ctx.label("1")
+  for step in 0 .. 3:
+    for q in 0 .. 3:
+      # Quadrant q of one k-step: A pair (31-2s, 30-2s), B pair
+      # (23-2s, 22-2s). Each q slot refills one freed register
+      # with next-block data:
+      #   q0 (s > 0): z(24-2s) <- [x6, #2s-1]  (step 0: loop subs)
+      #   q1:         z(23-2s) <- [x6, #2s]
+      #   q2:         z(31-2s) <- [x5, #2s]
+      #   q3:         z(30-2s) <- [x5, #2s+1]
+      # The 16th block load, z16 <- [x6, #7], sits between the addvl calls.
+      ctx.fmopa(zaTile(q, "s"), p(0), p(0),
+                z(31 - 2 * step - (q mod 2)), z(23 - 2 * step - (q div 2)))
+      case q
+      of 0:
+        if step == 0:
+          ctx.subs(w(16), w(16), 1)
+        else:
+          ctx.ld1w(z(24 - 2 * step), "s", p(0), memVL(x(6), 2 * step - 1))
+      of 1:
+        ctx.ld1w(z(23 - 2 * step), "s", p(0), memStep(x(6), 2 * step))
+      of 2:
+        ctx.ld1w(z(31 - 2 * step), "s", p(0), memStep(x(5), 2 * step))
+      of 3:
+        ctx.ld1w(z(30 - 2 * step), "s", p(0), memVL(x(5), 2 * step + 1))
+      else:
+        discard
+  ctx.addvl(x(5), x(5), 8)
+  ctx.ld1w(z(16), "s", p(0), memVL(x(6), 7))
+  ctx.addvl(x(6), x(6), 8)
+  ctx.bne("1b")
+  ctx.label("2")
+  for step in 0 .. 3:
+    for q in 0 .. 3:
+      ctx.fmopa(zaTile(q, "s"), p(0), p(0),
+                z(31 - 2 * step - (q mod 2)), z(23 - 2 * step - (q div 2)))
+  ctx.label("5")
+  ctx.`and`(w(17), w(14), 3)
+  ctx.cbz(w(17), "9f")
+  ctx.label("6")
+  # Oddments (kc % 4): loads put A in z16/z17 and B in z18/z19.
+  # za<q> takes (A, B) = (z(16 + q mod 2), z(18 + q div 2)).
+  for i in 0 .. 1:
+    ctx.ld1w(z(16 + i), "s", p(0), memStep(x(5), i))
+  for i in 0 .. 1:
+    ctx.ld1w(z(18 + i), "s", p(0), memStep(x(6), i))
+  for q in 0 .. 3:
+    ctx.fmopa(zaTile(q, "s"), p(0), p(0),
+              z(16 + q mod 2), z(18 + q div 2))
+  ctx.add(x(5), x(5), 128)
+  ctx.add(x(6), x(6), 128)
+  ctx.subs(w(17), w(17), 1)
+  ctx.bne("6b")
+  ctx.label("9")
+  ctx.mov(x(22), view(cOp2))
+  ctx.lsl(x(10), xview(csOp), 2)
+  ctx.mov(w(11), "#2")
+  ctx.mov(w(12), "#0")
+  ctx.label("3")
+  extractRows8(ctx, "za0h", reluOp2, aoneOp, bzeroOp, boneOp)
+  ctx.bne("3b")
+  ctx.mov(w(11), "#2")
+  ctx.mov(w(12), "#0")
+  ctx.label("4")
+  extractRows8(ctx, "za1h", reluOp2, aoneOp, bzeroOp, boneOp)
+  ctx.bne("4b")
+  ctx.smstop()
+  ctx.clobber("x5", "x6", "x10", "x11", "x22", "w12", "w14", "w16", "w17")
+  ctx.clobberZ()
+  ctx.clobberP()
+  ctx.clobberCC()
+  ctx.clobberMemory()
+
+macro genSme32x32Epi(
+    pa, pb, cOp, cs, kcOp, abits, bbits, reluOp, aone, bzero, bone: typed): untyped =
+  ## Expands to the `{.emit: ...}` pragma for `sme_gemm_ukernel_32x32_epi`
+  var ctx = init(AssemblerSME)
+  buildSme32x32Epi(ctx, pa, pb, cOp, cs, kcOp, abits, bbits,
+                   reluOp, aone, bzero, bone)
+  result = ctx.generate()
+
+proc sme_gemm_ukernel_32x32_epi*(
+    packA, packB: ptr float32, C: ptr float32, cRowStride: cint, kc: cint,
+    alpha, beta: float32, relu, alphaOne, betaZero, betaOne: cint) =
+  ## 32×32 f32 SME micro-kernel with a fused in-streaming extract to C
+  ## (single-vector inner loop). The dual-vector variant
+  ## `sme_gemm_ukernel_32x32_epi_dv` is the hot path with the same
+  ## contract.
+  ##
+  ## Expected input:
+  ##   - packA, packB: 32 contiguous f32 per k-step (the ex02a `(ir, kc, 32)` packed layout)
+  ##   - kc: k-steps to contract, `kc >= 0`
+  ##   - C: 32×32 f32 tile, col stride 1, row stride `cRowStride`
+  ##   - alpha, beta: scale factors
+  ##   - relu, alphaOne, betaZero, betaOne: flags mirroring the scalar epilogue's comparisons
+  ##
+  ## Output: `C[i][j] = beta*C[i][j] + alpha*f(AB[i][j])`, f = identity
+  ## or ReLU. The accumulator sits in ZA transposed (za row j = output col j),
+  ## so the in-streaming mova extract reads output rows
+  ## while applying the epilogue math:
+  ##
+  ##   before (ZA accumulator):            after (C, row-major):
+  ##     za[j][i] = AB[i][j]                C[i][j] = beta*C[i][j]
+  ##     (za row j = output col j)          + alpha*f(AB[i][j])
+  ##
+  ## ReLU `fclamp` maps NaN to 0 on M4, like the scalar epilogue.
+  ## `beta == 0` stores `alpha*f(AB)`, possibly `-0.0` where the scalar epilogue stores `+0.0`.
+  let alphaBits = cast[int32](alpha)
+  let betaBits = cast[int32](beta)
+  genSme32x32Epi(packA, packB, C, cRowStride, kc, alphaBits, betaBits,
+                 relu, alphaOne, betaZero, betaOne)
+
+proc buildSme32x32EpiDv(
+    ctx: var AssemblerSME,
+    pa, pb, cOp, cs, kcOp, abits, bbits, reluOp, aone, bzero, bone: NimNode) =
+  ## Records the `sme_gemm_ukernel_32x32_epi_dv` instruction stream into
+  ## `ctx` in source order: SME2 dual-vector loads in the 4-k-step blocks,
+  ## single-vector oddments, then the two fused extracts. Operand bindings
+  ## bindings: pointers and 64-bit values via
+  ## `"r"`, 32-bit flags via `"r"((long)...)`, the alpha/beta bit patterns
+  ## via `"r"((long)(...))`, and the ReLU +inf word as a literal.
+  let paOp = ctx.input("pa", pa)
+  let pbOp = ctx.input("pb", pb)
+  let cOp2 = ctx.input("C", cOp)
+  let csOp = ctx.inputLong("cs", cs)
+  let kcOp2 = ctx.inputLong("kc", kcOp)
+  let abitsOp = ctx.inputLongParen("abits", abits)
+  let bbitsOp = ctx.inputLongParen("bbits", bbits)
+  let infbitsOp = ctx.inputLit("infbits", 2143289344)
+  let reluOp2 = ctx.inputLong("relu", reluOp)
+  let aoneOp = ctx.inputLong("aone", aone)
+  let bzeroOp = ctx.inputLong("bzero", bzero)
+  let boneOp = ctx.inputLong("bone", bone)
+  ctx.smstart()
+  ctx.zeroZad()
+  ctx.ptrue(p(0), "s")
+  ctx.ptruePn9B()
+  ctx.mov(x(5), view(paOp))
+  ctx.mov(x(6), view(pbOp))
+  ctx.mov(w(14), wview(kcOp2))
+  ctx.dup(z(14), "s", wview(abitsOp))
+  ctx.dup(z(15), "s", wview(bbitsOp))
+  ctx.mov(z(4), "s", 0)
+  ctx.dup(z(5), "s", wview(infbitsOp))
+  ctx.cbz(w(14), "9f")
+  ctx.lsr(w(16), w(14), 2)
+  ctx.mov(x(21), "#0")
+  ctx.mov(x(20), "#0")
+  ctx.cbz(w(16), "5f")
+  for i in 0 .. 3:
+    ctx.ld1w2(23 - i, 5, 21)
+    ctx.incw(21)
+  for i in 0 .. 3:
+    ctx.ld1w2(19 - i, 6, 20)
+    ctx.incw(20)
+  ctx.sub(w(16), w(16), 1)
+  ctx.cbz(w(16), "2f")
+  ctx.label("1")
+  # Next-block dual-vector loads interleaved into the fmopa stream
+  # at hand-tuned positions: (step, fmopa-in-step, ld1w2 first reg,
+  # base, counter). Each entry refreshes one dual-vector pair
+  # for the next block.
+  const dvLoads = [
+    (1, 2, 23, 5, 21), (1, 3, 19, 6, 20), (1, 4, 22, 5, 21),
+    (2, 1, 18, 6, 20),
+    (3, 2, 21, 5, 21), (3, 3, 17, 6, 20), (3, 4, 20, 5, 21), (3, 4, 16, 6, 20)]
+  for step in 0 .. 3:
+    for q in 0 .. 3:
+      # Quadrant q of one k-step in emission order za0/za2/za1/za3: A pair
+      # (23-s, 31-s), B pair (19-s, 27-s).
+      ctx.fmopa(zaTile(2 * (q mod 2) + q div 2, "s"), p(0), p(0),
+                z(23 - step + 8 * (q div 2)), z(19 - step + 8 * (q mod 2)))
+      for (ls, pos, zt1, xn, rm) in dvLoads:
+        if ls == step and pos == q + 1:
+          ctx.ld1w2(zt1, xn, rm)
+          ctx.incw(rm)
+  ctx.subs(w(16), w(16), 1)
+  ctx.bne("1b")
+  ctx.label("2")
+  for step in 0 .. 3:
+    for q in 0 .. 3:
+      ctx.fmopa(zaTile(2 * (q mod 2) + q div 2, "s"), p(0), p(0),
+                z(23 - step + 8 * (q div 2)), z(19 - step + 8 * (q mod 2)))
+  ctx.label("5")
+  ctx.addLsl(x(5), x(5), x(21), 2)
+  ctx.addLsl(x(6), x(6), x(20), 2)
+  ctx.`and`(w(17), w(14), 3)
+  ctx.cbz(w(17), "9f")
+  ctx.label("6")
+  # Oddments (kc % 4): loads put A in z16/z17 and B in z18/z19.
+  # za<q> takes (A, B) = (z(16 + q mod 2), z(18 + q div 2)).
+  for i in 0 .. 1:
+    ctx.ld1w(z(16 + i), "s", p(0), memStep(x(5), i))
+  for i in 0 .. 1:
+    ctx.ld1w(z(18 + i), "s", p(0), memStep(x(6), i))
+  for q in 0 .. 3:
+    ctx.fmopa(zaTile(q, "s"), p(0), p(0),
+              z(16 + q mod 2), z(18 + q div 2))
+  ctx.add(x(5), x(5), 128)
+  ctx.add(x(6), x(6), 128)
+  ctx.subs(w(17), w(17), 1)
+  ctx.bne("6b")
+  ctx.label("9")
+  ctx.mov(x(22), view(cOp2))
+  ctx.lsl(x(10), xview(csOp), 2)
+  ctx.mov(w(11), "#2")
+  ctx.mov(w(12), "#0")
+  ctx.label("3")
+  extractRows8(ctx, "za0h", reluOp2, aoneOp, bzeroOp, boneOp)
+  ctx.bne("3b")
+  ctx.mov(w(11), "#2")
+  ctx.mov(w(12), "#0")
+  ctx.label("4")
+  extractRows8(ctx, "za1h", reluOp2, aoneOp, bzeroOp, boneOp)
+  ctx.bne("4b")
+  ctx.smstop()
+  ctx.clobber("x5", "x6", "x10", "x11", "x20", "x21", "x22",
+              "w12", "w14", "w16", "w17")
+  ctx.clobberZ()
+  ctx.clobberP()
+  ctx.clobberCC()
+  ctx.clobberMemory()
+
+macro genSme32x32EpiDv(
+    pa, pb, cOp, cs, kcOp, abits, bbits, reluOp, aone, bzero, bone: typed): untyped =
+  ## Expands to the `{.emit: ...}` pragma for `sme_gemm_ukernel_32x32_epi_dv`.
+  var ctx = init(AssemblerSME)
+  buildSme32x32EpiDv(ctx, pa, pb, cOp, cs, kcOp, abits, bbits,
+                     reluOp, aone, bzero, bone)
+  result = ctx.generate()
+
+proc sme_gemm_ukernel_32x32_epi_dv*(
+    packA, packB: ptr float32, C: ptr float32, cRowStride: cint, kc: cint,
+    alpha, beta: float32, relu, alphaOne, betaZero, betaOne: cint) =
+  ## 32×32 f32 SME micro-kernel with a fused in-streaming extract to C
+  ## (dual-vector SME2 inner loop, the driver's hot path):
+  ## `C[i][j] = beta*C[i][j] + alpha*f(AB[i][j])`, f = identity or ReLU.
+  ##
+  ## Expected input:
+  ##   - packA, packB: 32 contiguous f32 per k-step (the ex02a `(ir, kc, 32)` packed layout)
+  ##   - kc: k-steps to contract, `kc >= 0`
+  ##   - C: 32×32 f32 tile, col stride 1, row stride `cRowStride`
+  ##   - alpha, beta: scale factors
+  ##   - relu, alphaOne, betaZero, betaOne: flags mirroring the scalar epilogue:
+  ##     `alphaOne = alpha == 1`, `betaZero = beta == 0`,
+  ##     `betaOne = beta == 1`
+  ##
+  ## Output: `C[i][j] = beta*C[i][j] + alpha*f(AB[i][j])`.
+  ## The accumulator sits in ZA transposed (za row j = output col j),
+  ## so the in-streaming mova extract reads output rows
+  ## while applying the epilogue math:
+  ##
+  ##   before (ZA accumulator):            after (C, row-major):
+  ##     za[j][i] = AB[i][j]                C[i][j] = beta*C[i][j]
+  ##     (za row j = output col j)          + alpha*f(AB[i][j])
+  ##
+  ## ReLU `fclamp` maps NaN to 0 on M4, like the scalar epilogue.
+  ## `beta == 0` stores `alpha*f(AB)`, possibly `-0.0` where the scalar epilogue stores `+0.0`.
+  ## `ld1w2` dual-vector loads carry two k-steps each.
+  let alphaBits = cast[int32](alpha)
+  let betaBits = cast[int32](beta)
+  genSme32x32EpiDv(packA, packB, C, cRowStride, kc, alphaBits, betaBits,
+                   relu, alphaOne, betaZero, betaOne)
+
+proc buildNeonEpilogue(
+    ctx: var AssemblerSME,
+    cOp, abOp, rowStrideOp, abits, bbits,
+    reluOp, aone, bzero, bone: NimNode) =
+  ## Records the `neon_epilogue_f32_32x32` instruction stream into `ctx`
+  ## in source order: the beta==0 store loop, then the beta!=0
+  ## read-modify-write loop. Operand bindings:
+  ## constraint list: pointers via `"r"`, the row stride and flags via
+  ## `"r"((long)...)`, the alpha/beta bit patterns via `"r"((long)(...))`.
+  let cOp2 = ctx.input("C", cOp)
+  let abOp2 = ctx.input("AB", abOp)
+  let rsOp = ctx.inputLong("rowStride", rowStrideOp)
+  let abitsOp = ctx.inputLongParen("alphaBits", abits)
+  let bbitsOp = ctx.inputLongParen("betaBits", bbits)
+  let reluOp2 = ctx.inputLong("relu", reluOp)
+  let aoneOp = ctx.inputLong("alphaOne", aone)
+  let bzeroOp = ctx.inputLong("betaZero", bzero)
+  let boneOp = ctx.inputLong("betaOne", bone)
+  ctx.mov(x(20), view(cOp2))
+  ctx.mov(x(21), view(abOp2))
+  ctx.lsl(x(22), xview(rsOp), 2)
+  ctx.sub(x(22), x(22), 128)
+  ctx.dup(v(16), "4s", wview(abitsOp))
+  ctx.dup(v(17), "4s", wview(bbitsOp))
+  ctx.movi(v(18), "16b", 0)
+  ctx.mov(w(23), "#32")
+  ctx.cbz(wview(bzeroOp), "2f")
+  ctx.label("1")
+  ctx.ld1(vlist(0, 3, "4s"), memPost(x(21), 64))
+  ctx.ld1(vlist(4, 7, "4s"), memPost(x(21), 64))
+  ctx.cbz(wview(reluOp2), "3f")
+  for i in 0 .. 7:
+    ctx.fmax(v(i), "4s", v(i), v(18))
+  ctx.label("3")
+  ctx.cbnz(wview(aoneOp), "4f")
+  for i in 0 .. 7:
+    ctx.fmul(v(i), "4s", v(i), v(16))
+  ctx.label("4")
+  ctx.st1(vlist(0, 3, "4s"), memPost(x(20), 64))
+  ctx.st1(vlist(4, 7, "4s"), memPost(x(20), 64))
+  ctx.add(x(20), x(20), x(22))
+  ctx.subs(w(23), w(23), 1)
+  ctx.bne("1b")
+  ctx.b("9f")
+  ctx.label("2")
+  ctx.mov(x(19), x(20))
+  ctx.ld1(vlist(0, 3, "4s"), memPost(x(21), 64))
+  ctx.ld1(vlist(4, 7, "4s"), memPost(x(21), 64))
+  ctx.cbz(wview(reluOp2), "5f")
+  for i in 0 .. 7:
+    ctx.fmax(v(i), "4s", v(i), v(18))
+  ctx.label("5")
+  ctx.cbnz(wview(aoneOp), "6f")
+  for i in 0 .. 7:
+    ctx.fmul(v(i), "4s", v(i), v(16))
+  ctx.label("6")
+  ctx.ld1(vlist(8, 11, "4s"), memPost(x(20), 64))
+  ctx.ld1(vlist(12, 15, "4s"), memPost(x(20), 64))
+  ctx.cbnz(wview(boneOp), "7f")
+  for i in 8 .. 15:
+    ctx.fmul(v(i), "4s", v(i), v(17))
+  ctx.label("7")
+  for i in 0 .. 7:
+    ctx.fadd(v(8 + i), "4s", v(8 + i), v(i))
+  ctx.st1(vlist(8, 11, "4s"), memPost(x(19), 64))
+  ctx.st1(vlist(12, 15, "4s"), memPost(x(19), 64))
+  ctx.add(x(20), x(19), x(22))
+  ctx.subs(w(23), w(23), 1)
+  ctx.bne("2b")
+  ctx.label("9")
+  ctx.clobber("x19", "x20", "x21", "x22", "w23")
+  ctx.clobberV()
+  ctx.clobberCC()
+  ctx.clobberMemory()
+
+macro genNeonEpilogue(
+    cOp, abOp, rowStrideOp, abits, bbits,
+    reluOp, aone, bzero, bone: typed): untyped =
+  ## Expands to the `{.emit: ...}` pragma for `neon_epilogue_f32_32x32`
+  var ctx = init(AssemblerSME)
+  buildNeonEpilogue(ctx, cOp, abOp, rowStrideOp, abits, bbits,
+                    reluOp, aone, bzero, bone)
+  result = ctx.generate()
+
+proc neon_epilogue_f32_32x32*(
+    C: ptr float32, cRowStride: cint,   # C tile base, row stride in f32 elements
+    AB: ptr float32,                    # full 32x32 AB tile (128 B per row)
+    alpha, beta: float32,
+    relu, alphaOne, betaZero, betaOne: cint) =
+  ## Vectorized epilogue for a contiguous 32×32 f32 C tile (col stride 1,
+  ## row stride ≥ 32): `C[i][j] = beta*C[i][j] + alpha*f(AB[i][j])`,
+  ## f = identity or ReLU, 4 lanes per NEON op.
+  ##
+  ## Expected input:
+  ##   - AB: 32×32 f32 accumulator tile (row stride 32, 128 B per row)
+  ##   - C: 32×32 f32 tile, col stride 1, row stride ≥ 32
+  ##   - alpha, beta: scale factors
+  ##   - relu, alphaOne, betaZero, betaOne: flags mirroring the scalar epilogue's comparisons
+  ##
+  ## Output: the fused C tile:
+  ##
+  ##   before:                             after (C):
+  ##     AB[i][j] = Σ_k a_i[k] b_j[k]       C[i][j] = beta*C[i][j]
+  ##     C holds the prior values            + alpha*f(AB[i][j])
+  ##
+  ## Two divergences from the scalar epilogue:
+  ##   - a NaN accumulator propagates through the NEON `fmax` ReLU
+  ##     (scalar ReLU yields 0)
+  ##   - `alpha == ±0.0` with `beta == 0` stores signed zero where the scalar path stores +0.0
+  let alphaBits = cast[int32](alpha)
+  let betaBits = cast[int32](beta)
+  genNeonEpilogue(C, AB, cRowStride, alphaBits, betaBits,
+                  relu, alphaOne, betaZero, betaOne)
+
+# Tile dispatch
+# ----------------------------------------------------------------------------
+
+proc gemm_ukernel_sme*[MR, NR: static int](
+    packA, packB: ptr UncheckedArray[float32],
+    AB: var array[MR, array[NR, float32]],
+    kc: int) =
+  ## Computes `AB[ri][rj] = Σ_k packA[k*MR+ri] * packB[k*NR+rj]` with the SME
+  ## outer-product unit. `AB` is overwritten, never accumulated into.
+  ## ZA tiles are zeroed first, so callers may use `{.noInit.}`.
+  ##
+  ## Expected input:
+  ##   - packA: MR contiguous f32 per k-step (the ex02a `(ir, kc, MR)` packed layout)
+  ##   - packB: NR contiguous f32 per k-step (the ex02a `(ir, kc, NR)` packed layout)
+  ##   - kc: k-steps to contract, `kc >= 0`
+  ##   - AB: MR×NR f32 output tile
+  ##
+  ## Output: `AB` = the MR×NR outer-product tile, all lanes written.
+  ##
+  ## Two tile shapes, backed by two asm kernels in this file:
+  ## - MR == NR == 16: one ZA0 accumulator (sme_gemm_ukernel_16x16).
+  ## - MR == NR == 32: four ZA0..ZA3 accumulators, one per 16×16 quadrant
+  ##   of the 32×32 output tile (sme_gemm_ukernel_32x32), 4-way ILP
+  ##   hiding the `fmopa` latency.
+  static: doAssert MR == NR and MR in {16, 32},
+    "gemm_ukernel_sme requires square tiles of 16 or 32 (got MR=" & $MR & ", NR=" & $NR & ")"
+  doAssert kc >= 0, "gemm_ukernel_sme: kc must be >= 0 (got " & $kc & ")"
+  when MR == 16:
+    sme_gemm_ukernel_16x16(
+      cast[ptr float32](packA), cast[ptr float32](packB),
+      addr AB[0][0], kc.cint)
+  else:
+    sme_gemm_ukernel_32x32(
+      cast[ptr float32](packA), cast[ptr float32](packB),
+      addr AB[0][0], kc.cint)
+

--- a/workspace/ceramic/examples/ex02_matmul_microkernels/gemm_ukernel_arm64_sme2_fuzzer.nim
+++ b/workspace/ceramic/examples/ex02_matmul_microkernels/gemm_ukernel_arm64_sme2_fuzzer.nim
@@ -16,9 +16,9 @@ import std/[random, strformat]
 import workspace/ceramic/examples/ex02_matmul_microkernels/gemm_ukernel_arm64_sme2
 
 proc gemmReference(
+    C: var openArray[float32],
     M, N, K: int, A, B: ptr UncheckedArray[float32],
-    alpha, beta: float32, relu: bool,
-    C: var openArray[float32]) =
+    alpha, beta: float32, relu: bool) =
   ## Scalar reference: `C[i*N+j] = beta*C[i*N+j] + alpha*f(acc)` with
   ## `f` = identity or ReLU and `acc = Σ_k A[i*K+k] * B[k*N+j]`.
   ## A `beta == 0` call writes `alpha*f(acc)` without reading C, matching
@@ -40,8 +40,8 @@ proc gemmReference(
               else: beta * C[ci] + alpha * f
 
 proc packTiles(
-    MR, NR, K: int, A, B: ptr UncheckedArray[float32],
-    packA, packB: ptr UncheckedArray[float32]) =
+    packA, packB: ptr UncheckedArray[float32],
+    MR, NR, K: int, A, B: ptr UncheckedArray[float32]) =
   ## Packs A/B into the kernels' `(ir, kc, MR/NR)` layout, the
   ## `gemmUkernelSme` documented contract: `packA[k*MR + r] = A[r*K + k]`,
   ## `packB[k*NR + j] = B[k*NR + j]`.
@@ -102,21 +102,22 @@ proc main() =
         for i in 0 ..< B.len: B[i] = rng.rand(2.0'f32) - 1.0'f32
         var packA = newSeq[float32](K * MR)
         var packB = newSeq[float32](K * NR)
-        packTiles(MR, NR, K,
-                  cast[ptr UncheckedArray[float32]](addr A[0]),
-                  cast[ptr UncheckedArray[float32]](addr B[0]),
-                  cast[ptr UncheckedArray[float32]](addr packA[0]),
-                  cast[ptr UncheckedArray[float32]](addr packB[0]))
+        packTiles(
+          cast[ptr UncheckedArray[float32]](addr packA[0]),
+          cast[ptr UncheckedArray[float32]](addr packB[0]),
+          MR, NR, K,
+          cast[ptr UncheckedArray[float32]](addr A[0]),
+          cast[ptr UncheckedArray[float32]](addr B[0]))
         var AB: array[MR, array[NR, float32]]
         gemmUkernelSme[MR, NR](
           cast[ptr UncheckedArray[float32]](addr packA[0]),
           cast[ptr UncheckedArray[float32]](addr packB[0]),
           AB, K)
         var refC = newSeq[float32](MR * NR)
-        gemmReference(MR, NR, K,
+        gemmReference(refC, MR, NR, K,
                       cast[ptr UncheckedArray[float32]](addr A[0]),
                       cast[ptr UncheckedArray[float32]](addr B[0]),
-                      1.0'f32, 0.0'f32, false, refC)
+                      1.0'f32, 0.0'f32, false)
         var flat: array[MR * NR, float32]
         for i in 0 ..< MR:
           for j in 0 ..< NR:
@@ -141,21 +142,22 @@ proc main() =
         for i in 0 ..< B.len: B[i] = rng.rand(2.0'f32) - 1.0'f32
         var packA = newSeq[float32](K * MR)
         var packB = newSeq[float32](K * NR)
-        packTiles(MR, NR, K,
-                  cast[ptr UncheckedArray[float32]](addr A[0]),
-                  cast[ptr UncheckedArray[float32]](addr B[0]),
-                  cast[ptr UncheckedArray[float32]](addr packA[0]),
-                  cast[ptr UncheckedArray[float32]](addr packB[0]))
+        packTiles(
+          cast[ptr UncheckedArray[float32]](addr packA[0]),
+          cast[ptr UncheckedArray[float32]](addr packB[0]),
+          MR, NR, K,
+          cast[ptr UncheckedArray[float32]](addr A[0]),
+          cast[ptr UncheckedArray[float32]](addr B[0]))
         var AB: array[MR, array[NR, float32]]
         gemmUkernelSme[MR, NR](
           cast[ptr UncheckedArray[float32]](addr packA[0]),
           cast[ptr UncheckedArray[float32]](addr packB[0]),
           AB, K)
         var refC = newSeq[float32](MR * NR)
-        gemmReference(MR, NR, K,
+        gemmReference(refC, MR, NR, K,
                       cast[ptr UncheckedArray[float32]](addr A[0]),
                       cast[ptr UncheckedArray[float32]](addr B[0]),
-                      1.0'f32, 0.0'f32, false, refC)
+                      1.0'f32, 0.0'f32, false)
         var flat: array[MR * NR, float32]
         for i in 0 ..< MR:
           for j in 0 ..< NR:
@@ -182,11 +184,12 @@ proc main() =
             for i in 0 ..< B.len: B[i] = rng.rand(2.0'f32) - 1.0'f32
             var packA = newSeq[float32](K * MR)
             var packB = newSeq[float32](K * NR)
-            packTiles(MR, NR, K,
-                      cast[ptr UncheckedArray[float32]](addr A[0]),
-                      cast[ptr UncheckedArray[float32]](addr B[0]),
-                      cast[ptr UncheckedArray[float32]](addr packA[0]),
-                      cast[ptr UncheckedArray[float32]](addr packB[0]))
+            packTiles(
+              cast[ptr UncheckedArray[float32]](addr packA[0]),
+              cast[ptr UncheckedArray[float32]](addr packB[0]),
+              MR, NR, K,
+              cast[ptr UncheckedArray[float32]](addr A[0]),
+              cast[ptr UncheckedArray[float32]](addr B[0]))
             var C = newSeq[float32](MR * NR)
             for i in 0 ..< C.len: C[i] = rng.rand(2.0'f32) - 1.0'f32
             var refC = C
@@ -197,10 +200,10 @@ proc main() =
               alpha, beta, cint(relu),
               cint(alpha == 1.0'f32), cint(beta == 0.0'f32),
               cint(beta == 1.0'f32))
-            gemmReference(MR, NR, K,
+            gemmReference(refC, MR, NR, K,
                           cast[ptr UncheckedArray[float32]](addr A[0]),
                           cast[ptr UncheckedArray[float32]](addr B[0]),
-                          alpha, beta, relu == 1, refC)
+                          alpha, beta, relu == 1)
             let (ok, maxAbs, maxRel) = closeEnough(C, refC)
             totalCases.inc
             seedCases.inc
@@ -222,11 +225,12 @@ proc main() =
             for i in 0 ..< B.len: B[i] = rng.rand(2.0'f32) - 1.0'f32
             var packA = newSeq[float32](K * MR)
             var packB = newSeq[float32](K * NR)
-            packTiles(MR, NR, K,
-                      cast[ptr UncheckedArray[float32]](addr A[0]),
-                      cast[ptr UncheckedArray[float32]](addr B[0]),
-                      cast[ptr UncheckedArray[float32]](addr packA[0]),
-                      cast[ptr UncheckedArray[float32]](addr packB[0]))
+            packTiles(
+              cast[ptr UncheckedArray[float32]](addr packA[0]),
+              cast[ptr UncheckedArray[float32]](addr packB[0]),
+              MR, NR, K,
+              cast[ptr UncheckedArray[float32]](addr A[0]),
+              cast[ptr UncheckedArray[float32]](addr B[0]))
             var C = newSeq[float32](MR * NR)
             for i in 0 ..< C.len: C[i] = rng.rand(2.0'f32) - 1.0'f32
             var refC = C
@@ -237,10 +241,10 @@ proc main() =
               alpha, beta, cint(relu),
               cint(alpha == 1.0'f32), cint(beta == 0.0'f32),
               cint(beta == 1.0'f32))
-            gemmReference(MR, NR, K,
+            gemmReference(refC, MR, NR, K,
                           cast[ptr UncheckedArray[float32]](addr A[0]),
                           cast[ptr UncheckedArray[float32]](addr B[0]),
-                          alpha, beta, relu == 1, refC)
+                          alpha, beta, relu == 1)
             let (ok, maxAbs, maxRel) = closeEnough(C, refC)
             totalCases.inc
             seedCases.inc

--- a/workspace/ceramic/examples/ex02_matmul_microkernels/gemm_ukernel_arm64_sme2_fuzzer.nim
+++ b/workspace/ceramic/examples/ex02_matmul_microkernels/gemm_ukernel_arm64_sme2_fuzzer.nim
@@ -1,0 +1,263 @@
+## Seeded fuzzer for the SME2 GEMM micro-kernels in `gemm_ukernel_arm64_sme2.nim`.
+##
+## Stress-tests the four kernels plus the `gemmUkernelSme` dispatcher against a
+## scalar reference: seeded random A/B, kc oddments (the `% 4` blocks/tail and
+## `% 16` A-pack edges), every alpha/beta combination, ReLU on and off.
+##
+## aarch64-only: the kernels require ARMv9.2 with FEAT_SME2 and the
+## `-march=armv9-a+sme2` flag the kernel module sets via localpassC.
+##
+## Usage:
+##   nim cpp -r -d:release --hints:off --warnings:off \
+##     --outdir:build/wip/fuzzer --nimcache:nimcache/wip/fuzzer \
+##     workspace/ceramic/examples/ex02_matmul_microkernels/gemm_ukernel_arm64_sme2_fuzzer.nim
+
+import std/[random, strformat]
+import workspace/ceramic/examples/ex02_matmul_microkernels/gemm_ukernel_arm64_sme2
+
+proc gemmReference(
+    M, N, K: int, A, B: ptr UncheckedArray[float32],
+    alpha, beta: float32, relu: bool,
+    C: var openArray[float32]) =
+  ## Scalar reference: `C[i*N+j] = beta*C[i*N+j] + alpha*f(acc)` with
+  ## `f` = identity or ReLU and `acc = Σ_k A[i*K+k] * B[k*N+j]`.
+  ## A `beta == 0` call writes `alpha*f(acc)` without reading C, matching
+  ## the kernels' betaZero path.
+  ##
+  ## Expected input:
+  ##   - A: M×K row-major f32, B: K×N row-major f32
+  ##   - C: M×N row-major f32, prior values read when `beta != 0`
+  ##
+  ## Output: C updated in place.
+  for i in 0 ..< M:
+    for j in 0 ..< N:
+      var acc = 0.0'f32
+      for k in 0 ..< K:
+        acc += A[i * K + k] * B[k * N + j]
+      let f = if relu and acc < 0.0'f32: 0.0'f32 else: acc
+      let ci = i * N + j
+      C[ci] = if beta == 0.0'f32: alpha * f
+              else: beta * C[ci] + alpha * f
+
+proc packTiles(
+    MR, NR, K: int, A, B: ptr UncheckedArray[float32],
+    packA, packB: ptr UncheckedArray[float32]) =
+  ## Packs A/B into the kernels' `(ir, kc, MR/NR)` layout, the
+  ## `gemmUkernelSme` documented contract: `packA[k*MR + r] = A[r*K + k]`,
+  ## `packB[k*NR + j] = B[k*NR + j]`.
+  ##
+  ## Expected input:
+  ##   - A: MR×K row-major f32, B: K×NR row-major f32
+  ##   - packA: K*MR f32, packB: K*NR f32
+  ##
+  ## Output: packed buffers filled.
+  for k in 0 ..< K:
+    for r in 0 ..< MR:
+      packA[k * MR + r] = A[r * K + k]
+    for j in 0 ..< NR:
+      packB[k * NR + j] = B[k * NR + j]
+
+proc closeEnough(C, refC: openArray[float32]): tuple[ok: bool, maxAbs, maxRel: float32] =
+  ## Kernel-vs-reference comparison: `maxAbs <= 1e-4` and `maxRel <= 1e-1`
+  ## (per-element relative with a 1e-12 floor).
+  ##
+  ## atol 1e-4 is the primary gate: the full grid's worst absolute error
+  ## is 8.6e-6 (f32 accumulation order, verified 2 ulps from f64-exact),
+  ## a 12x margin. rtol 1e-1 is secondary: per-cell relative amplifies
+  ## on near-zero cells (a 1-ulp diff on a 2e-4 cancellation cell reads
+  ## ~1e-2), so only genuinely wrong cells (real bugs) trip it.
+  doAssert C.len == refC.len
+  var maxAbs = 0.0'f32
+  var maxRel = 0.0'f32
+  for i in 0 ..< C.len:
+    let d = abs(C[i] - refC[i])
+    maxAbs = max(maxAbs, d)
+    maxRel = max(maxRel, d / max(abs(C[i]), max(abs(refC[i]), 1e-12'f32)))
+  (maxAbs <= 1e-4'f32 and maxRel <= 1e-1'f32, maxAbs, maxRel)
+
+proc main() =
+  const
+    Ks = [1, 2, 3, 4, 5, 7, 8, 15, 16, 17, 31, 32, 33, 47, 63, 64, 65,
+          127, 128, 129]
+    AlphaBeta = [(1.0'f32, 0.0'f32), (0.5'f32, 2.0'f32), (0.0'f32, 0.0'f32),
+                 (1.0'f32, 1.0'f32), (2.0'f32, 0.5'f32), (-0.5'f32, 1.5'f32)]
+  var totalCases = 0
+  var worstAbs = 0.0'f32
+  var worstRel = 0.0'f32
+  var worstDesc = ""
+  var worstSeed = -1
+
+  for seed in 0 ..< 8:
+    var rng = initRand(seed)
+    var seedCases = 0
+    var seedWorst = 0.0'f32
+    for K in Ks:
+      # 16×16 AB-store kernel through the dispatcher: AB = A·B.
+      block:
+        const MR = 16
+        const NR = 16
+        var A = newSeq[float32](MR * K)
+        var B = newSeq[float32](K * NR)
+        for i in 0 ..< A.len: A[i] = rng.rand(2.0'f32) - 1.0'f32
+        for i in 0 ..< B.len: B[i] = rng.rand(2.0'f32) - 1.0'f32
+        var packA = newSeq[float32](K * MR)
+        var packB = newSeq[float32](K * NR)
+        packTiles(MR, NR, K,
+                  cast[ptr UncheckedArray[float32]](addr A[0]),
+                  cast[ptr UncheckedArray[float32]](addr B[0]),
+                  cast[ptr UncheckedArray[float32]](addr packA[0]),
+                  cast[ptr UncheckedArray[float32]](addr packB[0]))
+        var AB: array[MR, array[NR, float32]]
+        gemmUkernelSme[MR, NR](
+          cast[ptr UncheckedArray[float32]](addr packA[0]),
+          cast[ptr UncheckedArray[float32]](addr packB[0]),
+          AB, K)
+        var refC = newSeq[float32](MR * NR)
+        gemmReference(MR, NR, K,
+                      cast[ptr UncheckedArray[float32]](addr A[0]),
+                      cast[ptr UncheckedArray[float32]](addr B[0]),
+                      1.0'f32, 0.0'f32, false, refC)
+        var flat: array[MR * NR, float32]
+        for i in 0 ..< MR:
+          for j in 0 ..< NR:
+            flat[i * NR + j] = AB[i][j]
+        let (ok, maxAbs, maxRel) = closeEnough(flat, refC)
+        totalCases.inc
+        seedCases.inc
+        seedWorst = max(seedWorst, maxAbs)
+        doAssert ok, &"seed {seed} smeGemmUkernel16x16 K={K}: maxAbs={maxAbs:.3e} maxRel={maxRel:.3e}"
+        if maxAbs > worstAbs:
+          worstAbs = maxAbs
+          worstRel = maxRel
+          worstDesc = "smeGemmUkernel16x16"
+          worstSeed = seed
+      # 32×32 AB-store kernel through the dispatcher: AB = A·B.
+      block:
+        const MR = 32
+        const NR = 32
+        var A = newSeq[float32](MR * K)
+        var B = newSeq[float32](K * NR)
+        for i in 0 ..< A.len: A[i] = rng.rand(2.0'f32) - 1.0'f32
+        for i in 0 ..< B.len: B[i] = rng.rand(2.0'f32) - 1.0'f32
+        var packA = newSeq[float32](K * MR)
+        var packB = newSeq[float32](K * NR)
+        packTiles(MR, NR, K,
+                  cast[ptr UncheckedArray[float32]](addr A[0]),
+                  cast[ptr UncheckedArray[float32]](addr B[0]),
+                  cast[ptr UncheckedArray[float32]](addr packA[0]),
+                  cast[ptr UncheckedArray[float32]](addr packB[0]))
+        var AB: array[MR, array[NR, float32]]
+        gemmUkernelSme[MR, NR](
+          cast[ptr UncheckedArray[float32]](addr packA[0]),
+          cast[ptr UncheckedArray[float32]](addr packB[0]),
+          AB, K)
+        var refC = newSeq[float32](MR * NR)
+        gemmReference(MR, NR, K,
+                      cast[ptr UncheckedArray[float32]](addr A[0]),
+                      cast[ptr UncheckedArray[float32]](addr B[0]),
+                      1.0'f32, 0.0'f32, false, refC)
+        var flat: array[MR * NR, float32]
+        for i in 0 ..< MR:
+          for j in 0 ..< NR:
+            flat[i * NR + j] = AB[i][j]
+        let (ok, maxAbs, maxRel) = closeEnough(flat, refC)
+        totalCases.inc
+        seedCases.inc
+        seedWorst = max(seedWorst, maxAbs)
+        doAssert ok, &"seed {seed} smeGemmUkernel32x32 K={K}: maxAbs={maxAbs:.3e} maxRel={maxRel:.3e}"
+        if maxAbs > worstAbs:
+          worstAbs = maxAbs
+          worstRel = maxRel
+          worstDesc = "smeGemmUkernel32x32"
+          worstSeed = seed
+      # Fused kernels: alpha/beta/ReLU applied in streaming mode.
+      for (alpha, beta) in AlphaBeta:
+        for relu in [0, 1]:
+          block:
+            const MR = 32
+            const NR = 32
+            var A = newSeq[float32](MR * K)
+            var B = newSeq[float32](K * NR)
+            for i in 0 ..< A.len: A[i] = rng.rand(2.0'f32) - 1.0'f32
+            for i in 0 ..< B.len: B[i] = rng.rand(2.0'f32) - 1.0'f32
+            var packA = newSeq[float32](K * MR)
+            var packB = newSeq[float32](K * NR)
+            packTiles(MR, NR, K,
+                      cast[ptr UncheckedArray[float32]](addr A[0]),
+                      cast[ptr UncheckedArray[float32]](addr B[0]),
+                      cast[ptr UncheckedArray[float32]](addr packA[0]),
+                      cast[ptr UncheckedArray[float32]](addr packB[0]))
+            var C = newSeq[float32](MR * NR)
+            for i in 0 ..< C.len: C[i] = rng.rand(2.0'f32) - 1.0'f32
+            var refC = C
+            smeGemmUkernel32x32Epi(
+              cast[ptr float32](addr packA[0]),
+              cast[ptr float32](addr packB[0]),
+              addr C[0], cint(NR), cint(K),
+              alpha, beta, cint(relu),
+              cint(alpha == 1.0'f32), cint(beta == 0.0'f32),
+              cint(beta == 1.0'f32))
+            gemmReference(MR, NR, K,
+                          cast[ptr UncheckedArray[float32]](addr A[0]),
+                          cast[ptr UncheckedArray[float32]](addr B[0]),
+                          alpha, beta, relu == 1, refC)
+            let (ok, maxAbs, maxRel) = closeEnough(C, refC)
+            totalCases.inc
+            seedCases.inc
+            seedWorst = max(seedWorst, maxAbs)
+            doAssert ok, &"seed {seed} smeGemmUkernel32x32Epi K={K} " &
+              &"alpha={alpha} beta={beta} relu={relu}: " &
+              &"maxAbs={maxAbs:.3e} maxRel={maxRel:.3e}"
+            if maxAbs > worstAbs:
+              worstAbs = maxAbs
+              worstRel = maxRel
+              worstDesc = "smeGemmUkernel32x32Epi"
+              worstSeed = seed
+          block:
+            const MR = 32
+            const NR = 32
+            var A = newSeq[float32](MR * K)
+            var B = newSeq[float32](K * NR)
+            for i in 0 ..< A.len: A[i] = rng.rand(2.0'f32) - 1.0'f32
+            for i in 0 ..< B.len: B[i] = rng.rand(2.0'f32) - 1.0'f32
+            var packA = newSeq[float32](K * MR)
+            var packB = newSeq[float32](K * NR)
+            packTiles(MR, NR, K,
+                      cast[ptr UncheckedArray[float32]](addr A[0]),
+                      cast[ptr UncheckedArray[float32]](addr B[0]),
+                      cast[ptr UncheckedArray[float32]](addr packA[0]),
+                      cast[ptr UncheckedArray[float32]](addr packB[0]))
+            var C = newSeq[float32](MR * NR)
+            for i in 0 ..< C.len: C[i] = rng.rand(2.0'f32) - 1.0'f32
+            var refC = C
+            smeGemmUkernel32x32EpiDv(
+              cast[ptr float32](addr packA[0]),
+              cast[ptr float32](addr packB[0]),
+              addr C[0], cint(NR), cint(K),
+              alpha, beta, cint(relu),
+              cint(alpha == 1.0'f32), cint(beta == 0.0'f32),
+              cint(beta == 1.0'f32))
+            gemmReference(MR, NR, K,
+                          cast[ptr UncheckedArray[float32]](addr A[0]),
+                          cast[ptr UncheckedArray[float32]](addr B[0]),
+                          alpha, beta, relu == 1, refC)
+            let (ok, maxAbs, maxRel) = closeEnough(C, refC)
+            totalCases.inc
+            seedCases.inc
+            seedWorst = max(seedWorst, maxAbs)
+            doAssert ok, &"seed {seed} smeGemmUkernel32x32EpiDv K={K} " &
+              &"alpha={alpha} beta={beta} relu={relu}: " &
+              &"maxAbs={maxAbs:.3e} maxRel={maxRel:.3e}"
+            if maxAbs > worstAbs:
+              worstAbs = maxAbs
+              worstRel = maxRel
+              worstDesc = "smeGemmUkernel32x32EpiDv"
+              worstSeed = seed
+    echo &"  seed {seed}: {seedCases} cases, worst maxAbs {seedWorst:.3e}"
+
+  echo ""
+  echo &"Fuzzer summary: {totalCases} cases, all passed."
+  echo &"  worst maxAbs {worstAbs:.3e} (maxRel {worstRel:.3e}) in {worstDesc}, seed {worstSeed}"
+  echo "  atol 1e-4 (primary), rtol 1e-1 (near-zero cells) vs the scalar reference. Deterministic (seeded)."
+
+main()

--- a/workspace/ceramic/examples/ex02a_matmul_handtuned_arm64_sme2.nim
+++ b/workspace/ceramic/examples/ex02a_matmul_handtuned_arm64_sme2.nim
@@ -1,0 +1,761 @@
+## ex02a_matmul_handtuned_arm64_sme2: hand-tuned SME2-accelerated serial GEMM
+##
+## mr = nr = 32, kc_atom = 16: the 32×32 output tile maps to four 16×16 ZA
+## tiles (4-way ILP). SME micro-kernel dispatch on arm64, generic fallback
+## elsewhere.
+##
+## BLIS 5-loop structure:
+##
+##   Loop 5 (jc): column panels of C/B
+##   Loop 4 (pc): rank-k updates over K
+##   Loop 3 (ic): row blocks of A
+##   Loop 2 (jr): micro-panels of B
+##   Loop 1 (ir): micro-tiles of A
+##
+##   C[M, N] += α · f(A[M, K] × B[K, N]) + β · C[M, N]
+
+{.experimental: "callOperator".}
+
+import std/math
+import workspace/ceramic/src/int_tuples
+import workspace/ceramic/src/layouts
+import workspace/ceramic/src/layout_algebra
+import workspace/ceramic/src/tensors
+export int_tuples, layouts, layout_algebra, tensors
+
+# ═══════════════════════════════════════════════════════════════════════════
+#  Activation enum + epilogue_body template
+# ═══════════════════════════════════════════════════════════════════════════
+
+type Activation* = enum
+  ## Activation function applied to the A·B accumulator before the alpha/beta
+  ## combination in the epilogue.
+  akIdentity
+  akReLU
+
+template genEpilogue*(epilogueName: untyped, relu: static bool, activationBody: untyped): untyped =
+  ## Generate an epilogue proc with the activation inlined.
+  ## Inside `activationBody`, use `x` for the AB accumulator value.
+  ## `relu` selects the NEON fast path's activation (same fmax semantics).
+  proc `epilogueName`[T; MR, NR: static int; Sh, St](
+      C: TensorView[T, Sh, St],
+      AB: array[MR, array[NR, T]],
+      mr, nr: int,
+      alpha, beta: T) =
+    when defined(arm64) and T is float32:
+      # Fast path: full 32×32 tile with contiguous C rows (col stride 1, row
+      # stride ≥ tile width). NEON 4-lane ops. Alpha/beta/activation flags use
+      # the scalar path's comparisons, so both paths agree element-for-element
+      # for all finite inputs.
+      if mr == 32 and nr == 32 and C.layout.stride[1] == 1 and C.layout.stride[0] >= 32:
+        neon_epilogue_f32_32x32(
+          cast[ptr float32](C.data), cint(C.layout.stride[0]),
+          cast[ptr float32](addr AB[0][0]),
+          alpha, beta,
+          cint(relu), cint(alpha == T(1)), cint(beta == T(0)), cint(beta == T(1)))
+        return
+    if beta == T(0):
+      for i in 0 ..< mr:
+        for j in 0 ..< nr:
+          C[i, j] = T(0)
+    elif beta != T(1):
+      for i in 0 ..< mr:
+        for j in 0 ..< nr:
+          C[i, j] *= beta
+    if alpha == T(1):
+      for i in 0 ..< mr:
+        for j in 0 ..< nr:
+          let x {.inject.} = AB[i][j]
+          C[i, j] += activationBody
+    else:
+      for i in 0 ..< mr:
+        for j in 0 ..< nr:
+          let x {.inject.} = AB[i][j]
+          C[i, j] += alpha * activationBody
+
+# Generate concrete epilogue procs (zero dispatch overhead)
+genEpilogue(epilogue_identity, relu = false):
+  x
+genEpilogue(epilogue_relu, relu = true):
+  if x > T(0): x else: T(0)
+
+# ═══════════════════════════════════════════════════════════════════════════
+#  pack_layout: derive pack-buffer layout from zipped_divide
+# ═══════════════════════════════════════════════════════════════════════════
+
+template pack_layout*(zd: Layout, transposed: static bool): auto =
+  ## Derive the pack-buffer layout from a `zipped_divide` layout: tile elements
+  ## compact, then the remaining dimension scaled by the tile size.
+  let tileCompact = make_layout(zd.shape[0], LayoutLeft)
+  let tile_size = product(zd.shape[0])
+  let restCompact = make_layout(zd.shape[1],
+    when transposed: LayoutRight else: LayoutLeft)
+  let restScaled = mapLeavesWith(restCompact):
+    (it_sh, it_st * tile_size)
+  nested_product(tileCompact, restScaled)
+
+# ═══════════════════════════════════════════════════════════════════════════
+#  MmaAtom: micro-kernel parameters
+# ═══════════════════════════════════════════════════════════════════════════
+
+type MmaAtom = object
+  mr*, nr*, kc*: int
+
+# ═══════════════════════════════════════════════════════════════════════════
+#  Cache & tile sizing
+# ═══════════════════════════════════════════════════════════════════════════
+
+# Cache tile size caps for float32: kc = 2048, mc = 192.
+proc autoTileParams(atom: static MmaAtom, M, K: int): tuple[mc, kc: int] =
+  const mr = atom.mr
+  const nr = atom.nr
+  const kc_atom = atom.kc
+  result.kc = min(2048, K)    # kc = 2048 keeps a single pc pass at K = 2048.
+                              # smaller kc re-reads C per pass and measures worse
+  result.kc = (result.kc div kc_atom) * kc_atom
+  if result.kc < kc_atom:
+    result.kc = min(K, kc_atom)
+  result.mc = min(192, M)     # Laser: 768 B / sizeof(float32)
+  result.mc = (result.mc div mr) * mr
+  if result.mc < mr:
+    result.mc = min(M, mr)
+
+# ═══════════════════════════════════════════════════════════════════════════
+#  Micro-kernel dispatch
+# ═══════════════════════════════════════════════════════════════════════════
+
+import workspace/ceramic/examples/ex02_matmul_microkernels/gemm_ukernel_generic
+import workspace/ceramic/examples/ex02_matmul_microkernels/gemm_ukernel_arm64_sme2
+import workspace/ceramic/examples/ex02_matmul_microkernels/gemm_packing_arm64_sme2
+export gemm_ukernel_arm64_sme2  # epilogue templates instantiate in the caller's scope
+
+## Clang prefetch builtin used by the GEMM loops. Available on every target,
+## so the off-arm64 fallback compiles.
+proc builtin_prefetch*(p: pointer, rw: cint, locality: cint) {.importc: "__builtin_prefetch", nodecl.}
+## Clang alignment-assert builtin used by the pack paths. Available on every
+## target, so the off-arm64 fallback compiles.
+proc builtin_assume_aligned*(p: pointer, alignment: csize): pointer {.importc: "__builtin_assume_aligned", nodecl.}
+
+const simdArch {.strdefine.} = "auto"
+
+when simdArch == "auto":
+  when defined(arm64):
+    const resolvedArch = "sme"
+  else:
+    const resolvedArch = "generic"
+elif simdArch == "sme":
+  when defined(arm64):
+    const resolvedArch = "sme"
+  else:
+    {.error: "simdArch='sme' requires an arm64 target with SME (Apple M4 or newer).".}
+else:
+  const resolvedArch = "generic"
+
+when resolvedArch == "generic":
+  {.warning: "SIMD arch is 'generic'. For SME acceleration compile with -d:simdArch=sme on arm64.".}
+
+proc simdArchString*(): string = resolvedArch
+
+
+template gemm_ukernel(packA, packB, AB, kc: untyped): untyped =
+  when resolvedArch == "sme":
+    gemm_ukernel_sme(packA, packB, AB, kc)
+  else:
+    gemm_ukernel_generic(packA, packB, AB, kc)
+
+# ═══════════════════════════════════════════════════════════════════════════
+#  Epilogue dispatch
+# ═══════════════════════════════════════════════════════════════════════════
+
+template gemm_epilogue(activation: Activation, C, AB, mr, nr, alpha, beta: untyped): untyped =
+  ## TensorView epilogue dispatch.
+  if activation == akReLU:
+    epilogue_relu(C, AB, mr, nr, alpha, beta)
+  else:
+    epilogue_identity(C, AB, mr, nr, alpha, beta)
+
+# ═══════════════════════════════════════════════════════════════════════════
+#  gemm_strided: BLIS 5-loop GEMM
+# ═══════════════════════════════════════════════════════════════════════════
+
+## BLIS 5-loop GEMM: `C ← beta·C + alpha·f(A·B)` with a micro-kernel dispatch
+## (SME on arm64, scalar fallback otherwise).
+##
+## `rowStrideA/colStrideA`: element strides of the M×K row-major/column-major A view
+## (rowStrideA = 1 ⇒ column-major). Same convention for B (K×N) and C (M×N).
+## `activation`: elementwise function applied to the A·B accumulator before the alpha/beta combination (akIdentity or akReLU).
+##
+## Postcondition: all M·N lanes of C are written exactly once, in the order
+## `C[i*rowStrideC + j*colStrideC]`, regardless of tile overhang.
+proc gemm_strided*[T: SomeNumber](
+    M, N, K: int,
+    alpha: T,
+    A: ptr UncheckedArray[T], rowStrideA, colStrideA: int,
+    B: ptr UncheckedArray[T], rowStrideB, colStrideB: int,
+    beta: T,
+    C: ptr UncheckedArray[T], rowStrideC, colStrideC: int,
+    activation: Activation = akIdentity) =
+
+  # ── Micro-kernel tile dimensions ──
+  # mr = nr = 32: four 16×16 ZA quadrants (4-way ILP, ~2 TFLOP/s SME ceiling).
+  const
+    mr = 32
+    nr = 32
+    kc_atom = 16
+
+  # ── Cache-block dimensions ──
+  const atom = MmaAtom(mr: mr, nr: nr, kc: kc_atom)
+  let (mc, kc) = autoTileParams(atom, M, K)
+  if mc < mr or kc < kc_atom:
+    for i in 0 ..< M:
+      for j in 0 ..< N:
+        var acc = 0.T
+        for k in 0 ..< K:
+          acc += A[i * rowStrideA + k * colStrideA] * B[k * rowStrideB + j * colStrideB]
+        let ci = i * rowStrideC + j * colStrideC
+        C[ci] = beta * C[ci] + alpha * acc
+    return
+
+  # ── Derived quantities ──
+  let num_jr = ceil_div(N, nr)
+  let nc     = num_jr * nr
+  let num_ir = mc div mr
+  let num_ic = ceil_div(M, mc)
+  let num_pc = ceil_div(K, kc)
+
+  # ── Matrix views ──
+  let vA = make_view(A, (M, K), (rowStrideA, colStrideA))
+  let vB = make_view(B, (K, N), (rowStrideB, colStrideB))
+  var vC = make_view(C, (M, N), (rowStrideC, colStrideC))
+
+  # ── Pack buffer layouts ──
+  let packALay = make_layout((num_ir, kc, mr), LayoutRight)
+  let packBLay = make_layout((num_jr, kc, nr), LayoutRight)
+  let packSizeA = int(cosize(packALay))
+  let packSizeB = int(cosize(packBLay))
+  var packMemA = newSeq[T](packSizeA + (32 div sizeof(T)))
+  var packMemB = newSeq[T](packSizeB + (32 div sizeof(T)))
+  # Align to 32 bytes. ld1w/st1w need no alignment (any alignment works).
+  # Kept for a uniform pack layout across ukernels.
+  let alignA = (cast[int](addr packMemA[0]) + 31) and not 31
+  let alignB = (cast[int](addr packMemB[0]) + 31) and not 31
+
+  # ── Pack buffer base pointers ──
+  var packA_ptr = cast[ptr UncheckedArray[T]](alignA)
+  var packB_ptr = cast[ptr UncheckedArray[T]](alignB)
+
+  # ── Loop 4 (pc): rank-k updates ──
+  for pc in 0 ..< num_pc:
+    let current_kc = min(K - pc * kc, kc)
+    if current_kc <= 0: continue
+    let effective_beta = if pc == 0: beta else: T(1)
+
+    for jc in 0 ..< 1:
+      let panelB = local_tile(vB, (kc, nc), (pc, jc))
+      let pB_ptr = cast[ptr UncheckedArray[T]](panelB.data)
+      let pB_rs = panelB.layout.stride[0]  # row stride of panel
+      let pB_cs = panelB.layout.stride[1]  # col stride of panel
+
+      # Pack B: explicit triple loop (copyMem-compatible stride, SIMD-friendly)
+      let packB_aligned = cast[ptr UncheckedArray[T]](builtin_assume_aligned(cast[pointer](packB_ptr), 32))
+      for jr in 0 ..< num_jr:
+        let eff = min(nr, N - jr * nr)   # lanes valid in the last micro-panel
+        if pB_cs == 1:
+          when defined(arm64) and T is float32:
+            if N mod nr == 0 and num_jr mod 4 == 0:
+              # Four full panels per pass: one B-row visit reads 512 contiguous bytes
+              # (DRAM row locality) instead of a 128-B slice. The group's remaining jr iterations are no-ops.
+              if jr mod 4 == 0:
+                sme_packB_copy_32f32_x4(
+                  cast[ptr float32](cast[int](packB_aligned) +% ((jr + 0) * kc * nr) *% sizeof(T).int),
+                  cast[ptr float32](cast[int](packB_aligned) +% ((jr + 1) * kc * nr) *% sizeof(T).int),
+                  cast[ptr float32](cast[int](packB_aligned) +% ((jr + 2) * kc * nr) *% sizeof(T).int),
+                  cast[ptr float32](cast[int](packB_aligned) +% ((jr + 3) * kc * nr) *% sizeof(T).int),
+                  cast[ptr float32](cast[int](pB_ptr) +% (jr * nr) *% sizeof(T).int),
+                  cint(pB_rs), cint(current_kc))
+            elif eff == nr:
+              # 32 valid lanes per row: 128-B NEON copies (2× ld1/st1 per row).
+              # Partial-column last panels (eff < nr) keep the copyMem loop
+              # below, so B is never read past its valid lanes.
+              neon_packB_copy_32f32(
+                cast[ptr float32](cast[int](packB_aligned) +% (jr * kc * nr) *% sizeof(T).int),
+                cast[ptr float32](cast[int](pB_ptr) +% (jr * nr) *% sizeof(T).int),
+                cint(pB_rs), cint(current_kc))
+            else:
+              # B rows are contiguous: copyMem
+              for k in 0 ..< current_kc:
+                let dstOff = jr * kc * nr + k * nr
+                let srcOff = k * pB_rs + jr * nr
+                copyMem(addr packB_aligned[dstOff], addr pB_ptr[srcOff], eff * sizeof(T).int)
+                for jj in eff ..< nr:
+                  packB_aligned[dstOff + jj] = T(0)
+          else:
+            # B rows are contiguous: copyMem
+            for k in 0 ..< current_kc:
+              let dstOff = jr * kc * nr + k * nr
+              let srcOff = k * pB_rs + jr * nr
+              copyMem(addr packB_aligned[dstOff], addr pB_ptr[srcOff], eff * sizeof(T).int)
+              for jj in eff ..< nr:
+                packB_aligned[dstOff + jj] = T(0)
+        else:
+          for k in 0 ..< current_kc:
+            let dstOff = jr * kc * nr + k * nr
+            let srcOff = k * pB_rs + jr * nr * pB_cs
+            for jj in 0 ..< eff:
+              packB_aligned[dstOff + jj] = pB_ptr[srcOff + jj * pB_cs]
+            for jj in eff ..< nr:
+              packB_aligned[dstOff + jj] = T(0)
+
+      # ── Loop 3 (ic): row blocks of A ──
+      for ic in 0 ..< num_ic:
+        let current_mc = min(M - ic * mc, mc)
+        if current_mc <= 0:
+          continue
+        let last_m = (current_mc < mc)
+        let num_ir_eff = if last_m: ceil_div(current_mc, mr)
+                         else: num_ir
+
+        let panelA = local_tile(vA, (mc, kc), (ic, pc))
+
+        let pA_ptr = cast[ptr UncheckedArray[T]](panelA.data)
+        let pA_rs = panelA.layout.stride[0]
+        let pA_cs = panelA.layout.stride[1]
+
+        # Pack A: explicit triple loop (with copyMem for contiguous rows)
+        let packA_aligned = cast[ptr UncheckedArray[T]](builtin_assume_aligned(cast[pointer](packA_ptr), 32))
+        if pA_rs == 1:
+          # Rows are contiguous in memory (column-major): use copyMem
+          for ir in 0 ..< num_ir_eff:
+            let srcRow = ir * mr
+            let lastTile = (srcRow + mr) > current_mc
+            for k in 0 ..< current_kc:
+              let dstOff = ir * kc * mr + k * mr
+              let srcOff = srcRow + k * pA_cs
+              if lastTile:
+                let valid = current_mc - srcRow
+                copyMem(addr packA_aligned[dstOff], addr pA_ptr[srcOff], valid * sizeof(T).int)
+                for ii in valid ..< mr:
+                  packA_aligned[dstOff + ii] = T(0)
+              else:
+                copyMem(addr packA_aligned[dstOff], addr pA_ptr[srcOff], mr * sizeof(T).int)
+        elif pA_cs == 1:
+          when defined(arm64) and T is float32:
+            # Row-major A: NEON 8×8 trn pack, or the streaming mova 16×16 pack
+            # when kc % 16 == 0 (16-column ZA tile). validRows zero-fills rows
+            # past current_mc, and leftover k steps use the scalar gather below.
+            static: doAssert mr == 32  # helpers' 8-row/16-row store geometry
+            let kBlocks = current_kc div 8
+            let kBlocks16 = current_kc div 16
+            let kcEven16 = current_kc mod 16 == 0
+            let kDone = if kcEven16: kBlocks16 * 16 else: kBlocks * 8
+            for ir in 0 ..< num_ir_eff:
+              let srcRow = ir * mr
+              let dstBase = ir * kc * mr
+              if kBlocks > 0:
+                if kcEven16:
+                  # Two 16-row groups per 32-row tile.
+                  for g in 0 ..< 2:
+                    let groupValid = max(0, min(16, current_mc - srcRow - g * 16))
+                    sme_packA_transpose_16rows(
+                      cast[ptr float32](cast[int](packA_aligned) +% (dstBase + g * 16) *% sizeof(T).int),
+                      cast[ptr float32](cast[int](pA_ptr) +% ((srcRow + g * 16) * pA_rs) *% sizeof(T).int),
+                      cint(pA_rs), cint(kBlocks16), cint(groupValid))
+                else:
+                  # Four 8-row groups per 32-row tile.
+                  for g in 0 ..< 4:
+                    let groupValid = max(0, min(8, current_mc - srcRow - g * 8))
+                    neon_packA_transpose_8rows(
+                      cast[ptr float32](cast[int](packA_aligned) +% (dstBase + g * 8) *% sizeof(T).int),
+                      cast[ptr float32](cast[int](pA_ptr) +% ((srcRow + g * 8) * pA_rs) *% sizeof(T).int),
+                      cint(pA_rs), cint(kBlocks), cint(groupValid))
+              for k in kDone ..< current_kc:
+                let dstOff = dstBase + k * mr
+                let srcOff = srcRow * pA_rs + k * pA_cs
+                for ii in 0 ..< mr:
+                  if (srcRow + ii) < current_mc:
+                    packA_aligned[dstOff + ii] = pA_ptr[srcOff + ii * pA_rs]
+                  else:
+                    packA_aligned[dstOff + ii] = T(0)
+          else:
+            # Scalar gather: same pack layout as the NEON path, without the 8×8 block transpose.
+            # Rows past current_mc store zeros.
+            for ir in 0 ..< num_ir_eff:
+              let srcRow = ir * mr
+              for k in 0 ..< current_kc:
+                let dstOff = ir * kc * mr + k * mr
+                let srcOff = srcRow * pA_rs + k * pA_cs
+                for ii in 0 ..< mr:
+                  if (srcRow + ii) < current_mc:
+                    packA_aligned[dstOff + ii] = pA_ptr[srcOff + ii * pA_rs]
+                  else:
+                    packA_aligned[dstOff + ii] = T(0)
+        else:
+          for ir in 0 ..< num_ir_eff:
+            let srcRow = ir * mr
+            for k in 0 ..< current_kc:
+              let dstOff = ir * kc * mr + k * mr
+              let srcOff = srcRow * pA_rs + k * pA_cs
+              for ii in 0 ..< mr:
+                if (srcRow + ii) < current_mc:
+                  packA_aligned[dstOff + ii] = pA_ptr[srcOff + ii * pA_rs]
+                else:
+                  packA_aligned[dstOff + ii] = T(0)
+
+        # ── Loop 1 (ir): micro-tiles of A, then Loop 2 (jr): micro-panels of B ──
+        # ir outer, jr inner: the packed A tile stays resident across the jr
+        # sweep, while the inner loop streams the packed B panels. Tile visit order
+        # changes, so no element's accumulation order is affected.
+        let packB_ptr = cast[ptr UncheckedArray[T]](alignB)
+        let packA_ptr = cast[ptr UncheckedArray[T]](alignA)
+        let packA_jump = kc * mr   # elements per ir slice
+        for ir in 0 ..< num_ir_eff:
+          let cRow = ic * mc + ir * mr
+          let aOffset = ir * packA_jump
+          let eff_mr = min(mr, M - cRow)
+          for jr in 0 ..< num_jr:
+            let cCol = jr * nr
+            if cCol >= N:
+              break
+
+            let bTilePtr = cast[ptr UncheckedArray[T]](packB_ptr)
+            let bOffset = jr * kc * nr   # elements into the packed B buffer for micro-panel jr
+            var AB {.noInit.}: array[mr, array[nr, T]]
+            # Prefetch the next B and A panels.
+            builtin_prefetch(cast[pointer](cast[int](bTilePtr) +% bOffset *% sizeof(T).int), 0, 1)
+            builtin_prefetch(cast[pointer](cast[int](packA_ptr) +% aOffset *% sizeof(T).int), 0, 1)
+            # Epilogue: displace (layout algebra) for view, raw-pointer dispatch
+            let eff_nr = min(nr, N - cCol)
+            let cTile {.noInit.} = displace(vC, (cRow, cCol))
+            when defined(arm64) and T is float32:
+              if eff_mr == mr and eff_nr == nr and
+                 vC.layout.stride[1] == 1 and vC.layout.stride[0] >= nr:
+                # Full 32×32 tile with contiguous C rows: kernel extracts ZA straight to C,
+                # fusing alpha/beta/ReLU in streaming mode (no AB scratch, no separate epilogue).
+                sme_gemm_ukernel_32x32_epi_dv(
+                  cast[ptr float32](cast[int](packA_ptr) +% aOffset *% sizeof(T).int),
+                  cast[ptr float32](cast[int](bTilePtr) +% bOffset *% sizeof(T).int),
+                  cast[ptr float32](cTile.data),
+                  cint(vC.layout.stride[0]), cint(current_kc),
+                  alpha, effective_beta,
+                  cint(activation == akReLU),
+                  cint(alpha == T(1)), cint(effective_beta == T(0)),
+                  cint(effective_beta == T(1)))
+              else:
+                gemm_ukernel(
+                  cast[ptr UncheckedArray[T]](cast[int](packA_ptr) +% aOffset *% sizeof(T).int),
+                  cast[ptr UncheckedArray[T]](cast[int](bTilePtr) +% bOffset *% sizeof(T).int),
+                  AB, current_kc)
+                gemm_epilogue(activation, cTile, AB, eff_mr, eff_nr, alpha, effective_beta)
+            else:
+              gemm_ukernel(
+                cast[ptr UncheckedArray[T]](cast[int](packA_ptr) +% aOffset *% sizeof(T).int),
+                cast[ptr UncheckedArray[T]](cast[int](bTilePtr) +% bOffset *% sizeof(T).int),
+                AB, current_kc)
+              gemm_epilogue(activation, cTile, AB, eff_mr, eff_nr, alpha, effective_beta)
+
+# ═══════════════════════════════════════════════════════════════════════════
+#  Convenience overload: openArray[T]
+# ═══════════════════════════════════════════════════════════════════════════
+
+proc gemm_strided*[T: SomeNumber](
+    M, N, K: int,
+    alpha: T,
+    A: openArray[T], rowStrideA, colStrideA: int,
+    B: openArray[T], rowStrideB, colStrideB: int,
+    beta: T,
+    C: var openArray[T], rowStrideC, colStrideC: int,
+    activation: Activation = akIdentity) =
+  ## openArray convenience overload of the pointer `gemm_strided`: same contract.
+  ## A, B and C must be non-empty. A K == 0 call still needs non-empty A and B
+  ## buffers (the natural M×0 and 0×N shapes trip the doAssert below).
+  doAssert A.len > 0 and B.len > 0 and C.len > 0, "gemm_strided: empty matrices not supported"
+  gemm_strided[T](
+    M, N, K, alpha,
+    cast[ptr UncheckedArray[T]](addr A[0]), rowStrideA, colStrideA,
+    cast[ptr UncheckedArray[T]](addr B[0]), rowStrideB, colStrideB,
+    beta,
+    cast[ptr UncheckedArray[T]](addr C[0]), rowStrideC, colStrideC,
+    activation)
+
+# ═══════════════════════════════════════════════════════════════════════════
+#  Test driver
+# ═══════════════════════════════════════════════════════════════════════════
+
+when isMainModule:
+  import std/[random, strutils]
+
+  when defined(arm64):
+    doAssert simdArchString() == "sme",
+      "SME path not active on arm64 (resolvedArch = " & simdArchString() & ")"
+
+  proc gemm_reference(M, N, K: int, alpha: float32,
+      A: openArray[float32], rsA, csA: int,
+      B: openArray[float32], rsB, csB: int,
+      beta: float32, C: var openArray[float32], rsC, csC: int) =
+    for j in 0 ..< N:
+      for i in 0 ..< M:
+        let ci = i * rsC + j * csC
+        C[ci] = if beta == 0.0'f32: 0.0'f32
+                elif beta != 1.0'f32: C[ci] * beta
+                else: C[ci]
+    for j in 0 ..< N:
+      for k in 0 ..< K:
+        let bv = B[k * rsB + j * csB]
+        if bv != 0.0'f32:
+          for i in 0 ..< M:
+            C[i * rsC + j * csC] += alpha * A[i * rsA + k * csA] * bv
+
+  proc test(M, N, K: int, rsA, csA, rsB, csB, rsC, csC: int, label: string, tol: float32 = 1e-4'f32,
+      alpha: float32 = 1.0'f32, beta: float32 = 1.0'f32) =
+    # Run a GEMM test: compare this example's gemm_strided against a naive reference.
+    # Tests default to alpha=1, beta=1. Pass different values to exercise
+    # the K==0 / alpha==0 edge cases and general alpha/beta correctness. K==0
+    # cases run through the scalar fallback (kc < kc_atom), never the SME
+    # kernel's kc == 0 branch, which gemm_strided cannot reach.
+    echo "\n### ", label
+    randomize(42)
+    let aLen = max((M-1)*rsA + (K-1)*csA + 1, 0)
+    let bLen = max((K-1)*rsB + (N-1)*csB + 1, 0)
+    let cLen = max((M-1)*rsC + (N-1)*csC + 1, 0)
+    let bPad = 32
+    # Pack loop clamps its copy width to N - jr*nr, so B is never over-read.
+    # Pad keeps B.len > 0 for the K == 0 shape (the footprint formula yields
+    # 0 elements for a 0×N matrix), satisfying the openArray overload's doAssert.
+    var A = newSeq[float32](aLen)
+    var B = newSeq[float32](bLen + bPad)
+    var C_ref = newSeq[float32](cLen)
+    var C_tst = newSeq[float32](cLen)
+    for i in 0 ..< A.len:   A[i] = rand(1.0'f32)
+    for i in 0 ..< B.len:   B[i] = rand(1.0'f32)
+    for i in 0 ..< C_ref.len: C_ref[i] = rand(1.0'f32)
+    for i in 0 ..< C_tst.len: C_tst[i] = C_ref[i]
+
+    gemm_reference(M, N, K, alpha, A, rsA, csA, B, rsB, csB, beta, C_ref, rsC, csC)
+    gemm_strided(M, N, K, alpha, A, rsA, csA, B, rsB, csB, beta, C_tst, rsC, csC, akIdentity)
+
+    var err: float32 = 0
+    for i in 0 ..< cLen:
+      err = max(err, abs(C_ref[i] - C_tst[i]))
+    echo "  max error: ", err.formatFloat(ffScientific, 2),
+         if err < tol: " ✅" else: " ❌"
+    doAssert err < tol, "Error tolerance exceeded (got " & $err & ")"
+
+  test(16, 16, 16, 1, 16, 1, 16, 1, 16, "Square 16x16 col-major")
+
+  # Direct kernel-level kc == 0 test: the SME asm's zeroed-tile branch
+  # (`cbz w14, 2f`) is unreachable through gemm_strided, since K=0 routes
+  # to the scalar fallback.
+  when defined(arm64):
+    block:
+      var packA: array[16, float32]
+      var packB: array[16, float32]
+      var AB: array[16, array[16, float32]]
+      for i in 0 ..< 16:
+        for j in 0 ..< 16:
+          AB[i][j] = 123.0'f32
+      gemm_ukernel_sme(
+        cast[ptr UncheckedArray[float32]](addr packA[0]),
+        cast[ptr UncheckedArray[float32]](addr packB[0]),
+        AB, 0)
+      for i in 0 ..< 16:
+        for j in 0 ..< 16:
+          doAssert AB[i][j] == 0.0'f32, "kernel kc=0 must zero the tile"
+      echo "  Kernel kc=0 (zeroed tile): ✅"
+  when defined(arm64):
+    block:
+      # 32×32 kernel kc == 0: the zeroed-tile branch.
+      var packA: array[32, float32]
+      var packB: array[32, float32]
+      var AB: array[32, array[32, float32]]
+      for i in 0 ..< 32:
+        for j in 0 ..< 32:
+          AB[i][j] = 123.0'f32
+      gemm_ukernel_sme(
+        cast[ptr UncheckedArray[float32]](addr packA[0]),
+        cast[ptr UncheckedArray[float32]](addr packB[0]),
+        AB, 0)
+      for i in 0 ..< 32:
+        for j in 0 ..< 32:
+          doAssert AB[i][j] == 0.0'f32, "32x32 kernel kc=0 must zero the tile"
+      echo "  32x32 Kernel kc=0 (zeroed tile): ✅"
+  when defined(arm64):
+    block:
+      # Fused kernel kc == 0: extracts the zeroed ZA tiles with a beta read.
+      # Expected result: C = beta*C + alpha*0.
+      var packA: array[32, float32]
+      var packB: array[32, float32]
+      var C: array[32 * 32, float32]
+      var Cref: array[32 * 32, float32]
+      randomize(42)
+      for i in 0 ..< C.len:
+        C[i] = rand(1.0'f32)
+        Cref[i] = C[i]
+      sme_gemm_ukernel_32x32_epi_dv(addr packA[0], addr packB[0], addr C[0],
+        cint(32), cint(0), 1.0'f32, 2.0'f32, 0, 1, 0, 0)  # kc=0, beta=2
+      for i in 0 ..< C.len:
+        doAssert abs(C[i] - 2.0'f32 * Cref[i]) < 1e-6, "fused kc=0 must yield beta*C"
+      echo "  Fused kernel kc=0 (beta*C): ✅"
+  test(16, 16, 16, 16, 1, 16, 1, 16, 1, "Square 16x16 row-major")
+  test(20, 32, 18, 18, 1, 32, 1, 32, 1, "Edge tiles: M=20, K=18 (non-multiples of 16)")
+  test(32, 20, 32, 32, 1, 20, 1, 20, 1, "Edge tiles: N=20 (non-multiple of 16)")
+  test(17, 16, 17, 17, 1, 16, 1, 16, 1, "Edge tiles: M=17, K=17 (minimal overhang)")
+  test(48, 48, 48, 48, 1, 48, 1, 48, 1, "Non-square 48x48")
+  test(128, 128, 128, 1, 128, 1, 128, 1, 128, "Large 128x128 col-major")
+  test(512, 512, 512, 512, 1, 512, 1, 512, 1, "Large 512x512 row-major", tol = 1e-3'f32)
+  # A-pack zero-group regression: K = 1..7 (mod 16) leaves a final pc block
+  # with current_kc < 8, so the NEON transpose pack must handle zero 8-column
+  # groups without walking out of bounds.
+  test(32, 32, 17, 32, 1, 32, 1, 32, 1, "K=17: A-pack nColGroups=0 (regression)")
+  test(32, 32, 513, 513, 1, 513, 1, 513, 1, "K=513: A-pack nColGroups=0 at kc=512")
+  # K=18: pc=1 leaves current_kc=2, so the 32×32 kernel runs its kc % 4
+  # oddments tail and the A-pack scalar gather covers all k-steps.
+  # K=36/M=36: pc=1 leaves current_kc=4 (kernel single-block path). M=36
+  # makes ic=1 a 4-row block, exercising the A-transpose partial 8-row group
+  # and the pack's overhang zero-fill.
+  test(32, 32, 18, 32, 1, 32, 1, 32, 1, "K=18: kernel oddments tail (kc=2) + A-pack remainder")
+  test(36, 36, 36, 36, 1, 36, 1, 36, 1, "K=36/M=36: kernel single-block kc=4, A-pack 4-step remainder, partial 8-row group")
+  # K=19: pc=1 leaves current_kc=3: the kernel's oddments-only tail runs
+  # w17 = 3 iterations of the `6:` loop (kc % 4 == 3, no full blocks).
+  # K=47: pc=1 leaves current_kc=15, w16 = 3 blocks plus a 3-oddment tail
+  # exercising the mixed prologue+oddments path in the fused kernel.
+  test(32, 32, 19, 32, 1, 32, 1, 32, 1, "K=19: kc=3 oddments-only tail (kc % 4 == 3)")
+  test(32, 32, 47, 47, 1, 47, 1, 47, 1, "K=47: blocks + 3-oddment tail (kc=32, tail kc=15)")
+  test(8, 8, 4, 1, 10, 1, 10, 1, 10, "Non-square (8x4) scalar path")
+  test(2, 2, 2, 1, 2, 1, 2, 1, 2, "Tiny 2x2 (triple-loop path)")
+  # Edge cases: alpha==0 (K>0) should still apply beta to C
+  test(32, 32, 32, 32, 1, 32, 1, 32, 1, "alpha=0, beta=1", alpha = 0.0'f32)
+  test(32, 32, 32, 32, 1, 32, 1, 32, 1, "alpha=0.5, beta=2", alpha = 0.5'f32, beta = 2.0'f32)
+  test(32, 32, 32, 32, 1, 32, 1, 32, 1, "alpha=0, beta=0", alpha = 0.0'f32, beta = 0.0'f32)
+  # K==0: scalar fallback with an empty k-loop, C = beta*C + alpha*0
+  test(32, 32, 0, 32, 1, 32, 1, 32, 1, "K=0, beta=1 (no accumulation)")
+  test(32, 32, 0, 32, 1, 32, 1, 32, 1, "K=0, beta=2", beta = 2.0'f32)
+  block:
+    # ReLU via the fused SME extract (fclamp): full 32×32 tile, row-major C.
+    # A rows alternate +1/-1 by column and B rows alternate -1/+1 by row:
+    # every A·B accumulator is -32, so the fclamp is observable. An identity
+    # clamp would leave -32 in C.
+    let (M, N, K) = (32, 32, 32)
+    let rs = N
+    var A = newSeq[float32](M * K)
+    var B = newSeq[float32](K * N)
+    for i in 0 ..< M:
+      for k in 0 ..< K:
+        A[i * K + k] = if (k mod 2) == 0: 1.0'f32 else: -1.0'f32
+    for k in 0 ..< K:
+      for j in 0 ..< N:
+        B[k * N + j] = if (k mod 2) == 0: -1.0'f32 else: 1.0'f32
+    var C_ref = newSeq[float32](M * N)
+    var C_tst = newSeq[float32](M * N)
+    randomize(42)
+    for i in 0 ..< M * N: C_ref[i] = rand(1.0'f32)
+    for i in 0 ..< M * N: C_tst[i] = C_ref[i]
+    # Reference: C = beta*C + alpha*max(A·B, 0) with alpha=1, beta=1
+    for i in 0 ..< M:
+      for j in 0 ..< N:
+        var acc = 0.0'f32
+        for k in 0 ..< K:
+          acc += A[i * K + k] * B[k * N + j]
+        C_ref[i * N + j] += max(acc, 0.0'f32)
+    gemm_strided(M, N, K, 1.0'f32, A, rs, 1, B, rs, 1, 1.0'f32, C_tst, rs, 1, akReLU)
+    var err: float32 = 0
+    for i in 0 ..< M * N:
+      err = max(err, abs(C_ref[i] - C_tst[i]))
+    doAssert err < 1e-4'f32, "fused ReLU tolerance exceeded (got " & $err & ")"
+    echo "  ReLU via the fused SME extract (fclamp): max error ", err.formatFloat(ffScientific, 2), " ✅"
+  block:
+    # ReLU on a partial tile (N=20): the fused dispatch keeps tiles below
+    # 32×32 on the AB-store kernel + epilogue path, so this check runs
+    # the epilogue's ReLU with clamped and pass-through rows. A rows alternate
+    # by (i+k) parity and B rows by k parity, so every accumulator is +32 on
+    # even i rows and -32 on odd i rows.
+    let (M, N, K) = (32, 20, 32)
+    var A = newSeq[float32](M * K)
+    var B = newSeq[float32](K * N)
+    for i in 0 ..< M:
+      for k in 0 ..< K:
+        A[i * K + k] = if ((i + k) mod 2) == 0: 1.0'f32 else: -1.0'f32
+    for k in 0 ..< K:
+      for j in 0 ..< N:
+        B[k * N + j] = if (k mod 2) == 0: 1.0'f32 else: -1.0'f32
+    var C_ref = newSeq[float32](M * N)
+    var C_tst = newSeq[float32](M * N)
+    randomize(42)
+    for i in 0 ..< M * N: C_ref[i] = rand(1.0'f32)
+    for i in 0 ..< M * N: C_tst[i] = C_ref[i]
+    # Reference: C = C + max(A·B, 0): +32 on even rows, 0 on odd rows
+    for i in 0 ..< M:
+      for j in 0 ..< N:
+        var acc = 0.0'f32
+        for k in 0 ..< K:
+          acc += A[i * K + k] * B[k * N + j]
+        C_ref[i * N + j] += max(acc, 0.0'f32)
+    gemm_strided(M, N, K, 1.0'f32, A, K, 1, B, N, 1, 1.0'f32, C_tst, N, 1, akReLU)
+    var err: float32 = 0
+    for i in 0 ..< M * N:
+      err = max(err, abs(C_ref[i] - C_tst[i]))
+    doAssert err < 1e-4'f32, "partial-tile ReLU tolerance exceeded (got " & $err & ")"
+    echo "  ReLU on partial tile (old AB+epilogue path): max error ", err.formatFloat(ffScientific, 2), " ✅"
+  block:
+    # Fused ReLU with alpha=0.5, beta=2: the extract applies fclamp first, then
+    # alpha, then beta*C. The same -32 accumulator pattern plus one NaN A lane:
+    # fclamp(NaN) = 0 on M4, so row 0 must come out as beta*C,
+    # matching the scalar max(NaN, 0) = 0.
+    let (M, N, K) = (32, 32, 32)
+    let rs = N
+    var A = newSeq[float32](M * K)
+    var B = newSeq[float32](K * N)
+    for i in 0 ..< M:
+      for k in 0 ..< K:
+        A[i * K + k] = if (k mod 2) == 0: 1.0'f32 else: -1.0'f32
+    A[0] = NaN
+    for k in 0 ..< K:
+      for j in 0 ..< N:
+        B[k * N + j] = if (k mod 2) == 0: -1.0'f32 else: 1.0'f32
+    var C_orig = newSeq[float32](M * N)
+    var C_ref = newSeq[float32](M * N)
+    var C_tst = newSeq[float32](M * N)
+    randomize(42)
+    for i in 0 ..< M * N: C_orig[i] = rand(1.0'f32)
+    for i in 0 ..< M * N:
+      C_ref[i] = C_orig[i]
+      C_tst[i] = C_orig[i]
+    # Reference: C = 2*C + 0.5*max(A·B, 0), with max(NaN, 0) = 0.
+    for i in 0 ..< M:
+      for j in 0 ..< N:
+        var acc = 0.0'f32
+        for k in 0 ..< K:
+          acc += A[i * K + k] * B[k * N + j]
+        C_ref[i * N + j] = 2.0'f32 * C_ref[i * N + j] + 0.5'f32 * max(acc, 0.0'f32)
+    gemm_strided(M, N, K, 0.5'f32, A, rs, 1, B, rs, 1, 2.0'f32, C_tst, rs, 1, akReLU)
+    var err: float32 = 0
+    for i in 0 ..< M * N:
+      err = max(err, abs(C_ref[i] - C_tst[i]))
+    doAssert err < 1e-4'f32, "fused ReLU alpha/beta tolerance exceeded (got " & $err & ")"
+    echo "  ReLU via fused SME extract (alpha=0.5, beta=2): max error ", err.formatFloat(ffScientific, 2), " ✅"
+    # NaN lane (row 0) must equal beta*C: alpha*max(NaN, 0) = 0, asserted
+    # against the independent pre-GEMM C values.
+    for j in 0 ..< N:
+      doAssert abs(C_tst[j] - 2.0'f32 * C_orig[j]) < 1e-6,
+        "NaN lane must stay beta*C (got " & $C_tst[j] & ")"
+    echo "  ReLU NaN lane (fclamp NaN->0, C = beta*C): ✅"
+  when defined(arm64):
+    block:
+      # NEON epilogue's ReLU (fmax) branch is unreachable through
+      # gemm_strided: the fused dispatch owns every full 32×32 contiguous
+      # tile, which is the NEON fast path's only precondition.
+      var AB: array[32, array[32, float32]]
+      var C: array[32 * 32, float32]
+      var Cref: array[32 * 32, float32]
+      randomize(42)
+      for i in 0 ..< 32:
+        for j in 0 ..< 32:
+          AB[i][j] = if ((i + j) mod 2) == 0: 1.0'f32 else: -1.0'f32
+      for i in 0 ..< C.len:
+        C[i] = rand(1.0'f32)
+        Cref[i] = C[i] + (if ((i div 32 + i mod 32) mod 2) == 0: 1.0'f32 else: 0.0'f32)
+      neon_epilogue_f32_32x32(addr C[0], cint(32), addr AB[0][0],
+        1.0'f32, 1.0'f32, 1, 1, 0, 1)
+      for i in 0 ..< C.len:
+        doAssert abs(C[i] - Cref[i]) < 1e-6, "NEON epilogue ReLU mismatch (got " & $C[i] & ")"
+      echo "  NEON epilogue ReLU (fmax, direct call): ✅"
+  echo "\nDone."

--- a/workspace/ceramic/examples/ex02a_matmul_handtuned_arm64_sme2.nim
+++ b/workspace/ceramic/examples/ex02a_matmul_handtuned_arm64_sme2.nim
@@ -48,7 +48,7 @@ template genEpilogue*(epilogueName: untyped, relu: static bool, activationBody: 
       # the scalar path's comparisons, so both paths agree element-for-element
       # for all finite inputs.
       if mr == 32 and nr == 32 and C.layout.stride[1] == 1 and C.layout.stride[0] >= 32:
-        neon_epilogue_f32_32x32(
+        neonEpilogueF3232x32(
           cast[ptr float32](C.data), cint(C.layout.stride[0]),
           cast[ptr float32](addr AB[0][0]),
           alpha, beta,
@@ -134,7 +134,7 @@ export gemm_ukernel_arm64_sme2  # epilogue templates instantiate in the caller's
 proc builtin_prefetch*(p: pointer, rw: cint, locality: cint) {.importc: "__builtin_prefetch", nodecl.}
 ## Clang alignment-assert builtin used by the pack paths. Available on every
 ## target, so the off-arm64 fallback compiles.
-proc builtin_assume_aligned*(p: pointer, alignment: csize): pointer {.importc: "__builtin_assume_aligned", nodecl.}
+proc builtin_assume_aligned*(p: pointer, alignment: csize_t): pointer {.importc: "__builtin_assume_aligned", nodecl.}
 
 const simdArch {.strdefine.} = "auto"
 
@@ -159,7 +159,7 @@ proc simdArchString*(): string = resolvedArch
 
 template gemm_ukernel(packA, packB, AB, kc: untyped): untyped =
   when resolvedArch == "sme":
-    gemm_ukernel_sme(packA, packB, AB, kc)
+    gemmUkernelSme(packA, packB, AB, kc)
   else:
     gemm_ukernel_generic(packA, packB, AB, kc)
 
@@ -213,7 +213,8 @@ proc gemm_strided*[T: SomeNumber](
         for k in 0 ..< K:
           acc += A[i * rowStrideA + k * colStrideA] * B[k * rowStrideB + j * colStrideB]
         let ci = i * rowStrideC + j * colStrideC
-        C[ci] = beta * C[ci] + alpha * acc
+        C[ci] = if beta == T(0): alpha * acc
+                else: beta * C[ci] + alpha * acc
     return
 
   # ── Derived quantities ──
@@ -250,45 +251,37 @@ proc gemm_strided*[T: SomeNumber](
     if current_kc <= 0: continue
     let effective_beta = if pc == 0: beta else: T(1)
 
-    for jc in 0 ..< 1:
-      let panelB = local_tile(vB, (kc, nc), (pc, jc))
-      let pB_ptr = cast[ptr UncheckedArray[T]](panelB.data)
-      let pB_rs = panelB.layout.stride[0]  # row stride of panel
-      let pB_cs = panelB.layout.stride[1]  # col stride of panel
+    # B is packed across the full N dimension: nc = num_jr*nr covers all of N.
+    let panelB = local_tile(vB, (kc, nc), (pc, 0))
+    let pB_ptr = cast[ptr UncheckedArray[T]](panelB.data)
+    let pB_rs = panelB.layout.stride[0]  # row stride of panel
+    let pB_cs = panelB.layout.stride[1]  # col stride of panel
 
-      # Pack B: explicit triple loop (copyMem-compatible stride, SIMD-friendly)
-      let packB_aligned = cast[ptr UncheckedArray[T]](builtin_assume_aligned(cast[pointer](packB_ptr), 32))
-      for jr in 0 ..< num_jr:
-        let eff = min(nr, N - jr * nr)   # lanes valid in the last micro-panel
-        if pB_cs == 1:
-          when defined(arm64) and T is float32:
-            if N mod nr == 0 and num_jr mod 4 == 0:
-              # Four full panels per pass: one B-row visit reads 512 contiguous bytes
-              # (DRAM row locality) instead of a 128-B slice. The group's remaining jr iterations are no-ops.
-              if jr mod 4 == 0:
-                sme_packB_copy_32f32_x4(
-                  cast[ptr float32](cast[int](packB_aligned) +% ((jr + 0) * kc * nr) *% sizeof(T).int),
-                  cast[ptr float32](cast[int](packB_aligned) +% ((jr + 1) * kc * nr) *% sizeof(T).int),
-                  cast[ptr float32](cast[int](packB_aligned) +% ((jr + 2) * kc * nr) *% sizeof(T).int),
-                  cast[ptr float32](cast[int](packB_aligned) +% ((jr + 3) * kc * nr) *% sizeof(T).int),
-                  cast[ptr float32](cast[int](pB_ptr) +% (jr * nr) *% sizeof(T).int),
-                  cint(pB_rs), cint(current_kc))
-            elif eff == nr:
-              # 32 valid lanes per row: 128-B NEON copies (2× ld1/st1 per row).
-              # Partial-column last panels (eff < nr) keep the copyMem loop
-              # below, so B is never read past its valid lanes.
-              neon_packB_copy_32f32(
-                cast[ptr float32](cast[int](packB_aligned) +% (jr * kc * nr) *% sizeof(T).int),
+    # Pack B: explicit triple loop (copyMem-compatible stride, SIMD-friendly)
+    let packB_aligned = cast[ptr UncheckedArray[T]](builtin_assume_aligned(cast[pointer](packB_ptr), 32))
+    for jr in 0 ..< num_jr:
+      let eff = min(nr, N - jr * nr)   # lanes valid in the last micro-panel
+      if pB_cs == 1:
+        when defined(arm64) and T is float32:
+          if N mod nr == 0 and num_jr mod 4 == 0:
+            # Four full panels per pass: one B-row visit reads 512 contiguous bytes
+            # (DRAM row locality) instead of a 128-B slice. The group's remaining jr iterations are no-ops.
+            if jr mod 4 == 0:
+              smePackBCopy32f32x4(
+                cast[ptr float32](cast[int](packB_aligned) +% ((jr + 0) * kc * nr) *% sizeof(T).int),
+                cast[ptr float32](cast[int](packB_aligned) +% ((jr + 1) * kc * nr) *% sizeof(T).int),
+                cast[ptr float32](cast[int](packB_aligned) +% ((jr + 2) * kc * nr) *% sizeof(T).int),
+                cast[ptr float32](cast[int](packB_aligned) +% ((jr + 3) * kc * nr) *% sizeof(T).int),
                 cast[ptr float32](cast[int](pB_ptr) +% (jr * nr) *% sizeof(T).int),
                 cint(pB_rs), cint(current_kc))
-            else:
-              # B rows are contiguous: copyMem
-              for k in 0 ..< current_kc:
-                let dstOff = jr * kc * nr + k * nr
-                let srcOff = k * pB_rs + jr * nr
-                copyMem(addr packB_aligned[dstOff], addr pB_ptr[srcOff], eff * sizeof(T).int)
-                for jj in eff ..< nr:
-                  packB_aligned[dstOff + jj] = T(0)
+          elif eff == nr:
+            # 32 valid lanes per row: 128-B NEON copies (2× ld1/st1 per row).
+            # Partial-column last panels (eff < nr) keep the copyMem loop
+            # below, so B is never read past its valid lanes.
+            neonPackBCopy32f32(
+              cast[ptr float32](cast[int](packB_aligned) +% (jr * kc * nr) *% sizeof(T).int),
+              cast[ptr float32](cast[int](pB_ptr) +% (jr * nr) *% sizeof(T).int),
+              cint(pB_rs), cint(current_kc))
           else:
             # B rows are contiguous: copyMem
             for k in 0 ..< current_kc:
@@ -298,98 +291,95 @@ proc gemm_strided*[T: SomeNumber](
               for jj in eff ..< nr:
                 packB_aligned[dstOff + jj] = T(0)
         else:
+          # B rows are contiguous: copyMem
           for k in 0 ..< current_kc:
             let dstOff = jr * kc * nr + k * nr
-            let srcOff = k * pB_rs + jr * nr * pB_cs
-            for jj in 0 ..< eff:
-              packB_aligned[dstOff + jj] = pB_ptr[srcOff + jj * pB_cs]
+            let srcOff = k * pB_rs + jr * nr
+            copyMem(addr packB_aligned[dstOff], addr pB_ptr[srcOff], eff * sizeof(T).int)
             for jj in eff ..< nr:
               packB_aligned[dstOff + jj] = T(0)
+      else:
+        for k in 0 ..< current_kc:
+          let dstOff = jr * kc * nr + k * nr
+          let srcOff = k * pB_rs + jr * nr * pB_cs
+          for jj in 0 ..< eff:
+            packB_aligned[dstOff + jj] = pB_ptr[srcOff + jj * pB_cs]
+          for jj in eff ..< nr:
+            packB_aligned[dstOff + jj] = T(0)
 
-      # ── Loop 3 (ic): row blocks of A ──
-      for ic in 0 ..< num_ic:
-        let current_mc = min(M - ic * mc, mc)
-        if current_mc <= 0:
-          continue
-        let last_m = (current_mc < mc)
-        let num_ir_eff = if last_m: ceil_div(current_mc, mr)
-                         else: num_ir
+    # ── Loop 3 (ic): row blocks of A ──
+    for ic in 0 ..< num_ic:
+      let current_mc = min(M - ic * mc, mc)
+      if current_mc <= 0:
+        continue
+      let last_m = (current_mc < mc)
+      let num_ir_eff = if last_m: ceil_div(current_mc, mr)
+                       else: num_ir
 
-        let panelA = local_tile(vA, (mc, kc), (ic, pc))
+      let panelA = local_tile(vA, (mc, kc), (ic, pc))
 
-        let pA_ptr = cast[ptr UncheckedArray[T]](panelA.data)
-        let pA_rs = panelA.layout.stride[0]
-        let pA_cs = panelA.layout.stride[1]
+      let pA_ptr = cast[ptr UncheckedArray[T]](panelA.data)
+      let pA_rs = panelA.layout.stride[0]
+      let pA_cs = panelA.layout.stride[1]
 
-        # Pack A: explicit triple loop (with copyMem for contiguous rows)
-        let packA_aligned = cast[ptr UncheckedArray[T]](builtin_assume_aligned(cast[pointer](packA_ptr), 32))
-        if pA_rs == 1:
-          # Rows are contiguous in memory (column-major): use copyMem
+      # Pack A: explicit triple loop (with copyMem for contiguous rows)
+      let packA_aligned = cast[ptr UncheckedArray[T]](builtin_assume_aligned(cast[pointer](packA_ptr), 32))
+      if pA_rs == 1:
+        # Rows are contiguous in memory (column-major): use copyMem
+        for ir in 0 ..< num_ir_eff:
+          let srcRow = ir * mr
+          let lastTile = (srcRow + mr) > current_mc
+          for k in 0 ..< current_kc:
+            let dstOff = ir * kc * mr + k * mr
+            let srcOff = srcRow + k * pA_cs
+            if lastTile:
+              let valid = current_mc - srcRow
+              copyMem(addr packA_aligned[dstOff], addr pA_ptr[srcOff], valid * sizeof(T).int)
+              for ii in valid ..< mr:
+                packA_aligned[dstOff + ii] = T(0)
+            else:
+              copyMem(addr packA_aligned[dstOff], addr pA_ptr[srcOff], mr * sizeof(T).int)
+      elif pA_cs == 1:
+        when defined(arm64) and T is float32:
+          # Row-major A: NEON 8×8 trn pack, or the streaming mova 16×16 pack
+          # when kc % 16 == 0 (16-column ZA tile). validRows zero-fills rows
+          # past current_mc, and leftover k steps use the scalar gather below.
+          static: doAssert mr == 32  # helpers' 8-row/16-row store geometry
+          let kBlocks = current_kc div 8
+          let kBlocks16 = current_kc div 16
+          let kcEven16 = current_kc mod 16 == 0
+          let kDone = if kcEven16: kBlocks16 * 16 else: kBlocks * 8
           for ir in 0 ..< num_ir_eff:
             let srcRow = ir * mr
-            let lastTile = (srcRow + mr) > current_mc
-            for k in 0 ..< current_kc:
-              let dstOff = ir * kc * mr + k * mr
-              let srcOff = srcRow + k * pA_cs
-              if lastTile:
-                let valid = current_mc - srcRow
-                copyMem(addr packA_aligned[dstOff], addr pA_ptr[srcOff], valid * sizeof(T).int)
-                for ii in valid ..< mr:
-                  packA_aligned[dstOff + ii] = T(0)
+            let dstBase = ir * kc * mr
+            if kBlocks > 0:
+              if kcEven16:
+                # Two 16-row groups per 32-row tile.
+                for g in 0 ..< 2:
+                  let groupValid = max(0, min(16, current_mc - srcRow - g * 16))
+                  smePackATranspose16rows(
+                    cast[ptr float32](cast[int](packA_aligned) +% (dstBase + g * 16) *% sizeof(T).int),
+                    cast[ptr float32](cast[int](pA_ptr) +% ((srcRow + g * 16) * pA_rs) *% sizeof(T).int),
+                    cint(pA_rs), cint(kBlocks16), cint(groupValid))
               else:
-                copyMem(addr packA_aligned[dstOff], addr pA_ptr[srcOff], mr * sizeof(T).int)
-        elif pA_cs == 1:
-          when defined(arm64) and T is float32:
-            # Row-major A: NEON 8×8 trn pack, or the streaming mova 16×16 pack
-            # when kc % 16 == 0 (16-column ZA tile). validRows zero-fills rows
-            # past current_mc, and leftover k steps use the scalar gather below.
-            static: doAssert mr == 32  # helpers' 8-row/16-row store geometry
-            let kBlocks = current_kc div 8
-            let kBlocks16 = current_kc div 16
-            let kcEven16 = current_kc mod 16 == 0
-            let kDone = if kcEven16: kBlocks16 * 16 else: kBlocks * 8
-            for ir in 0 ..< num_ir_eff:
-              let srcRow = ir * mr
-              let dstBase = ir * kc * mr
-              if kBlocks > 0:
-                if kcEven16:
-                  # Two 16-row groups per 32-row tile.
-                  for g in 0 ..< 2:
-                    let groupValid = max(0, min(16, current_mc - srcRow - g * 16))
-                    sme_packA_transpose_16rows(
-                      cast[ptr float32](cast[int](packA_aligned) +% (dstBase + g * 16) *% sizeof(T).int),
-                      cast[ptr float32](cast[int](pA_ptr) +% ((srcRow + g * 16) * pA_rs) *% sizeof(T).int),
-                      cint(pA_rs), cint(kBlocks16), cint(groupValid))
+                # Four 8-row groups per 32-row tile.
+                for g in 0 ..< 4:
+                  let groupValid = max(0, min(8, current_mc - srcRow - g * 8))
+                  neonPackATranspose8rows(
+                    cast[ptr float32](cast[int](packA_aligned) +% (dstBase + g * 8) *% sizeof(T).int),
+                    cast[ptr float32](cast[int](pA_ptr) +% ((srcRow + g * 8) * pA_rs) *% sizeof(T).int),
+                    cint(pA_rs), cint(kBlocks), cint(groupValid))
+            for k in kDone ..< current_kc:
+              let dstOff = dstBase + k * mr
+              let srcOff = srcRow * pA_rs + k * pA_cs
+              for ii in 0 ..< mr:
+                if (srcRow + ii) < current_mc:
+                  packA_aligned[dstOff + ii] = pA_ptr[srcOff + ii * pA_rs]
                 else:
-                  # Four 8-row groups per 32-row tile.
-                  for g in 0 ..< 4:
-                    let groupValid = max(0, min(8, current_mc - srcRow - g * 8))
-                    neon_packA_transpose_8rows(
-                      cast[ptr float32](cast[int](packA_aligned) +% (dstBase + g * 8) *% sizeof(T).int),
-                      cast[ptr float32](cast[int](pA_ptr) +% ((srcRow + g * 8) * pA_rs) *% sizeof(T).int),
-                      cint(pA_rs), cint(kBlocks), cint(groupValid))
-              for k in kDone ..< current_kc:
-                let dstOff = dstBase + k * mr
-                let srcOff = srcRow * pA_rs + k * pA_cs
-                for ii in 0 ..< mr:
-                  if (srcRow + ii) < current_mc:
-                    packA_aligned[dstOff + ii] = pA_ptr[srcOff + ii * pA_rs]
-                  else:
-                    packA_aligned[dstOff + ii] = T(0)
-          else:
-            # Scalar gather: same pack layout as the NEON path, without the 8×8 block transpose.
-            # Rows past current_mc store zeros.
-            for ir in 0 ..< num_ir_eff:
-              let srcRow = ir * mr
-              for k in 0 ..< current_kc:
-                let dstOff = ir * kc * mr + k * mr
-                let srcOff = srcRow * pA_rs + k * pA_cs
-                for ii in 0 ..< mr:
-                  if (srcRow + ii) < current_mc:
-                    packA_aligned[dstOff + ii] = pA_ptr[srcOff + ii * pA_rs]
-                  else:
-                    packA_aligned[dstOff + ii] = T(0)
+                  packA_aligned[dstOff + ii] = T(0)
         else:
+          # Scalar gather: same pack layout as the NEON path, without the 8×8 block transpose.
+          # Rows past current_mc store zeros.
           for ir in 0 ..< num_ir_eff:
             let srcRow = ir * mr
             for k in 0 ..< current_kc:
@@ -400,58 +390,69 @@ proc gemm_strided*[T: SomeNumber](
                   packA_aligned[dstOff + ii] = pA_ptr[srcOff + ii * pA_rs]
                 else:
                   packA_aligned[dstOff + ii] = T(0)
-
-        # ── Loop 1 (ir): micro-tiles of A, then Loop 2 (jr): micro-panels of B ──
-        # ir outer, jr inner: the packed A tile stays resident across the jr
-        # sweep, while the inner loop streams the packed B panels. Tile visit order
-        # changes, so no element's accumulation order is affected.
-        let packB_ptr = cast[ptr UncheckedArray[T]](alignB)
-        let packA_ptr = cast[ptr UncheckedArray[T]](alignA)
-        let packA_jump = kc * mr   # elements per ir slice
+      else:
         for ir in 0 ..< num_ir_eff:
-          let cRow = ic * mc + ir * mr
-          let aOffset = ir * packA_jump
-          let eff_mr = min(mr, M - cRow)
-          for jr in 0 ..< num_jr:
-            let cCol = jr * nr
-            if cCol >= N:
-              break
-
-            let bTilePtr = cast[ptr UncheckedArray[T]](packB_ptr)
-            let bOffset = jr * kc * nr   # elements into the packed B buffer for micro-panel jr
-            var AB {.noInit.}: array[mr, array[nr, T]]
-            # Prefetch the next B and A panels.
-            builtin_prefetch(cast[pointer](cast[int](bTilePtr) +% bOffset *% sizeof(T).int), 0, 1)
-            builtin_prefetch(cast[pointer](cast[int](packA_ptr) +% aOffset *% sizeof(T).int), 0, 1)
-            # Epilogue: displace (layout algebra) for view, raw-pointer dispatch
-            let eff_nr = min(nr, N - cCol)
-            let cTile {.noInit.} = displace(vC, (cRow, cCol))
-            when defined(arm64) and T is float32:
-              if eff_mr == mr and eff_nr == nr and
-                 vC.layout.stride[1] == 1 and vC.layout.stride[0] >= nr:
-                # Full 32×32 tile with contiguous C rows: kernel extracts ZA straight to C,
-                # fusing alpha/beta/ReLU in streaming mode (no AB scratch, no separate epilogue).
-                sme_gemm_ukernel_32x32_epi_dv(
-                  cast[ptr float32](cast[int](packA_ptr) +% aOffset *% sizeof(T).int),
-                  cast[ptr float32](cast[int](bTilePtr) +% bOffset *% sizeof(T).int),
-                  cast[ptr float32](cTile.data),
-                  cint(vC.layout.stride[0]), cint(current_kc),
-                  alpha, effective_beta,
-                  cint(activation == akReLU),
-                  cint(alpha == T(1)), cint(effective_beta == T(0)),
-                  cint(effective_beta == T(1)))
+          let srcRow = ir * mr
+          for k in 0 ..< current_kc:
+            let dstOff = ir * kc * mr + k * mr
+            let srcOff = srcRow * pA_rs + k * pA_cs
+            for ii in 0 ..< mr:
+              if (srcRow + ii) < current_mc:
+                packA_aligned[dstOff + ii] = pA_ptr[srcOff + ii * pA_rs]
               else:
-                gemm_ukernel(
-                  cast[ptr UncheckedArray[T]](cast[int](packA_ptr) +% aOffset *% sizeof(T).int),
-                  cast[ptr UncheckedArray[T]](cast[int](bTilePtr) +% bOffset *% sizeof(T).int),
-                  AB, current_kc)
-                gemm_epilogue(activation, cTile, AB, eff_mr, eff_nr, alpha, effective_beta)
+                packA_aligned[dstOff + ii] = T(0)
+
+      # ── Loop 1 (ir): micro-tiles of A, then Loop 2 (jr): micro-panels of B ──
+      # ir outer, jr inner: the packed A tile stays resident across the jr
+      # sweep, while the inner loop streams the packed B panels. Tile visit order
+      # changes, so no element's accumulation order is affected.
+      let packB_ptr = cast[ptr UncheckedArray[T]](alignB)
+      let packA_ptr = cast[ptr UncheckedArray[T]](alignA)
+      let packA_jump = kc * mr   # elements per ir slice
+      for ir in 0 ..< num_ir_eff:
+        let cRow = ic * mc + ir * mr
+        let aOffset = ir * packA_jump
+        let eff_mr = min(mr, M - cRow)
+        for jr in 0 ..< num_jr:
+          let cCol = jr * nr
+          if cCol >= N:
+            break
+
+          let bTilePtr = cast[ptr UncheckedArray[T]](packB_ptr)
+          let bOffset = jr * kc * nr   # elements into the packed B buffer for micro-panel jr
+          var AB {.noInit.}: array[mr, array[nr, T]]
+          # Prefetch the next B and A panels.
+          builtin_prefetch(cast[pointer](cast[int](bTilePtr) +% bOffset *% sizeof(T).int), 0, 1)
+          builtin_prefetch(cast[pointer](cast[int](packA_ptr) +% aOffset *% sizeof(T).int), 0, 1)
+          # Epilogue: displace (layout algebra) for view, raw-pointer dispatch
+          let eff_nr = min(nr, N - cCol)
+          let cTile {.noInit.} = displace(vC, (cRow, cCol))
+          when defined(arm64) and T is float32:
+            if eff_mr == mr and eff_nr == nr and
+               vC.layout.stride[1] == 1 and vC.layout.stride[0] >= nr:
+              # Full 32×32 tile with contiguous C rows: kernel extracts ZA straight to C,
+              # fusing alpha/beta/ReLU in streaming mode (no AB scratch, no separate epilogue).
+              smeGemmUkernel32x32EpiDv(
+                cast[ptr float32](cast[int](packA_ptr) +% aOffset *% sizeof(T).int),
+                cast[ptr float32](cast[int](bTilePtr) +% bOffset *% sizeof(T).int),
+                cast[ptr float32](cTile.data),
+                cint(vC.layout.stride[0]), cint(current_kc),
+                alpha, effective_beta,
+                cint(activation == akReLU),
+                cint(alpha == T(1)), cint(effective_beta == T(0)),
+                cint(effective_beta == T(1)))
             else:
               gemm_ukernel(
                 cast[ptr UncheckedArray[T]](cast[int](packA_ptr) +% aOffset *% sizeof(T).int),
                 cast[ptr UncheckedArray[T]](cast[int](bTilePtr) +% bOffset *% sizeof(T).int),
                 AB, current_kc)
               gemm_epilogue(activation, cTile, AB, eff_mr, eff_nr, alpha, effective_beta)
+          else:
+            gemm_ukernel(
+              cast[ptr UncheckedArray[T]](cast[int](packA_ptr) +% aOffset *% sizeof(T).int),
+              cast[ptr UncheckedArray[T]](cast[int](bTilePtr) +% bOffset *% sizeof(T).int),
+              AB, current_kc)
+            gemm_epilogue(activation, cTile, AB, eff_mr, eff_nr, alpha, effective_beta)
 
 # ═══════════════════════════════════════════════════════════════════════════
 #  Convenience overload: openArray[T]
@@ -483,27 +484,11 @@ proc gemm_strided*[T: SomeNumber](
 
 when isMainModule:
   import std/[random, strutils]
+  import workspace/ceramic/benchmark/bench_utils
 
   when defined(arm64):
     doAssert simdArchString() == "sme",
       "SME path not active on arm64 (resolvedArch = " & simdArchString() & ")"
-
-  proc gemm_reference(M, N, K: int, alpha: float32,
-      A: openArray[float32], rsA, csA: int,
-      B: openArray[float32], rsB, csB: int,
-      beta: float32, C: var openArray[float32], rsC, csC: int) =
-    for j in 0 ..< N:
-      for i in 0 ..< M:
-        let ci = i * rsC + j * csC
-        C[ci] = if beta == 0.0'f32: 0.0'f32
-                elif beta != 1.0'f32: C[ci] * beta
-                else: C[ci]
-    for j in 0 ..< N:
-      for k in 0 ..< K:
-        let bv = B[k * rsB + j * csB]
-        if bv != 0.0'f32:
-          for i in 0 ..< M:
-            C[i * rsC + j * csC] += alpha * A[i * rsA + k * csA] * bv
 
   proc test(M, N, K: int, rsA, csA, rsB, csB, rsC, csC: int, label: string, tol: float32 = 1e-4'f32,
       alpha: float32 = 1.0'f32, beta: float32 = 1.0'f32) =
@@ -553,7 +538,7 @@ when isMainModule:
       for i in 0 ..< 16:
         for j in 0 ..< 16:
           AB[i][j] = 123.0'f32
-      gemm_ukernel_sme(
+      gemmUkernelSme(
         cast[ptr UncheckedArray[float32]](addr packA[0]),
         cast[ptr UncheckedArray[float32]](addr packB[0]),
         AB, 0)
@@ -570,7 +555,7 @@ when isMainModule:
       for i in 0 ..< 32:
         for j in 0 ..< 32:
           AB[i][j] = 123.0'f32
-      gemm_ukernel_sme(
+      gemmUkernelSme(
         cast[ptr UncheckedArray[float32]](addr packA[0]),
         cast[ptr UncheckedArray[float32]](addr packB[0]),
         AB, 0)
@@ -590,7 +575,7 @@ when isMainModule:
       for i in 0 ..< C.len:
         C[i] = rand(1.0'f32)
         Cref[i] = C[i]
-      sme_gemm_ukernel_32x32_epi_dv(addr packA[0], addr packB[0], addr C[0],
+      smeGemmUkernel32x32EpiDv(addr packA[0], addr packB[0], addr C[0],
         cint(32), cint(0), 1.0'f32, 2.0'f32, 0, 1, 0, 0)  # kc=0, beta=2
       for i in 0 ..< C.len:
         doAssert abs(C[i] - 2.0'f32 * Cref[i]) < 1e-6, "fused kc=0 must yield beta*C"
@@ -753,7 +738,7 @@ when isMainModule:
       for i in 0 ..< C.len:
         C[i] = rand(1.0'f32)
         Cref[i] = C[i] + (if ((i div 32 + i mod 32) mod 2) == 0: 1.0'f32 else: 0.0'f32)
-      neon_epilogue_f32_32x32(addr C[0], cint(32), addr AB[0][0],
+      neonEpilogueF3232x32(addr C[0], cint(32), addr AB[0][0],
         1.0'f32, 1.0'f32, 1, 1, 0, 1)
       for i in 0 ..< C.len:
         doAssert abs(C[i] - Cref[i]) < 1e-6, "NEON epilogue ReLU mismatch (got " & $C[i] & ")"

--- a/workspace/ceramic/examples/ex02a_matmul_handtuned_arm64_sme2.nim
+++ b/workspace/ceramic/examples/ex02a_matmul_handtuned_arm64_sme2.nim
@@ -213,6 +213,8 @@ proc gemm_strided*[T: SomeNumber](
         for k in 0 ..< K:
           acc += A[i * rowStrideA + k * colStrideA] * B[k * rowStrideB + j * colStrideB]
         let ci = i * rowStrideC + j * colStrideC
+        if activation == akReLU:
+          acc = max(acc, T(0))
         C[ci] = if beta == T(0): alpha * acc
                 else: beta * C[ci] + alpha * acc
     return
@@ -223,6 +225,9 @@ proc gemm_strided*[T: SomeNumber](
   let num_ir = mc div mr
   let num_ic = ceil_div(M, mc)
   let num_pc = ceil_div(K, kc)
+  doAssert activation == akIdentity or num_pc == 1,
+    "gemm_strided: activation is applied per k-block; K must fit one kc block (K=" &
+    $K & ", kc=" & $kc & ")"
 
   # ── Matrix views ──
   let vA = make_view(A, (M, K), (rowStrideA, colStrideA))

--- a/workspace/cpuplatforms/arm/macro_assembler_arm64.nim
+++ b/workspace/cpuplatforms/arm/macro_assembler_arm64.nim
@@ -126,6 +126,11 @@ func memPost*(base: XReg, imm: int): MemAddr =
   ## Post-indexed memory operand `[base], #imm`.
   MemAddr(base: base, kind: mkPostIndex, imm: imm)
 
+func memStep*(base: XReg, imm: int): MemAddr =
+  ## Memory operand for a vector load at `imm` vector lengths: `[base]`
+  ## when `imm == 0`, `[base, #imm, MUL VL]` otherwise.
+  if imm == 0: mem(base) else: memVL(base, imm)
+
 func `$`*(t: ZaTile): string = t.name & "." & t.shape
 func `$`*(s: ZaSlice): string =
   result = s.name & "." & s.shape & "[" & s.idx & ", " & $s.off
@@ -291,9 +296,9 @@ proc ld1w2*(a: var AssemblerSME, zt1, xn, rm: int) =
   a.inst 0xa1000000 or (rm shl 16) or (17 shl 10) or (xn shl 5) or zt1
 
 proc incw*(a: var AssemblerSME, xn: int) =
-  ## `incw xn, ALL, MUL #2` as a raw word: `.inst 0x04b1e3f0 | Xn`.
+  ## `incw xn, ALL, MUL #2` as a raw word: `.inst 0x04b1e3e0 | Xn`.
   ## Increments a vector counter by 32 elements (two 64-B vectors).
-  a.inst 0x04b1e3f0 or xn
+  a.inst 0x04b1e3e0 or xn
 
 # Instructions
 # -----------------------------------------------------------------------------
@@ -324,8 +329,8 @@ proc mov*(a: var AssemblerSME, dst: ZReg, shape: string, imm: int) =
 
 proc mov*(a: var AssemblerSME, dst: ZRange, src: ZaSlice) =
   ## SME2 tile-slice read into vectors: `mov <dst>, <src>`.
-  ## On M4 a `.h` column group of a `.s` tile holds one output row, which is
-  ## what makes the transposed-tile extract work.
+  ## Multi-vector `.h` slices pair tile N with tile N+2, the same
+  ## M4-verified delivery as the `mova` reads.
   a.code.add "mov " & $dst & ", " & $src & '\n'
 
 proc add*(a: var AssemblerSME, dst: XReg or WReg, src: XReg or WReg, imm: int) =
@@ -423,17 +428,21 @@ proc st1w*(a: var AssemblerSME, slice: ZaSlice, pr: PReg, mem: MemAddr) =
 
 proc fmopa*(a: var AssemblerSME, tile: ZaTile, pg1, pg2: PReg, zn, zm: ZReg) =
   ## Fused outer-product accumulate: `fmopa <tile>, <pg1>/m, <pg2>/m, <zn>.s, <zm>.s`.
-  ## M4 computes `ZA[i][j] += Y[i] * X[j]` for operands `(X, Y)`,
-  ## transposed vs the ARM-doc convention.
-  ## AB-store kernels pass (B, A). The epi kernel passes (A, B), whose
-  ## transposed tile feeds the column-wise mova extract.
+  ## Computes `ZA[i][j] += Zn[i] * Zm[j]` (ARM-doc semantics, M4-verified:
+  ## first operand contributes rows, second columns).
+  ## AB-store kernels pass `(B, A)`, which transposes the accumulator.
+  ## Epi kernels pass `(A, B)` for an untransposed one.
   ## Swapping the order silently transposes every tile, detectable only with asymmetric data.
   a.code.add "fmopa " & $tile & ", " & $pg1 & "/m, " & $pg2 & "/m, " & $zn & ".s, " & $zm & ".s" & '\n'
 
 proc mova*(a: var AssemblerSME, zrng: ZRange, slice: ZaSlice) =
   ## SME2 tile-slice read to vectors: `mova <zrng>, <slice>`.
-  ## `slice` is a column group (`zaNh.h[w12, 0:3]`). On M4 a `.h` column
-  ## of a `.s` tile holds one output row, which is the transposed-tile extract.
+  ## `slice` is a horizontal slice group (`zaNh.h[w12, 0:3]`). M4-verified
+  ## delivery: vectors 0/2 carry rows of the named tile, vectors 1/3 the
+  ## same rows of the tile two above it (`za0h.h[w12, 0:3]` yields
+  ## `za0 row w12/2, za2 row w12/2, za0 row w12/2+1, za2 row w12/2+1`).
+  ## The epi extract uses this pairing to fetch one output row's left and
+  ## right halves (za0/za2 for `za0h`, za1/za3 for `za1h`).
   a.code.add "mova " & $zrng & ", " & $slice & '\n'
 
 proc mova*(a: var AssemblerSME, slice: ZaSlice, zrng: ZRange) =

--- a/workspace/cpuplatforms/arm/macro_assembler_arm64.nim
+++ b/workspace/cpuplatforms/arm/macro_assembler_arm64.nim
@@ -158,6 +158,9 @@ func `$`*(m: MemAddr): string =
 proc addOperand(a: var AssemblerSME, op: AsmOperand) =
   for existing in a.inputs:
     if existing.asmId == op.asmId:
+      if existing.nimSymbol.repr != op.nimSymbol.repr:
+        raise newException(ValueError,
+          "conflicting binding for asm operand " & op.asmId)
       return
   a.inputs.add op
 

--- a/workspace/cpuplatforms/arm/macro_assembler_arm64.nim
+++ b/workspace/cpuplatforms/arm/macro_assembler_arm64.nim
@@ -1,0 +1,514 @@
+## Compile-time macro assembler for SVE/SME inline asm on Apple M4 (arm64).
+##
+## Record instructions and operand bindings, then `generate()` emits one
+## `{.emit: "asm volatile(...)".}` pragma with the operand and clobber lists
+## built from the recorded state. Operand bindings embed the Nim symbol nodes
+## in the emit, so the C backend renders the real (mangled) C names.
+##
+## Register namespace: `x(n)`/`w(n)` general-purpose, `z(n)` SVE vectors,
+## `p(n)` predicates, `pn(n)` predicate-as-counter, `v(n)` NEON vectors,
+## `zaTile(n, shape)` ZA accumulators, `zaSlice(name, shape, idx, off, hi)`
+## ZA tile slices.
+##
+## Apple clang rejects the textual SME2 multi-vector forms. Those instructions
+## are emitted as `.inst` words by `smstart`, `smstop`, `zeroZa0`, `zeroZad`,
+## `ptruePn9B`, `ld1w2`, and `incw`. M4 word formulas live in the doc
+## comments of those procs. Clobber lists are explicit per kernel: `clobberZ`,
+## `clobberP`, `clobberV`, plus named registers, `cc`, and `memory`.
+
+import std/[macros, strutils]
+
+type
+  XReg* = distinct int  ## 64-bit general-purpose register, `x0`..`x30`.
+  WReg* = distinct int  ## 32-bit view of a general-purpose register, `w0`..`w30`.
+  ZReg* = distinct int  ## SVE vector register, `z0`..`z31`.
+  PReg* = distinct int  ## SVE predicate register, `p0`..`p15`.
+  PNReg* = distinct int ## SME2 predicate-as-counter register, `pn0`..`pn15`.
+  VReg* = distinct int  ## NEON vector register, `v0`..`v31`.
+
+  ZaTile* = object
+    ## ZA accumulator reference: `zaN.<shape>` (the `fmopa` target).
+    name: string
+    shape: string
+
+  ZaSlice* = object
+    ## ZA tile slice: `zaN<o>.<shape>[wM, off]` single or `[wM, lo:hi]` range.
+    ## `name` carries the orientation suffix (`za0v`, `za0h`, `za1h`).
+    name: string
+    shape: string
+    idx: string
+    off: int
+    rangeHi: int
+
+  ZRange* = object
+    ## SVE vector range: `{zN.<shape>-zM.<shape>}`.
+    lo: ZReg
+    hi: ZReg
+    shape: string
+
+  VList* = object
+    ## NEON consecutive-vector list: `{vN.<shape>, ..., vM.<shape>}`.
+    lo: VReg
+    hi: VReg
+    shape: string
+
+  MemKind = enum
+    mkBase
+    mkMulVL
+    mkPostIndex
+
+  MemAddr* = object
+    ## Memory operand: `[xN]`, `[xN, #imm, MUL VL]`, or post-index `[xN], #imm`.
+    base: XReg
+    kind: MemKind
+    imm: int
+
+  AsmOperand* = object
+    ## Named asm operand: rendered in text as `%[id]`/`%w[id]`/`%x[id]`,
+    ## bound in the constraint list as `[id] "r"(<C expr>)`.
+    asmId: string
+    nimSymbol: NimNode
+    prefix: string
+    suffix: string
+
+  AssemblerSME* = object
+    ## Compile-time assembler state: instruction text plus operand and clobber lists.
+    code: string
+    inputs: seq[AsmOperand]
+    clobbers: seq[string]
+
+func init*(T: type AssemblerSME): AssemblerSME = discard
+
+# Register constructors and rendering
+# -----------------------------------------------------------------------------
+
+func x*(n: int): XReg = XReg(n)
+func w*(n: int): WReg = WReg(n)
+func z*(n: int): ZReg = ZReg(n)
+func p*(n: int): PReg = PReg(n)
+func pn*(n: int): PNReg = PNReg(n)
+func v*(n: int): VReg = VReg(n)
+
+func `$`*(r: XReg): string = "x" & $int(r)
+func `$`*(r: WReg): string = "w" & $int(r)
+func `$`*(r: ZReg): string = "z" & $int(r)
+func `$`*(r: PReg): string = "p" & $int(r)
+func `$`*(r: PNReg): string = "pn" & $int(r)
+func `$`*(r: VReg): string = "v" & $int(r)
+
+func zaTile*(n: int, shape: string): ZaTile =
+  ## ZA accumulator `zaN.<shape>` (n in 0..3 on M4's 4-tile file).
+  ZaTile(name: "za" & $n, shape: shape)
+
+func zaSlice*(name, shape, idx: string, off: int, rangeHi = -1): ZaSlice =
+  ## ZA tile slice: `name.shape[idx, off]` or `name.shape[idx, off:rangeHi]`.
+  ## `name` is the full tile prefix (`za0v`, `za0h`, `za1h`), `idx` a w
+  ## register (`w13`, `w12`), `rangeHi` -1 for a single-element slice.
+  ZaSlice(name: name, shape: shape, idx: idx, off: off, rangeHi: rangeHi)
+
+func zrng*(lo, hi: int, shape: string): ZRange =
+  ## SVE vector range `{zN.<shape>-zM.<shape>}` (M4 SME2 mova/fclamp forms).
+  ZRange(lo: z(lo), hi: z(hi), shape: shape)
+
+func vlist*(lo, hi: int, shape: string): VList =
+  ## NEON vector list `{vN.<shape>, ..., vM.<shape>}`, consecutive registers.
+  VList(lo: v(lo), hi: v(hi), shape: shape)
+
+func mem*(base: XReg): MemAddr =
+  ## Memory operand `[base]`.
+  MemAddr(base: base, kind: mkBase)
+
+func memVL*(base: XReg, imm: int): MemAddr =
+  ## Memory operand `[base, #imm, MUL VL]` (imm in -8..7 vector lengths).
+  MemAddr(base: base, kind: mkMulVL, imm: imm)
+
+func memPost*(base: XReg, imm: int): MemAddr =
+  ## Post-indexed memory operand `[base], #imm`.
+  MemAddr(base: base, kind: mkPostIndex, imm: imm)
+
+func `$`*(t: ZaTile): string = t.name & "." & t.shape
+func `$`*(s: ZaSlice): string =
+  result = s.name & "." & s.shape & "[" & s.idx & ", " & $s.off
+  if s.rangeHi >= 0:
+    result.add ":" & $s.rangeHi
+  result.add "]"
+func `$`*(r: ZRange): string =
+  "{" & $r.lo & "." & r.shape & "-" & $r.hi & "." & r.shape & "}"
+func `$`*(l: VList): string =
+  result = "{"
+  for n in int(l.lo) .. int(l.hi):
+    if n > int(l.lo):
+      result.add ", "
+    result.add "v" & $n & "." & l.shape
+  result.add "}"
+func `$`*(m: MemAddr): string =
+  case m.kind
+  of mkBase:     "[" & $m.base & "]"
+  of mkMulVL:    "[" & $m.base & ", #" & $m.imm & ", MUL VL]"
+  of mkPostIndex: "[" & $m.base & "], #" & $m.imm
+
+# Operand bindings
+# -----------------------------------------------------------------------------
+
+proc addOperand(a: var AssemblerSME, op: AsmOperand) =
+  for existing in a.inputs:
+    if existing.asmId == op.asmId:
+      return
+  a.inputs.add op
+
+proc input*(a: var AssemblerSME, id: string, sym: NimNode): AsmOperand =
+  ## Binds `[id] "r"(sym)` for a pointer or 64-bit value.
+  result = AsmOperand(
+    asmId: id, nimSymbol: sym,
+    prefix: "[" & id & "] \"r\"(", suffix: ")")
+  a.addOperand result
+
+proc inputLong*(a: var AssemblerSME, id: string, sym: NimNode): AsmOperand =
+  ## Binds `[id] "r"((long)sym)`. Aarch64 `"r"` is a 64-bit register,
+  ## so a 32-bit `cint` value needs the widening cast to match the original
+  ## kernels' operand text.
+  result = AsmOperand(
+    asmId: id, nimSymbol: sym,
+    prefix: "[" & id & "] \"r\"((long)", suffix: ")")
+  a.addOperand result
+
+proc inputLongParen*(a: var AssemblerSME, id: string, sym: NimNode): AsmOperand =
+  ## Binds `[id] "r"((long)(sym))` for a 32-bit value whose Nim source already
+  ## uses parentheses (the alpha/beta bit patterns).
+  result = AsmOperand(
+    asmId: id, nimSymbol: sym,
+    prefix: "[" & id & "] \"r\"((long)(", suffix: "))")
+  a.addOperand result
+
+proc inputLit*(a: var AssemblerSME, id: string, value: int64): AsmOperand =
+  ## Binds `[id] "r"(value)` for a compile-time literal (the ReLU +inf word).
+  result = AsmOperand(
+    asmId: id, nimSymbol: newLit(value),
+    prefix: "[" & id & "] \"r\"(", suffix: ")")
+  a.addOperand result
+
+func view*(op: AsmOperand): string = "%[" & op.asmId & "]"
+func wview*(op: AsmOperand): string = "%w[" & op.asmId & "]"
+func xview*(op: AsmOperand): string = "%x[" & op.asmId & "]"
+
+# Clobber tracking
+# -----------------------------------------------------------------------------
+
+proc clobber*(a: var AssemblerSME, regs: varargs[string]) =
+  ## Records registers for the clobber list, preserving call order.
+  for r in regs:
+    if r notin a.clobbers:
+      a.clobbers.add r
+
+proc clobberZ*(a: var AssemblerSME) =
+  ## Clobbers `z0`..`z31` (smstart zeroes the Z/V register file on M4).
+  for i in 0 .. 31:
+    a.clobber "z" & $i
+
+proc clobberP*(a: var AssemblerSME) =
+  ## Clobbers `p0`..`p15`.
+  for i in 0 .. 15:
+    a.clobber "p" & $i
+
+proc clobberV*(a: var AssemblerSME) =
+  ## Clobbers `v0`..`v31` (the NEON register file, low halves of z0..z31).
+  for i in 0 .. 31:
+    a.clobber "v" & $i
+
+proc clobberCC*(a: var AssemblerSME) =
+  ## Clobbers the condition flags.
+  a.clobber "cc"
+
+proc clobberMemory*(a: var AssemblerSME) =
+  ## Clobbers memory (the kernels read and write through raw pointers).
+  a.clobber "memory"
+
+func generate*(a: AssemblerSME): NimNode =
+  ## Returns the `{.emit: ...}` pragma for the recorded code.
+  ## String fragments and Nim symbol nodes are concatenated inside the emit,
+  ## so the C backend renders each symbol's real C name.
+  var frags: seq[NimNode]
+  var body = "\nasm volatile(\n"
+  for line in a.code.split('\n'):
+    if line.len > 0:
+      body.add "    \"" & line & "\\n\"\n"
+  body.add "    :\n    : "
+  frags.add newLit(body)
+  for i, op in a.inputs:
+    if i > 0:
+      frags.add newLit(", ")
+    frags.add newLit(op.prefix)
+    frags.add op.nimSymbol
+    frags.add newLit(op.suffix)
+  var tail = "\n    : "
+  for i, c in a.clobbers:
+    if i > 0:
+      tail.add ", "
+    tail.add "\"" & c & "\""
+  tail.add "\n);"
+  frags.add newLit(tail)
+  result = nnkPragma.newTree(
+    nnkExprColonExpr.newTree(ident"emit", nnkBracket.newTree(frags)))
+  result = nnkBlockStmt.newTree(newEmptyNode(), result)
+
+# Raw words and SME2 escape hatch
+# -----------------------------------------------------------------------------
+
+proc inst*(a: var AssemblerSME, word: int) =
+  ## Raw instruction word: `.inst 0x%08x`.
+  ## Escape hatch for SME2-only instructions Apple clang rejects textually.
+  a.code.add ".inst 0x" & toHex(word, 8).toLowerAscii & '\n'
+
+proc smstart*(a: var AssemblerSME) =
+  ## `smstart` as a raw word: `.inst 0xd503477f`.
+  ## Full form on M4 (streaming + ZA). It zeroes the Z/V register file,
+  ## whose NEON v-registers are the low 128 bits of the SVE z-registers.
+  ## Kernels inside the bracket must clobber all z and p registers.
+  a.inst 0xd503477f
+
+proc smstop*(a: var AssemblerSME) =
+  ## `smstop` as a raw word: `.inst 0xd503467f`.
+  a.inst 0xd503467f
+
+proc zeroZa0*(a: var AssemblerSME) =
+  ## `zero {za0.s}` as a raw word: `.inst 0xc0080001` (single-tile kernels).
+  a.inst 0xc0080001
+
+proc zeroZad*(a: var AssemblerSME) =
+  ## `zero {zad0..zad7}` as a raw word: `.inst 0xc00800ff`. Clears ZA0..ZA3.
+  a.inst 0xc00800ff
+
+proc ptruePn9B*(a: var AssemblerSME) =
+  ## `ptrue pn9.b` as a raw word: `.inst 0x25207811` (SME2 predicate-as-counter).
+  a.inst 0x25207811
+
+proc ld1w2*(a: var AssemblerSME, zt1, xn, rm: int) =
+  ## SME2 dual-vector load `ld1w {zt1, zt1+8}, pn9.b/Z, [xn, rm, LSL #2]`
+  ## as a raw word. Word formula: `0xa1000000 | (Rm << 16) | (17 << 10)
+  ## | (Xn << 5) | Zt1`. Second vector is implied Zt1 + 8.
+  ## Apple clang rejects the textual form, so this raw word is the only
+  ## rendering of the instruction.
+  a.inst 0xa1000000 or (rm shl 16) or (17 shl 10) or (xn shl 5) or zt1
+
+proc incw*(a: var AssemblerSME, xn: int) =
+  ## `incw xn, ALL, MUL #2` as a raw word: `.inst 0x04b1e3f0 | Xn`.
+  ## Increments a vector counter by 32 elements (two 64-B vectors).
+  a.inst 0x04b1e3f0 or xn
+
+# Instructions
+# -----------------------------------------------------------------------------
+
+proc ptrue*(a: var AssemblerSME, pr: PReg, shape: string) =
+  ## Predicate-true: `ptrue <pr>.<shape>`, shape "s" (32-bit lanes) or "b".
+  a.code.add "ptrue " & $pr & "." & shape & '\n'
+
+proc label*(a: var AssemblerSME, name: string) =
+  ## Local numeric label: `<name>:`. Branch targets append `b` (backward)
+  ## or `f` (forward) to the same name.
+  a.code.add name & ":\n"
+
+proc mov*(a: var AssemblerSME, dst: XReg or WReg, src: string) =
+  ## Move into a GPR: `mov <dst>, <src>`, where `src` is a rendered
+  ## operand view (`%[pa]`, `%w[kc]`) or an immediate (`#0`).
+  a.code.add "mov " & $dst & ", " & src & '\n'
+
+proc mov*(a: var AssemblerSME, dst: XReg or WReg, src: XReg or WReg) =
+  ## Move between GPRs: `mov <dst>, <src>`.
+  a.code.add "mov " & $dst & ", " & $src & '\n'
+
+proc mov*(a: var AssemblerSME, dst: ZReg, shape: string, imm: int) =
+  ## SVE vector immediate move: `mov <dst>.<shape>, #<imm>`
+  ## (the zeroing form, e.g. `mov z4.s, #0`. SVE `movi` is not accepted
+  ## by Apple clang).
+  a.code.add "mov " & $dst & "." & shape & ", #" & $imm & '\n'
+
+proc mov*(a: var AssemblerSME, dst: ZRange, src: ZaSlice) =
+  ## SME2 tile-slice read into vectors: `mov <dst>, <src>`.
+  ## On M4 a `.h` column group of a `.s` tile holds one output row, which is
+  ## what makes the transposed-tile extract work.
+  a.code.add "mov " & $dst & ", " & $src & '\n'
+
+proc add*(a: var AssemblerSME, dst: XReg or WReg, src: XReg or WReg, imm: int) =
+  ## Add immediate: `add <dst>, <src>, #<imm>`.
+  a.code.add "add " & $dst & ", " & $src & ", #" & $imm & '\n'
+
+proc add*(a: var AssemblerSME, dst: XReg, src: XReg, rhs: XReg) =
+  ## Add registers: `add <dst>, <src>, <rhs>`.
+  a.code.add "add " & $dst & ", " & $src & ", " & $rhs & '\n'
+
+proc addLsl*(a: var AssemblerSME, dst: XReg, src: XReg, rhs: XReg, shift: int) =
+  ## Add with shifted register: `add <dst>, <src>, <rhs>, LSL #<shift>`.
+  a.code.add "add " & $dst & ", " & $src & ", " & $rhs & ", LSL #" & $shift & '\n'
+
+proc addvl*(a: var AssemblerSME, dst: XReg, src: XReg, imm: int) =
+  ## Add vector length: `addvl <dst>, <src>, #<imm>` (imm in -32..31).
+  a.code.add "addvl " & $dst & ", " & $src & ", #" & $imm & '\n'
+
+proc sub*(a: var AssemblerSME, dst: XReg or WReg, src: XReg or WReg, imm: int) =
+  ## Subtract immediate: `sub <dst>, <src>, #<imm>`.
+  a.code.add "sub " & $dst & ", " & $src & ", #" & $imm & '\n'
+
+proc sub*(a: var AssemblerSME, dst: XReg, src: XReg, rhs: XReg) =
+  ## Subtract registers: `sub <dst>, <src>, <rhs>`.
+  a.code.add "sub " & $dst & ", " & $src & ", " & $rhs & '\n'
+
+proc subs*(a: var AssemblerSME, dst: WReg, src: WReg, imm: int) =
+  ## Subtract immediate setting flags: `subs <dst>, <src>, #<imm>`
+  ## (the k-loop counter decrement feeding `b.ne`).
+  a.code.add "subs " & $dst & ", " & $src & ", #" & $imm & '\n'
+
+proc lsr*(a: var AssemblerSME, dst: WReg, src: WReg, imm: int) =
+  ## Logical shift right immediate: `lsr <dst>, <src>, #<imm>`.
+  a.code.add "lsr " & $dst & ", " & $src & ", #" & $imm & '\n'
+
+proc lsl*(a: var AssemblerSME, dst: XReg, src: string, imm: int) =
+  ## Logical shift left immediate: `lsl <dst>, <src>, #<imm>`, where `src`
+  ## is an operand view (`%x[cs]`).
+  a.code.add "lsl " & $dst & ", " & src & ", #" & $imm & '\n'
+
+proc `and`*(a: var AssemblerSME, dst: WReg, src: WReg, imm: int) =
+  ## Bitwise and immediate: `and <dst>, <src>, #<imm>`.
+  a.code.add "and " & $dst & ", " & $src & ", #" & $imm & '\n'
+
+proc cmp*(a: var AssemblerSME, reg: WReg, imm: int) =
+  ## Compare immediate setting flags: `cmp <reg>, #<imm>`
+  ## (feeds the `b.lt`/`b.ne` pack branch guards).
+  a.code.add "cmp " & $reg & ", #" & $imm & '\n'
+
+proc cbz*(a: var AssemblerSME, reg: WReg, target: string) =
+  ## Compare and branch if zero: `cbz <reg>, <target>`.
+  a.code.add "cbz " & $reg & ", " & target & '\n'
+
+proc cbz*(a: var AssemblerSME, reg: string, target: string) =
+  ## Compare and branch if zero on a rendered operand view: `cbz <reg>, <target>`.
+  a.code.add "cbz " & reg & ", " & target & '\n'
+
+proc cbnz*(a: var AssemblerSME, reg: WReg, target: string) =
+  ## Compare and branch if nonzero: `cbnz <reg>, <target>`.
+  a.code.add "cbnz " & $reg & ", " & target & '\n'
+
+proc cbnz*(a: var AssemblerSME, reg: string, target: string) =
+  ## Compare and branch if nonzero on a rendered operand view: `cbnz <reg>, <target>`.
+  a.code.add "cbnz " & reg & ", " & target & '\n'
+
+proc bne*(a: var AssemblerSME, target: string) =
+  ## Branch if not equal: `b.ne <target>` (the k-loop back edge after `subs`).
+  a.code.add "b.ne " & target & '\n'
+
+proc blt*(a: var AssemblerSME, target: string) =
+  ## Branch if less than: `b.lt <target>` (the pack partial-row skip).
+  a.code.add "b.lt " & target & '\n'
+
+proc b*(a: var AssemblerSME, target: string) =
+  ## Unconditional branch: `b <target>`.
+  a.code.add "b " & target & '\n'
+
+proc ld1w*(a: var AssemblerSME, zr: ZReg, shape: string, pr: PReg, mem: MemAddr) =
+  ## Predicated single-vector load: `ld1w {<zr>.<shape>}, <pr>/z, <mem>`.
+  a.code.add "ld1w {" & $zr & "." & shape & "}, " & $pr & "/z, " & $mem & '\n'
+
+proc st1w*(a: var AssemblerSME, zr: ZReg, shape: string, pr: PReg, mem: MemAddr) =
+  ## Streaming single-vector store: `st1w {<zr>.<shape>}, <pr>, <mem>`.
+  ## Apple clang rejects the `/z` and `/m` suffixes on the store predicate,
+  ## so the store form takes a bare predicate.
+  a.code.add "st1w {" & $zr & "." & shape & "}, " & $pr & ", " & $mem & '\n'
+
+proc st1w*(a: var AssemblerSME, slice: ZaSlice, pr: PReg, mem: MemAddr) =
+  ## Tile-slice store: `st1w {<slice>}, <pr>, <mem>`.
+  ## Index register needs the explicit `, 0` offset field. Bare `[wN]`
+  ## form is rejected by Apple clang. M4 accepts a 2-entry source-
+  ## address tracker only, so kernels must not alternate more than two base
+  ## registers between consecutive tile-slice stores.
+  a.code.add "st1w {" & $slice & "}, " & $pr & ", " & $mem & '\n'
+
+proc fmopa*(a: var AssemblerSME, tile: ZaTile, pg1, pg2: PReg, zn, zm: ZReg) =
+  ## Fused outer-product accumulate: `fmopa <tile>, <pg1>/m, <pg2>/m, <zn>.s, <zm>.s`.
+  ## M4 computes `ZA[i][j] += Y[i] * X[j]` for operands `(X, Y)`,
+  ## transposed vs the ARM-doc convention.
+  ## AB-store kernels pass (B, A). The epi kernel passes (A, B), whose
+  ## transposed tile feeds the column-wise mova extract.
+  ## Swapping the order silently transposes every tile, detectable only with asymmetric data.
+  a.code.add "fmopa " & $tile & ", " & $pg1 & "/m, " & $pg2 & "/m, " & $zn & ".s, " & $zm & ".s" & '\n'
+
+proc mova*(a: var AssemblerSME, zrng: ZRange, slice: ZaSlice) =
+  ## SME2 tile-slice read to vectors: `mova <zrng>, <slice>`.
+  ## `slice` is a column group (`zaNh.h[w12, 0:3]`). On M4 a `.h` column
+  ## of a `.s` tile holds one output row, which is the transposed-tile extract.
+  a.code.add "mova " & $zrng & ", " & $slice & '\n'
+
+proc mova*(a: var AssemblerSME, slice: ZaSlice, zrng: ZRange) =
+  ## SME2 vector-to-tile write: `mova <slice>, <zrng>`.
+  ## Column-group form (`zaNh.s[w12, 0:3]`, w12 in {0, 4, 8, 12}), used for
+  ## the A-transpose pack: z-to-tile rows, then the tile-to-z read
+  ## transposes.
+  a.code.add "mova " & $slice & ", " & $zrng & '\n'
+
+proc fmul*(a: var AssemblerSME, zd: ZReg, shape: string, pr: PReg, zn, zm: ZReg) =
+  ## Predicated SVE multiply: `fmul <zd>.<shape>, <pr>/m, <zn>.<shape>, <zm>.<shape>`.
+  a.code.add "fmul " & $zd & "." & shape & ", " & $pr & "/m, " & $zn & "." & shape & ", " & $zm & "." & shape & '\n'
+
+proc fmul*(a: var AssemblerSME, vd: VReg, shape: string, vn, vm: VReg) =
+  ## NEON multiply: `fmul <vd>.<shape>, <vn>.<shape>, <vm>.<shape>`.
+  a.code.add "fmul " & $vd & "." & shape & ", " & $vn & "." & shape & ", " & $vm & "." & shape & '\n'
+
+proc fadd*(a: var AssemblerSME, zd: ZReg, shape: string, pr: PReg, zn, zm: ZReg) =
+  ## Predicated SVE add: `fadd <zd>.<shape>, <pr>/m, <zn>.<shape>, <zm>.<shape>`.
+  a.code.add "fadd " & $zd & "." & shape & ", " & $pr & "/m, " & $zn & "." & shape & ", " & $zm & "." & shape & '\n'
+
+proc fadd*(a: var AssemblerSME, vd: VReg, shape: string, vn, vm: VReg) =
+  ## NEON add: `fadd <vd>.<shape>, <vn>.<shape>, <vm>.<shape>`.
+  a.code.add "fadd " & $vd & "." & shape & ", " & $vn & "." & shape & ", " & $vm & "." & shape & '\n'
+
+proc fmax*(a: var AssemblerSME, vd: VReg, shape: string, vn, vm: VReg) =
+  ## NEON maximum: `fmax <vd>.<shape>, <vn>.<shape>, <vm>.<shape>`.
+  ## NaN propagates through the NEON `fmax`, unlike the SVE `fclamp` ReLU
+  ## which maps NaN to 0.
+  a.code.add "fmax " & $vd & "." & shape & ", " & $vn & "." & shape & ", " & $vm & "." & shape & '\n'
+
+proc fclamp*(a: var AssemblerSME, zrng: ZRange, zmin, zmax: ZReg) =
+  ## SVE clamp: `fclamp <zrng>, <zmin>.s, <zmax>.s`.
+  ## M4: `fclamp(NaN)` yields the min operand. The ReLU form with zmin = 0
+  ## and zmax = +inf maps NaN to 0 like the scalar epilogue.
+  a.code.add "fclamp " & $zrng & ", " & $zmin & ".s, " & $zmax & ".s" & '\n'
+
+proc dup*(a: var AssemblerSME, zr: ZReg, shape: string, src: string) =
+  ## SVE broadcast from a GPR: `dup <zr>.<shape>, <src>`, where `src` is
+  ## an operand view (`%w[abits]`).
+  a.code.add "dup " & $zr & "." & shape & ", " & src & '\n'
+
+proc dup*(a: var AssemblerSME, vr: VReg, shape: string, src: string) =
+  ## NEON broadcast from a GPR: `dup <vr>.<shape>, <src>`.
+  a.code.add "dup " & $vr & "." & shape & ", " & src & '\n'
+
+proc movi*(a: var AssemblerSME, vr: VReg, shape: string, imm: int) =
+  ## NEON immediate move: `movi <vr>.<shape>, #<imm>` (the zeroing form).
+  a.code.add "movi " & $vr & "." & shape & ", #" & $imm & '\n'
+
+proc ld1*(a: var AssemblerSME, vl: VList, mem: MemAddr) =
+  ## NEON multi-vector load: `ld1 <vl>, <mem>`, post-indexed form only
+  ## (Apple clang rejects plain `[xN, #imm]` offsets for 4-register ld1).
+  a.code.add "ld1 " & $vl & ", " & $mem & '\n'
+
+proc st1*(a: var AssemblerSME, vl: VList, mem: MemAddr) =
+  ## NEON multi-vector store: `st1 <vl>, <mem>`, post-indexed form only.
+  a.code.add "st1 " & $vl & ", " & $mem & '\n'
+
+proc stp*(a: var AssemblerSME, vd1, vd2: VReg, base: XReg, imm = 0) =
+  ## NEON register-pair store: `stp q<vd1>, q<vd2>, [<base>]`,
+  ## plus `[<base>, #<imm>]` when `imm != 0`. Renders the `q` (128-bit) register names.
+  ## `imm` is a plain byte offset, not
+  ## a `MUL VL` step. Operand is a base register plus immediate,
+  ## not a `MemAddr`.
+  a.code.add "stp q" & $int(vd1) & ", q" & $int(vd2) & ", [" & $base
+  if imm != 0:
+    a.code.add ", #" & $imm
+  a.code.add "]\n"
+
+proc trn1*(a: var AssemblerSME, vd: VReg, shape: string, vn, vm: VReg) =
+  ## NEON transpose, first result: `trn1 <vd>.<shape>, <vn>.<shape>, <vm>.<shape>`.
+  ## Half of the 8×8 transpose network used by the A-pack.
+  a.code.add "trn1 " & $vd & "." & shape & ", " & $vn & "." & shape & ", " & $vm & "." & shape & '\n'
+
+proc trn2*(a: var AssemblerSME, vd: VReg, shape: string, vn, vm: VReg) =
+  ## NEON transpose, second result: `trn2 <vd>.<shape>, <vn>.<shape>, <vm>.<shape>`.
+  a.code.add "trn2 " & $vd & "." & shape & ", " & $vn & "." & shape & ", " & $vm & "." & shape & '\n'


### PR DESCRIPTION
This adds a handtuned GEMM within 2% of the perf of Apple Accelerate on a Apple M4 Max CPU.

Note: single-threaded only. There is 1 SME per cluster of CPUs, on a M4 Max there are 2 P-core clusters + an E-core cluster, unsure if the SME on E-core (if any) has the same perf as the P-core's

Perf is 1.7 TFlops.

This uses a compile-time assembler implemented in Nim macro inspired by Constantine's but written for matrix and vector extensions: https://github.com/mratsim/constantine/blob/v0.2.0/constantine/platforms/isa_arm64/macro_assembler_arm64.nim

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added high-performance float32 matrix multiplication for ARM processors with SME2 support, including tiled computation and optimized handling of matrix edges.
  * Added strided and array-based GEMM interfaces with configurable scaling and optional ReLU activation.
  * Added portable fallback execution for systems without SME2 support.
  * Added optimized packing and computation paths for common 16×16 and 32×32 matrix tiles.

* **Tests**
  * Added correctness testing across edge dimensions, scaling, activation, zero-sized operations, and numerical accuracy.
  * Added deterministic fuzz testing for varied matrix shapes and parameter combinations.
  * Added performance benchmarking for 128×128, 256×256, and 512×512 matrices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->