### PR TITLE
Apple Metal simdgroup MMA reintegration.

### DIFF
--- a/workspace/ceramic/src/hardware/h_configgen.nim
+++ b/workspace/ceramic/src/hardware/h_configgen.nim
@@ -17,7 +17,9 @@
 ##   - `type MmaAtom = enum` with one member per atom,
 ##   - one exported const per atom per property: `NAME_m`, `NAME_n`,
 ##     `NAME_k`, `NAME_vpt`, `NAME_threadCount`, `NAME_aLayout`,
-##     `NAME_bLayout`, `NAME_cLayout`, `NAME_instr`.
+##     `NAME_bLayout`, `NAME_cLayout`, `NAME_instr`, plus `NAME_elem`
+##     (the MSL operand element name) for the Apple simdgroup atoms.
+##     Optional keys absent from an atom's declaration default to "".
 ##
 ## Mirrors Constantine's `declareCurves` machinery
 ## (`constantine/named/deriv/parser_fields.nim`): the same AST shape
@@ -63,6 +65,11 @@ const AtomPropKeys* = ["m", "n", "k", "vpt", "threadCount",
   ## The property keys every atom must declare, in declaration order.
   ## The generated const name is `NAME_key`.
 
+const OptionalAtomPropKeys = ["elem"]
+  ## Optional property keys, declared only by the atoms that need them
+  ## (the Apple simdgroup atoms' MSL operand element name). Absent keys
+  ## generate a default const ("" for string keys).
+
 const IntPropKeys = ["m", "n", "k", "vpt", "threadCount"]
   ## The scalar keys whose values must be positive int literals.
 
@@ -97,7 +104,7 @@ proc parseAtomDecls*(defs: var seq[AtomParams]; body: NimNode) =
       let valNode = prop[1]
       valNode.expectKind(nnkStmtList)
       let keyStr = $key
-      doAssert keyStr in AtomPropKeys,
+      doAssert keyStr in AtomPropKeys or keyStr in OptionalAtomPropKeys,
         "declareAtoms: unknown property `" & keyStr & "` on atom `" & $name & "`"
       doAssert keyStr notin seen,
         "declareAtoms: duplicate property `" & keyStr & "` on atom `" & $name & "`"
@@ -115,10 +122,16 @@ proc parseAtomDecls*(defs: var seq[AtomParams]; body: NimNode) =
                  v.strVal.startsWith("mma.sync.aligned."),
           "declareAtoms: invalid instruction `" & v.strVal & "` on atom `" & $name &
           "` (expected \"\", \"simdgroup_multiply_accumulate\", or an mma.sync.aligned.* mnemonic)"
+      elif keyStr == "elem":
+        let v = valNode[0]
+        v.expectKind(nnkStrLit)
+        doAssert v.strVal in ["float", "half", "bfloat"],
+          "declareAtoms: invalid MSL element name `" & v.strVal & "` on atom `" & $name &
+          "` (expected \"float\", \"half\", or \"bfloat\")"
       params.props.add (keyStr, valNode[0])
-    doAssert seen.len == AtomPropKeys.len,
-      "declareAtoms: atom `" & $name & "` declares " & $seen.len &
-      " properties, expected " & $AtomPropKeys.len & " (" & AtomPropKeys.join(", ") & ")"
+    for key in AtomPropKeys:
+      doAssert key in seen,
+        "declareAtoms: atom `" & $name & "` is missing property `" & key & "`"
     defs.add params
 
 proc genAtomDecls(defs: seq[AtomParams]): NimNode =
@@ -127,6 +140,8 @@ proc genAtomDecls(defs: seq[AtomParams]): NimNode =
   ##   const NAME1_m* = 8            (one exported const per atom per property)
   ##         NAME1_n* = 8
   ##         …
+  ## Optional keys an atom does not declare emit a default const
+  ## ("" for the string key `elem`).
   result = newStmtList()
   var fields: seq[NimNode]
   for d in defs:
@@ -138,6 +153,14 @@ proc genAtomDecls(defs: seq[AtomParams]): NimNode =
       result.add newConstStmt(
         nnkPostfix.newTree(ident"*", ident(base & "_" & key)),
         val)
+    for key in OptionalAtomPropKeys:
+      var declared = false
+      for (k, _) in d.props:
+        if k == key: declared = true
+      if not declared:
+        result.add newConstStmt(
+          nnkPostfix.newTree(ident"*", ident(base & "_" & key)),
+          newLit(""))
 
 macro declareAtoms*(body: untyped): untyped =
   ## Parses the YAML-like atom registry block and expands to the enum

--- a/workspace/ceramic/src/hardware/h_mma_dispatch.nim
+++ b/workspace/ceramic/src/hardware/h_mma_dispatch.nim
@@ -7,18 +7,26 @@
 
 import std/[macros, strutils]
 import workspace/crucible
+import ./h_registry
+
+{.experimental: "dynamicBindSym".}
+# bindSym with a computed name (`$atom & "_suffix"`) from a static macro
+# parameter needs this experimental mode (same as h_properties.nim).
 
 ## Register-level MMA dispatch (compile-time string builder / AST emitter).
 ##
 ## Public entries:
-##   - `gemm_mma`: the macro that emits the register-level MMA call — NVIDIA
-##     `mma.sync` asm, or the Apple simdgroup intrinsic on Metal.
+##   - `gemm_mma`: the atom-first register-level MMA macro — the atom's registry
+##     consts (h_configgen) drive everything instruction-level: NVIDIA
+##     `mma.sync` asm, the Apple simdgroup intrinsic on Metal, or the
+##     universal software cross-lane shuffle reduction.
 ##   - `universalMma8x8x8`: the software 8×8×8 cross-lane shuffle reduction,
-##     the universal FMA atoms' device path.
+##     the universal FMA atoms' device path (the `gemm_mma` "universal" case
+##     delegates here).
 ##   - `buildNvidiaMmaAsm`: the asm string for one NVIDIA register-level MMA.
 ##
-# TODO: gemm_mma handles Nvidia asm + Apple simdgroup only; AMD and Intel
-# tensor cores are not implemented yet.
+# TODO: gemm_mma handles Nvidia asm + Apple simdgroup + the universal
+# software reduction; AMD and Intel tensor cores are not implemented yet.
 
 func constraintLetter(elemTypeName: string): string =
   ## Nim DSL register element type → GCC asm constraint letter.
@@ -85,57 +93,31 @@ func buildNvidiaMmaAsm*(instr: string; va, vb, vc: int;
   if not aliased:
     result.add ", " & operandClause(cName, constraintLetter(cElem), vc)
 
-# ═════════════════════════════════════════════════════════════════════════
-#  gemm_mma: one register-level MMA call
-# ═════════════════════════════════════════════════════════════════════════
-
-macro gemm_mma*(instr: static string; dV, aV, bV: static int;
-                dFrag, aFrag, bFrag: untyped): untyped =
-  ## Tensor-core-level Matrix-Multiplication
-  ##
-  ## Args:
-  ##   instr: the mma.sync mnemonic, or "simdgroup_multiply_accumulate"
-  ##     for the Apple simdgroup atoms
-  ##   dV, aV, bV: per-operand register counts (V per thread)
-  ##   dFrag: the accumulator fragment tensor, seeded to the asm output
-  ##     and written back (in-place accumulate)
-  ##   aFrag, bFrag: the operand fragment tensors, read-only
-  ##
-  ## The Apple simdgroup atoms emit a call to the `simdgroupMultiplyAccumulate`
-  ## builtin (the MSL printer maps it to the simdgroup intrinsic); the NVIDIA
-  ## atoms keep the extended-asm path below.
-  ##
-  ## TODO:
-  ##   Hardcoded element types:
-  ##     float32 accumulator
-  ##     uint32 operands (TF32)
-  case instr
-  of "simdgroup_multiply_accumulate":
-    return newCall(ident("simdgroupMultiplyAccumulate"), dFrag, aFrag, bFrag)
-  else:
-    if not instr.startsWith("mma.sync.aligned."):
-      error("gemm_mma: unsupported instruction `" & instr & "`")
-  let dElem = "float32"
-  let aElem = "uint32"
-  let bElem = "uint32"
-  let asmStr = buildNvidiaMmaAsm(instr, aV, bV, dV, "d", "a", "b", "d",
-                                 dElem, aElem, bElem, dElem)
-
-  # scalar register locals, one per fragment element:
-  #   d0..d(dV-1): var float32, seeded from the accumulator, written back after
-  #   a0..a(aV-1), b0..b(bV-1): let uint32, read from the operand tensors
-  result = newStmtList()
+func buildAppleSimdgroupAsm(dElem, aElem, bElem: string; dV, aV, bV: int): string =
+  ## The MSL staging block for one Apple simdgroup MMA:
+  ##   - one braced block per payload — mma_AB unrolls several payloads
+  ##     into the same function scope, so the `simdgroup_*8x8`
+  ##     declarations must not collide
+  ##   - fragments are `make_filled` (uninitialized simdgroup vars trip
+  ##     "used without initialization" diagnostics)
+  ##   - `d0`, `a0`… backticked names are Nim asm symbols → plain MSL locals
+  result = "{\n"
+  result.add "  simdgroup_" & dElem & "8x8 sd = make_filled_simdgroup_matrix<" & dElem &
+            ", 8>(" & dElem & "(0.0f));\n"
   for i in 0 ..< dV:
-    result.add newVarStmt(ident("d" & $i), newCall(dFrag, newLit(i)))
+    result.add "  sd.thread_elements()[" & $i & "] = `d" & $i & "`;\n"
+  result.add "  simdgroup_" & aElem & "8x8 sa = make_filled_simdgroup_matrix<" & aElem &
+            ", 8>(" & aElem & "(0.0f));\n"
   for i in 0 ..< aV:
-    result.add newLetStmt(ident("a" & $i), newCall(aFrag, newLit(i)))
+    result.add "  sa.thread_elements()[" & $i & "] = `a" & $i & "`;\n"
+  result.add "  simdgroup_" & bElem & "8x8 sb = make_filled_simdgroup_matrix<" & bElem &
+            ", 8>(" & bElem & "(0.0f));\n"
   for i in 0 ..< bV:
-    result.add newLetStmt(ident("b" & $i), newCall(bFrag, newLit(i)))
-  result.add newTree(nnkAsmStmt, newEmptyNode(), newLit(asmStr))
+    result.add "  sb.thread_elements()[" & $i & "] = `b" & $i & "`;\n"
+  result.add "  simdgroup_multiply_accumulate(sd, sa, sb, sd);\n"
   for i in 0 ..< dV:
-    result.add newAssignment(newCall(dFrag, newLit(i)), ident("d" & $i))
-  result = newTree(nnkBlockStmt, newEmptyNode(), result)
-
+    result.add "  `d" & $i & "` = sd.thread_elements()[" & $i & "];\n"
+  result.add "}"
 
 # ═════════════════════════════════════════════════════════════════════════
 #  universalMma8x8x8: the 8×8×8 register-level MMA
@@ -168,3 +150,120 @@ proc universalMma8x8x8*[TD; TA; TB](
     d[1] = d[1] + TD(a0) * TD(b01)
     d[0] = d[0] + TD(a1) * TD(b10)   # k = 2j+1 terms
     d[1] = d[1] + TD(a1) * TD(b11)
+
+# ═════════════════════════════════════════════════════════════════════════
+#  Atom registry access (macro-time)
+# ═════════════════════════════════════════════════════════════════════════
+
+template constStr(atom: untyped; suffix: untyped): string =
+  ## The string value of a per-atom registry const.
+  bindSym($atom & "_" & suffix).getImpl()[2].strVal
+
+proc leafProduct(n: NimNode): int =
+  ## Product of the int literals in a type-AST subtree (layout shape parts).
+  case n.kind
+  of nnkIntLit: result = int(n.intVal)
+  of nnkTupleConstr, nnkPar, nnkBracketExpr, nnkTupleTy, nnkBracket,
+     nnkIdentDefs:
+    result = 1
+    for ch in n:
+      result *= leafProduct(ch)
+  else: result = 1
+
+template vptOf(atom: untyped; layoutKey: untyped): int =
+  ## The operand's values per thread: the layout const's (T, V) shape
+  ## type's V component (the second part of the two-part shape tuple).
+  ## Mirrors valuesPerThread (atoms_mma_partitioning) from the layout type
+  ## alone — no layout-value evaluation needed.
+  let layoutType = bindSym($atom & "_" & layoutKey).getTypeInst()
+  doAssert layoutType.kind == nnkBracketExpr and layoutType.len == 3,
+    "gemm_mma: expected a Layout[Shape, Stride] type, got " & layoutType.repr
+  let shape = layoutType[1]
+  doAssert shape.len >= 2,
+    "gemm_mma: expected a (T, V) layout shape, got " & shape.repr
+  leafProduct(shape[1])
+
+# ═════════════════════════════════════════════════════════════════════════
+#  gemm_mma: one register-level MMA call
+# ═════════════════════════════════════════════════════════════════════════
+
+macro gemm_mma*(atom: static MmaAtom; dFrag, aFrag, bFrag: untyped): untyped =
+  ## One register-level MMA call — `atom.gemm_mma(dFrag, aFrag, bFrag)`.
+  ##
+  ## Everything instruction-level is derived from the atom's registry
+  ## consts (h_configgen): the mnemonic (`instr`), the per-operand
+  ## fragment counts (the layouts' V), and the MSL element names (`elem`).
+  ##
+  ## Dispatch by mnemonic:
+  ##   - "simdgroup_multiply_accumulate" (Apple atoms): an `nnkAsmStmt`
+  ##     staging block (buildAppleSimdgroupAsm), rendered by the Metal
+  ##     printer as raw MSL. The accumulator is always fp32; the operand
+  ##     element names come from the atom's `elem` registry const.
+  ##   - "" (universal FMA atoms): a plain call to `universalMma8x8x8`.
+  ##   - "mma.sync.aligned.*" (NVIDIA atoms): the extended-asm path below.
+  ##
+  ## Args:
+  ##   atom: the MmaAtom enum member
+  ##   dFrag: the accumulator fragment, seeded to the asm output and
+  ##     written back (in-place accumulate)
+  ##   aFrag, bFrag: the operand fragments, read-only
+  let instr = constStr(atom, "instr")
+  let dV = vptOf(atom, "cLayout")
+  let aV = vptOf(atom, "aLayout")
+  let bV = vptOf(atom, "bLayout")
+  case instr
+  of "simdgroup_multiply_accumulate":
+    if dV != 2 or aV != 2 or bV != 2:
+      error("gemm_mma: simdgroup_multiply_accumulate requires vpt 2 (Apple 8x8x8 atoms)")
+    let aElem = constStr(atom, "elem")
+    if aElem.len == 0:
+      error("gemm_mma: atom `" & $atom & "` is missing the `elem` registry " &
+            "property (\"float\"/\"half\"/\"bfloat\") for the Apple staging payload")
+    # Scalar locals: asm operand names must be plain MSL identifiers, so
+    # the fragment scalars are staged into Nim locals (bracket access: the
+    # tile layer's fragments are plain arrays; legacy Tensors support `[]`).
+    result = newStmtList()
+    for i in 0 ..< dV:
+      result.add newVarStmt(ident("d" & $i),
+        newTree(nnkBracketExpr, dFrag, newLit(i)))
+    for i in 0 ..< aV:
+      result.add newLetStmt(ident("a" & $i),
+        newTree(nnkBracketExpr, aFrag, newLit(i)))
+    for i in 0 ..< bV:
+      result.add newLetStmt(ident("b" & $i),
+        newTree(nnkBracketExpr, bFrag, newLit(i)))
+    result.add newTree(nnkAsmStmt, newEmptyNode(),
+      newLit(buildAppleSimdgroupAsm("float", aElem, aElem, dV, aV, bV)))
+    for i in 0 ..< dV:
+      result.add newAssignment(
+        newTree(nnkBracketExpr, dFrag, newLit(i)), ident("d" & $i))
+    result = newTree(nnkBlockStmt, newEmptyNode(), result)
+    return result
+  of "":
+    if dV != 2 or aV != 2 or bV != 2:
+      error("gemm_mma: universal requires vpt 2 (universal 8x8x8 atoms)")
+    result = newCall(bindSym("universalMma8x8x8"), dFrag, aFrag, bFrag)
+    return result
+  else:
+    if not instr.startsWith("mma.sync.aligned."):
+      error("gemm_mma: unsupported instruction `" & instr & "`")
+  let dElem = "float32"
+  let aElem = "uint32"
+  let bElem = "uint32"
+  let asmStr = buildNvidiaMmaAsm(instr, aV, bV, dV, "d", "a", "b", "d",
+                                 dElem, aElem, bElem, dElem)
+
+  # scalar register locals, one per fragment element:
+  #   d0..d(dV-1): var float32, seeded from the accumulator, written back after
+  #   a0..a(aV-1), b0..b(bV-1): let uint32, read from the operand tensors
+  result = newStmtList()
+  for i in 0 ..< dV:
+    result.add newVarStmt(ident("d" & $i), newCall(dFrag, newLit(i)))
+  for i in 0 ..< aV:
+    result.add newLetStmt(ident("a" & $i), newCall(aFrag, newLit(i)))
+  for i in 0 ..< bV:
+    result.add newLetStmt(ident("b" & $i), newCall(bFrag, newLit(i)))
+  result.add newTree(nnkAsmStmt, newEmptyNode(), newLit(asmStr))
+  for i in 0 ..< dV:
+    result.add newAssignment(newCall(dFrag, newLit(i)), ident("d" & $i))
+  result = newTree(nnkBlockStmt, newEmptyNode(), result)

--- a/workspace/ceramic/src/hardware/h_registry.nim
+++ b/workspace/ceramic/src/hardware/h_registry.nim
@@ -193,6 +193,7 @@ declareAtoms:
     bLayout: Apple8x8_B_Layout
     cLayout: Apple8x8_AC_Layout
     instr: "simdgroup_multiply_accumulate"
+    elem: "float"
   atom APPLE_8x8x8_F16:
     m: 8
     n: 8
@@ -203,6 +204,7 @@ declareAtoms:
     bLayout: Apple8x8_B_Layout
     cLayout: Apple8x8_AC_Layout
     instr: "simdgroup_multiply_accumulate"
+    elem: "half"
   atom APPLE_8x8x8_BF16:
     m: 8
     n: 8
@@ -213,6 +215,7 @@ declareAtoms:
     bLayout: Apple8x8_B_Layout
     cLayout: Apple8x8_AC_Layout
     instr: "simdgroup_multiply_accumulate"
+    elem: "bfloat"
 
   # NVIDIA tensor-core atoms: the mma.sync extended-asm path. The fp8
   # atom shares the m16n8k32 int8 layouts.

--- a/workspace/ceramic/src/kernel_gemm_gpu.nim
+++ b/workspace/ceramic/src/kernel_gemm_gpu.nim
@@ -178,8 +178,9 @@ func gemm_atom*[TD, ShD, StD, TA, ShA, StA, TB, ShB, StB](
   ##
   ## One mma.sync (tensor-core atoms), executed by the 32 lanes of a warp
   ## cooperatively, or one scalar FMA (the universal FMA atoms, empty
-  ## instr) on 1×1 fragments, executed by a single thread. The Apple
-  ## simdgroup atoms use the simdgroup-fragment overload below.
+  ## instr) on 1×1 fragments, executed by a single thread. All
+  ## instruction-carrying atoms dispatch through `gemm` (h_mma_dispatch),
+  ## which derives the mnemonic and fragment counts from the atom.
   ##
   ## Worked example (m16n8k8, (2, 2, 1), tile (32, 16, 32), 128 lanes = 4 warps):
   ##   each lane runs this call on its own register slice.
@@ -198,11 +199,7 @@ func gemm_atom*[TD, ShD, StD, TA, ShA, StA, TB, ShB, StB](
     # the expression where available.
     dFrag[0] = aFrag[0] * bFrag[0] + dFrag[0]
   else:
-    gemm_mma(mma.getInstr(),
-             toIntVal(mma.valuesPerThread(opC)),
-             toIntVal(mma.valuesPerThread(opA)),
-             toIntVal(mma.valuesPerThread(opB)),
-             dFrag, aFrag, bFrag)
+    gemm(mma, dFrag, aFrag, bFrag)
 
 # ═════════════════════════════════════════════════════════════════════════
 #  gemm_warp(mma, ...): loop over atoms

--- a/workspace/ceramic/src/tile_algebra/tile_config.nim
+++ b/workspace/ceramic/src/tile_algebra/tile_config.nim
@@ -19,9 +19,11 @@ export h_configgen, h_registry, h_properties
 
 func getTileConfig*(TOut, TIn: typedesc): static auto {.inline.} =
   when ccGetBackend() == ctMetal:
-    when TOut is float32 and TIn is float16: UNIVERSAL_8x8x8_F32F16F16F32
-    elif TOut is float32 and TIn is bfloat16: UNIVERSAL_8x8x8_F32BF16BF16F32
-    elif TOut is float32 and TIn is float32: UNIVERSAL_8x8x8_F32F32F32F32
+    # Metal: the Apple simdgroup atoms (hardware simdgroup_multiply_accumulate).
+    # The accumulator is always fp32; operand element selects the atom.
+    when TOut is float32 and TIn is float16: APPLE_8x8x8_F16
+    elif TOut is float32 and TIn is bfloat16: APPLE_8x8x8_BF16
+    elif TOut is float32 and TIn is float32: APPLE_8x8x8_F32
     else: {.error: "getTileConfig: no atom for (" & $TOut & ", " & $TIn &
       ") mix (fp32 accumulator with f16/bf16/f32 operands only)".}
   elif ccGetBackend() == ctCuda:

--- a/workspace/ceramic/src/tile_algebra/tile_mma.nim
+++ b/workspace/ceramic/src/tile_algebra/tile_mma.nim
@@ -18,11 +18,10 @@ proc mma_AB*[TIn; R, C, K: static int; A: static MmaAtom](
     a: RtLeft[TIn, R, K, A],
     b: RtRight[TIn, K, C, A]) =
   ## `dst.mma_AB(a, b)`: dst += a·b over the K subtiles, accumulated in fp32.
-  # TODO: tensor cores
   const rowTiles = R div A.getM()
   const colTiles = C div A.getN()
   const rK = K div A.getK()
   for n in 0 ..< rowTiles:
     for m in 0 ..< colTiles:
       for k in 0 ..< rK:
-        universalMma8x8x8(dst.frags[n][m].frag, a.frags[n][k].frag, b.frags[m][k].frag)
+        A.gemm_mma(dst.frags[n][m].frag, a.frags[n][k].frag, b.frags[m][k].frag)

--- a/workspace/crucible/src/codegen/targets/metal_lang.nim
+++ b/workspace/crucible/src/codegen/targets/metal_lang.nim
@@ -570,7 +570,10 @@ proc genMetalImpl(ctx: var GpuContext, ast: GpuAst, indent: int): string =
     result.add '}'
 
   of gpuInlineAsm:
-    raiseAssert "Inline assembly is not supported on the Metal target."
+    # Raw MSL statement: the gpuBlock loop appends the `;` terminator
+    # (CUDA/OpenCL/Vulkan wrap the body in `asm(...)`; MSL has no such
+    # wrapper — the simdgroup intrinsics are plain statements).
+    result = indentStr & genAsmStmt(ast).strip
 
   of gpuEmit:
     # Self-terminating raw text: the gpuBlock loop appends no `;`


### PR DESCRIPTION
This reintegrates the Apple Simdgroup machinery that was added in https://github.com/mratsim/tattletale/pull/68 and deleted in https://github.com/mratsim/tattletale/pull/73/changes/521e90f7450335458443d92a38580a0ea84de26d

They were deleted because they introduced heavy changes in the compiler (new enums, new builtins tables, text matching on simdgroup_load/store/matrix_acumulate, new passes, and forcing all backends to be aware of Simdgroup and ignore it + heavy Metal specialization).

Instead, they now uses the `{.emit: "...".}` facility to push complexity in the Ceramic library and keep the compiler lean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Apple Metal GPU support for optimized matrix multiplication using float16, bfloat16, and float32 data types.
  * Automatically selects the appropriate hardware-optimized matrix operations for supported Metal workloads.
  * Added support for generating and executing Metal inline matrix instructions.

* **Bug Fixes**
  * Improved handling of optional matrix-operation metadata and validation.
  * Unsupported matrix configurations now produce clearer compile-time errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->