### PR TITLE
Paged attention, silu/mul, rms-norm-residual, mega-kernel fused (up,gate,down proj + silu and mul)

### DIFF
--- a/.agents/skills/testing/SKILL.md
+++ b/.agents/skills/testing/SKILL.md
@@ -503,3 +503,58 @@ when isMainModule:
 - Use `printTensor` and `printTensorShape` for debugging failures
 - Test files should be in `workspace/module/tests/` directory
 - File names should start with `test_` or `t_`
+
+## Kernel tests against a reference
+
+A kernel test that compares against a libtorch reference is three clearly
+separated parts, so a reader always sees which variable comes from the
+kernel, which from the reference, and where the comparison happens:
+
+1. A proc that **computes with the function under check** (runs the kernel,
+   returns the output as a tensor).
+2. A proc that **computes the reference** (libtorch over the same inputs).
+3. The `check*()` proc that builds the shared inputs once, calls both, and
+   asserts.
+
+```nim
+proc kernelUnderTest(xf: seq[float32], M, N: int): F.Tensor =
+  ## Runs the kernel on the fp16-rounded inputs; returns the fp16
+  ## output converted to fp32.
+  var engine = bkMetal.init()
+  engine.ingest(kernelMsl)
+  ...  # build fp16 buffers from xf, engine.run, read back
+  result = toTensor(outF).reshape(M, N)
+
+proc reference(xf: seq[float32], M, N: int): F.Tensor =
+  ## The reference: torch op over the same fp16-rounded inputs.
+  let xh = toTensor(xf).reshape(M, N).to(kFloat16)
+  result = F.some_op(xh.to(kFloat32))
+
+proc checkFeature(): bool =
+  ## Kernel output vs the torch reference on one random batch.
+  Torch.manual_seed(0x5EED'u64)
+  let xf = scaledRand(M, N, 2.0'f32)
+  let actual = kernelUnderTest(xf, M, N)
+  let expected = reference(xf, M, N)
+  echo &"  worst |Δ| = {worstAbsDiff(actual, expected)} (tolerance 5e-3)"
+  assertAllClose(actual, expected, rtol = 0.0'f64, abstol = 5e-3'f64)
+  result = true
+
+when isMainModule:
+  runCppTest("feature vs the torch reference", checkFeature)
+```
+
+Rules:
+
+- Name the two results `actual` and `expected` (or `kernel`/`ref`), so the
+  kernel-vs-reference split is visible at the assert.
+- Both sides derive from the SAME random inputs, with fp16 rounding applied
+  identically (the kernel buffer rounds once; the reference widens the same
+  fp16 values). Never round the reference from the kernel's fp16 output.
+- Complex reference construction (per-seq SDPA, gathers, masks) lives inside
+  the reference proc; the `check*()` proc stays readable.
+- A tiny `worstAbsDiff(a, b: F.Tensor): float32` helper prints the worst
+  deviation before the assert; the assert carries the tolerance.
+- Test documentation scales with test complexity: an element-wise tile op or
+  a kernel-vs-reference match needs a few lines of setup, the reference
+  call, the tolerance, done.

--- a/workspace/ceramic/ceramic.nim
+++ b/workspace/ceramic/ceramic.nim
@@ -28,8 +28,7 @@ import ./src/layout_indexing
 
 export int_tuples, layouts, layout_algebra, tensors, tile_algebra,
        tile_epilogues, kernel_gemm_epilogues,
-       gemm, matmul, rms_single_row, attn_fwd,
-       gemm_relu, linear, linear_relu
+       k_tile_gemm, k_tile_rmsnorm, k_tile_attn
 export kernel_copy_cpu, kernel_copy_gpu, kernel_fillwith_cpu,
        kernel_fillwith_gpu, layout_indexing_cpu, layout_indexing_gpu,
        layout_indexing

--- a/workspace/positron/src/kernels/ceramic/gated_mlp_silu.nim
+++ b/workspace/positron/src/kernels/ceramic/gated_mlp_silu.nim
@@ -1,0 +1,105 @@
+## Tattletale
+## Copyright (c) 2026 Mamy André-Ratsimbazafy
+## Licensed and distributed under either of
+##   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+##   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+## at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+# ############################################################
+#
+#     Gated MLP forward (gated_mlp_silu): Tile API megakernel
+#
+# ############################################################
+
+## Fused GatedMLP inference on the ceramic Tile API: the gate and up
+## gemms, the silu·mul activation and the down gemm in one kernel,
+## the GatedMLP.forward contract (`workspace/transformers/src/layers/mlp.nim`):
+## `out = down_proj(silu(gate_proj(x)) · up_proj(x))`.
+## Experimental: not a production kernel, known gaps below, not fixed.
+##
+## Per-element semantics:
+##   - gate/up = the fp16 weight gemms with fp32 accumulation. The result
+##     rounds to fp16 (RNE) at the convert, matching the materialized fp16
+##     gate_out/up_out of the reference linear layers
+##   - act = silu(gate16)·up16 with the silu_and_mul semantics (fp32
+##     silu from the fp16 gate, fp16-rounded silu, one fp16-rounded
+##     product), no actLimit clamp
+##   - out = the fp16 act gemm with fp32 accumulation, rounded to fp16
+##     at the store through the `to` chokepoint
+##
+## Tile geometry:
+##   - one TileC×TileC output tile per threadgroup (the launcher
+##     instantiates TileC = 32), grid (NOut div TileC, ceil(M/TileC)),
+##     the atom's 32 lanes
+##   - each threadgroup loops the NIntm div TileC intermediate tiles
+##     and per tile re-derives the TileC×TileC gate/up tiles through
+##     the hidden K-loop (16-col chunks), converts them to fp16, fuses
+##     the silu·mul into a TileC×TileC act tile, then accumulates
+##     the act·WDown product into the output tile
+##   - the weights load through the transposed B-operand views of the row-major
+##     (K, NIntm) / (NIntm, NOut) buffers
+##   - partial M batches need no host padding: the X tile loads
+##     row-bounded (rows ≥ M zero-filled, tile_io_rows) and the Out
+##     store skips them
+##
+## Contract (not enforced, a violated shape under-covers the grid):
+##   - K multiple of 16 (the gate/up K-chunk), NIntm and NOut
+##     multiples of TileC (the tile width, 32)
+##
+## Known production gaps (documented, not fixed):
+##   - each threadgroup re-derives its gate/up tiles once per NOut
+##     tile (the fusion stages no intermediate to gmem). Production
+##     would stage the act tile once per (batch, intermediate) block
+##   - no actLimit clamp (the reference GatedMLP has none)
+
+import workspace/crucible
+import workspace/ceramic
+import ./silu_and_mul
+import ./tile_io_rows
+
+proc gated_mlp_silu_fwd*(
+    Out: ptr UncheckedArray[float16],          # (M, NOut): the MLP output
+    X: ptr UncheckedArray[float16],            # (M, K): the input rows
+    WGate, WUp: ptr UncheckedArray[float16],   # (K, NIntm): gate/up weights
+    WDown: ptr UncheckedArray[float16],        # (NIntm, NOut): the down weight
+    M, K, NIntm, NOut: int32,
+    TileC: static int) {.device.} =
+  ## One TileC×TileC output tile per threadgroup (grid x = the NOut tile, y = the M tile),
+  ## the module doc's contract applied per intermediate tile:
+  ##   - the gate/up gemms
+  ##   - the fused silu·mul act tile
+  ##   - the down gemm accumulation
+  ##   - the row-bounded X load and Out store
+  let tx = int32(threadgroup_position_in_grid.x)
+  let ty = int32(threadgroup_position_in_grid.y)
+  let glX = gd(X, shape = (-1, -1, -1, -1), stride = (K, 0, K, 1))
+  let glWg = gd(WGate, shape = (-1, -1, -1, -1), stride = (1, 0, 1, NIntm))
+  let glWu = gd(WUp, shape = (-1, -1, -1, -1), stride = (1, 0, 1, NIntm))
+  let glWd = gd(WDown, shape = (-1, -1, -1, -1), stride = (1, 0, 1, NOut))
+  let glOut = gd(Out, shape = (-1, -1, -1, -1), stride = (NOut, 0, NOut, 1))
+  var d_rtl: rt_l(float32, TileC, TileC, getTileConfig(float32, float16))
+  d_rtl.zero()
+  for ic in 0'i32 ..< NIntm div int32(TileC):
+    var gate: rt_l(float32, TileC, TileC, getTileConfig(float32, float16))
+    var up: rt_l(float32, TileC, TileC, getTileConfig(float32, float16))
+    gate.zero()
+    up.zero()
+    for k in 0'i32 ..< K div 16:
+      var x_t: rt_l(float16, TileC, 16)
+      loadTileRows(x_t, glX, (0, 0, ty, k), M)
+      var wg_t: rt_r(float16, 16, TileC)
+      loadTile(wg_t, glWg, (0, 0, ic, k))
+      var wu_t: rt_r(float16, 16, TileC)
+      loadTile(wu_t, glWu, (0, 0, ic, k))
+      gate.mma_AB(x_t, wg_t)
+      up.mma_AB(x_t, wu_t)
+    var gate16: rt_l(float16, TileC, TileC)
+    var up16: rt_l(float16, TileC, TileC)
+    gate16.convert(gate)
+    up16.convert(up)
+    var act: rt_l(float16, TileC, TileC)
+    siluAndMulElem(act, gate16, up16, 0.0'f32)
+    var wd_t: rt_r(float16, TileC, TileC)
+    loadTile(wd_t, glWd, (0, 0, tx, ic))
+    d_rtl.mma_AB(act, wd_t)
+  storeTileRows(glOut, d_rtl, (0, 0, ty, tx), M)

--- a/workspace/positron/src/kernels/ceramic/paged_attn.nim
+++ b/workspace/positron/src/kernels/ceramic/paged_attn.nim
@@ -1,0 +1,229 @@
+## Tattletale
+## Copyright (c) 2026 Mamy André-Ratsimbazafy
+## Licensed and distributed under either of
+##   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+##   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+## at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+# ############################################################
+#
+#     Paged multi-head attention forward (Tile API port)
+#
+# ############################################################
+
+## Paged multi-head attention forward on the ceramic Tile API: decode
+## and prefill in one kernel, K/V fetched per 8-row block through a
+## dense `block_table` + `cache_seqlens` (no page→contiguous gather).
+## Experimental: not a production kernel, known gaps below, not fixed.
+##
+## Buffers, fp16 first then int32 tables then scalars:
+##   - o, q: (num_qo_tokens, H, D)
+##   - k_cache, v_cache: (num_pages, page_size, Nkv, D), seq-first
+##     slab (row stride Nkv·D, head-dim contiguous)
+##   - block_table: (num_seqs, max_pages) dense, -1 padding, never read
+##   - cache_seqlens: (num_seqs)
+##   - cu_seqlens_q: (num_seqs+1), the prefill query ranges
+##   - num_seqs, H, Nkv, max_pages, page_size: int32
+##   - D: static int, 64 or 128 (tile geometry). No generic brackets,
+##     no stride or scratch parameters.
+##
+## The 16-bit element type is the DSL's `float16` (distinct uint16,
+## bit-identical on the host).
+##
+## Grid and modes:
+##   - grid (q token blocks, H, num_seqs): z = seq, y = head, x = the
+##     seq's 8-row q block
+##   - decode (q_len == 1): causal OFF, each query attends the cached
+##     rows [0, cache_seqlen)
+##   - prefill (q_len ≥ 2): causal ON over [0, cache_seqlen + q_len),
+##     query row j attends keys [0, cache_seqlen + j] (flash-attn
+##     varlen semantics)
+##   - GQA: kv_head = q_head div (H div Nkv)
+##
+## Block fetch, page_size a multiple of 8 so each 8-row KV block lies
+## inside one page. For block t0:
+##   - page_idx = t0 div page_size, in_page = t0 mod page_size,
+##     page_id = block_table[seq·max_pages + page_idx]
+##   - slab base = page_id·(page_size·Nkv·D) + in_page·(Nkv·D) +
+##     kv_head·D, passed as the origin's batch component, the block
+##     rows local to it
+##   - the K view carries stride (1, 1, Nkv·D, 1). The V view
+##     carries the transposed stride (1, 1, 1, Nkv·D), so the P·V mma
+##     consumes Vᵀ from the natural slab view, matching the plain attn kernel's V view
+##
+## Partial last page:
+##   - K/V rows are bounded by cache_seqlens[seq] (decode) or
+##     cache_seqlen + q_len (prefill), never by page multiples. The
+##     tail page may hold garbage beyond the covered length
+##     (bound, don't filter)
+##   - the KV loop stays inside the seq's table pages
+##     (pageBlocks = ceil(totalK/page_size)·(page_size div 8), a block
+##     beyond the last table page would read a -1 padding slot). It
+##     also stays inside the last block's attended range
+##     (lastKey = min(cachedLen + q0Local + 7, totalK − 1))
+##   - garbage rows load as valid slab memory and are excluded by the
+##     banded mask: masked S columns are set to the most-negative
+##     finite fp32 (−3.402823466e38), so the running row max ignores
+##     them and exp2(S − m) underflows to exact +0.0. The P, l and O
+##     accumulations never see them
+##
+## Numerics:
+##   - online softmax in TM's exp2 shape, q_mul = scale·log2(e) folded
+##     into Q (exp2(S·q_mul − m) is the exp(S·scale) convention,
+##     scale = 1/sqrt(D))
+##   - P downcast to fp16 (`convert`) before the P·V mma. The output
+##     store quantizes the fp32 O tile to fp16 (RNE) through the `to`
+##     chokepoint
+##
+## Local device procs: the shared tile_algebra lacks the banded causal mask, so the module carries maskCausal locally.
+## The row-bounded load/store come from tile_io_rows (positron local extension).
+##
+## Known production gaps (documented, not fixed):
+##   - Layer-major PagePool stride: production slabs are
+##     [num_pages, num_layers, page_size, kv_heads, head_dim]. This
+##     kernel consumes a per-layer slab view contiguous per layer (row
+##     stride Nkv·D), so the per-layer view needs a layer offset and a
+##     batch stride of num_layers·page_size·Nkv·D.
+##   - Runtime page_size: production should specialize page_size as a
+##     constexpr (the fetch math derives pageBlocks and the page
+##     stride from it).
+##   - Single-path gate: the new API has no `useCeramicLayout` toggle
+##     (the old API's addressing-layer switch). The kernel is the one
+##     path.
+
+import workspace/crucible
+import workspace/ceramic
+import ./tile_io_rows
+
+export int_tuples, layouts, layout_constructors, layout_indexing, tensors,
+       ptr_arithmetic, tile_algebra
+
+# ═════════════════════════════════════════════════════════════════════
+#  Local device extensions: the tile API gaps the paged fetch needs
+#  ═════════════════════════════════════════════════════════════════════
+
+proc maskCausal[A: static MmaAtom](
+    tile: var RtLeft[float32, 8, 8, A],
+    limit: int32) {.device.} =
+  ## Banded causal mask on an 8×8 S tile: element (r, c) is attended
+  ## iff c <= limit + r. Masked elements become the most-negative
+  ## finite fp32 (−3.402823466e38), so the online softmax excludes
+  ## them (the row max ignores them, exp2(S − m) underflows to exact
+  ## +0.0). `limit` is the block's band offset (cachedLen + q0Local −
+  ## kv_idx·8 − decodeAdj), signed: a negative limit masks every
+  ## column of the row, where an unsigned wrap would leave them
+  ## attended. The frag walk follows the loadTile lane→element mapping,
+  ## so the mask hits exactly the elements the Q·Kᵀ mma produced.
+  const M = A.getM()
+  const N = A.getN()
+  const rowTiles = 8 div M
+  const colTiles = 8 div N
+  const vpt = A.getVpt()
+  let lane = int(thread_index_in_threadgroup)
+  let cell = crd2idx(A.getLayoutA(), (lane, 0)).toIntVal()
+  let row = cell mod M
+  let col = cell div M
+  for n in 0 ..< rowTiles:
+    for m in 0 ..< colTiles:
+      for v in 0 ..< vpt:
+        let band = limit + int32(row + n * M)
+        if int32(col + m * N + v) > band:
+          tile.frags[n][m].frag[v] = -3.402823466e38'f32
+
+# ═════════════════════════════════════════════════════════════════════
+#  The kernel
+#  ═════════════════════════════════════════════════════════════════════
+
+proc paged_attn_fwd*(
+    o: ptr UncheckedArray[float16],            # (num_qo_tokens, H, D)
+    q: ptr UncheckedArray[float16],            # (num_qo_tokens, H, D)
+    k_cache, v_cache: ptr UncheckedArray[float16],  # (num_pages, page_size, Nkv, D)
+    block_table: ptr UncheckedArray[int32],    # (num_seqs, max_pages) dense
+    cache_seqlens: ptr UncheckedArray[int32],  # (num_seqs)
+    cu_seqlens_q: ptr UncheckedArray[int32],   # (num_seqs+1) prefill q ranges
+    num_seqs, H, Nkv, max_pages, page_size: int32,
+    D: static int) {.device.} =
+  ## One grid point = (seq, head, 8-row q block), following the module
+  ## doc's contract: the q tile loads row-bounded, the KV loop is
+  ## bounded by the seq's table pages and the banded causal mask, and
+  ## the fp16 store writes only the seq's q rows.
+  static: doAssert D == 64 or D == 128
+
+  let seqId = int32(threadgroup_position_in_grid.z)
+  let head = int32(threadgroup_position_in_grid.y)
+  let qBlock = int32(threadgroup_position_in_grid.x)
+
+  # The q/o views carry the (q row, head, dim) strides. The K/V views
+  # carry the slab's row stride and take the per-block base as the
+  # origin's batch component (see the module doc's fetch formula).
+  let gl_q = gd(q, shape = (-1, -1, -1, -1), stride = (H * D, D, H * D, 1))
+  let gl_o = gd(o, shape = (-1, -1, -1, -1), stride = (H * D, D, H * D, 1))
+  let gl_k = gd(k_cache, shape = (-1, -1, -1, -1), stride = (1, 1, Nkv * D, 1))
+  # The V view is the transposed slab view: the RtRight loadTile
+  # hands Vᵀ to the P·V mma.
+  let gl_v = gd(v_cache, shape = (-1, -1, -1, -1), stride = (1, 1, 1, Nkv * D))
+
+  let kvHead = head div (H div Nkv)
+  let q0 = cu_seqlens_q[seqId]
+  let qLen = cu_seqlens_q[seqId + 1] - q0
+  let cachedLen = cache_seqlens[seqId]
+  # decode (q_len = 1) attends cached rows only. Prefill (q_len ≥ 2)
+  # also covers the new tokens' rows (the band carries the one-row
+  # difference)
+  let decodeAdj = (if qLen == 1: 1'i32 else: 0'i32)
+  let totalK = cachedLen + qLen - decodeAdj
+  let q0Local = qBlock * 8
+  let pageStride = page_size * Nkv * int32(D)
+  let rowStride = Nkv * int32(D)
+  # The KV loop stays inside the seq's table pages and the last
+  # attended block.
+  let pageBlocks = ((totalK + page_size - 1) div page_size) * (page_size div 8)
+  let lastKey = (if cachedLen + q0Local + 7 < totalK - 1:
+                   cachedLen + q0Local + 7
+                 else:
+                   totalK - 1)
+  let lastAttBlock = lastKey div 8 + 1
+  let kvBlocks = (if pageBlocks < lastAttBlock: pageBlocks else: lastAttBlock)
+
+  var q_reg: rt_l(float16, 8, D)
+  var k_reg: rt_r(float16, D, 8)
+  var v_reg: rt_r(float16, 8, D)
+  var att_block: rt_l(float32, 8, 8, getTileConfig(float32, float16))
+  var p_reg: rt_l(float16, 8, 8)
+  var o_reg: rt_l(float32, 8, D, getTileConfig(float32, float16))
+  var max_vec_last: rv(float32, 8, 8)
+  var max_vec: rv(float32, 8, 8)
+  var norm_vec: rv(float32, 8, 8)
+
+  loadTileRows(q_reg, gl_q, (q0, head, qBlock, 0), qLen)
+  max_vec.neg_infty()
+  norm_vec.zero()
+  o_reg.zero()
+  let q_mul = (if D == 128: 0.08838834764'f32 else: 0.125'f32) *
+              1.44269504089'f32
+  q_reg.mul(q_reg, q_mul)
+  for kv_idx in 0'i32 ..< kvBlocks:
+    let pageIdx = (kv_idx * 8) div page_size
+    let inPage = kv_idx * 8 - pageIdx * page_size
+    let pageId = block_table[seqId * max_pages + pageIdx]
+    let base = pageId * pageStride + inPage * rowStride + kvHead * int32(D)
+    # The block's rows are local to the base: the origin's row-tile
+    # component stays 0.
+    loadTile(k_reg, gl_k, (base, 0, 0, 0))
+    att_block.zero()
+    att_block.mma_AB(q_reg, k_reg)
+    maskCausal(att_block, cachedLen + q0Local - kv_idx * 8 - decodeAdj)
+    max_vec_last.copy(max_vec)
+    max_vec.row_max(att_block, max_vec)
+    max_vec_last.sub(max_vec_last, max_vec)
+    max_vec_last.exp2(max_vec_last)
+    att_block.sub_row(att_block, max_vec)
+    att_block.exp2(att_block)
+    norm_vec.mul(norm_vec, max_vec_last)
+    norm_vec.row_sum(att_block, norm_vec)
+    p_reg.convert(att_block)
+    o_reg.mul_row(o_reg, max_vec_last)
+    loadTile(v_reg, gl_v, (base, 0, 0, 0))
+    o_reg.mma_AB(p_reg, v_reg)
+  o_reg.div_row(o_reg, norm_vec)
+  storeTileRows(gl_o, o_reg, (q0, head, qBlock, 0), qLen)

--- a/workspace/positron/src/kernels/ceramic/rms_norm_res_in.nim
+++ b/workspace/positron/src/kernels/ceramic/rms_norm_res_in.nim
@@ -1,0 +1,129 @@
+## Tattletale
+## Copyright (c) 2026 Mamy André-Ratsimbazafy
+## Licensed and distributed under either of
+##   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+##   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+## at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+# ############################################################
+#
+#     Fused residual-add RMSNorm (rms_norm_res_in): Tile API port
+#
+# ############################################################
+
+## Fused residual-add RMSNorm on the ceramic Tile API:
+## `Out[r][c] = rms_norm(x + res_in)[r][c]` over fp16 (M, C) input and
+## residual buffers and an fp16 (M, C) output, the residual add inside
+## the kernel (one launch, no host pre-add).
+## Experimental: not a production kernel, known gaps below, not fixed.
+##
+## Per-element semantics:
+##   - the sum s = x + res rounds to fp16 (RNE) and re-promotes to
+##     fp32, the exllamav3 RES_IN `add_resid_in` write shape: the
+##     value the norm consumes and the residual stream would carry
+##   - the norm sequence is the standalone `rms_norm` arithmetic:
+##     s², row_sum, ·1/C, +ε, rsqrt, mul_row, γ mul, one fp16 rounding
+##     at the store
+##   - with a zero residual the output is bit-identical to the
+##     standalone kernel on the same input
+##
+## Tile geometry:
+##   - one 8-row × TileC-col tile per threadgroup, grid (1, ceil(M/8)),
+##     the atom's 32 lanes, TileC the static tile width (128)
+##   - each threadgroup loops the C div TileC column blocks twice:
+##     pass 1 accumulates the row sums of s² over all blocks, pass 2
+##     normalizes and stores
+##   - the views carry the rmsnorm swapped strides (row axis = the
+##     contiguous hidden dim, stride 1 for X/R/Out, col stride C = the
+##     token row), so the origin's row component holds the column-block
+##     index and its col component the row-block index
+##   - γ broadcasts through a (0, 0, 1, 0) view
+##   - rows ≥ M are zero-filled on load and skipped on store, so
+##     partial-M batches need no host padding
+##
+## Known production gaps (documented, not fixed):
+##   - C must be a multiple of TileC. A partial last column block is
+##     out of contract
+##   - the updated residual stream is not written. Production packs or
+##     multi-buffers it with the output (the engine reads back only
+##     binding 0)
+##   - concrete fp16 in / fp16 out only, no fp32 path
+
+import workspace/crucible
+import workspace/ceramic
+import ./tile_io_rows
+
+export int_tuples, layouts, layout_constructors, layout_indexing, tensors,
+       ptr_arithmetic, tile_algebra
+
+# ═════════════════════════════════════════════════════════════════════
+#  Local device extensions: the tile API gaps the fusion needs
+#  ═════════════════════════════════════════════════════════════════════
+
+proc addResidF16[R, C: static int; A: static MmaAtom](
+    dst: var RtRight[float32, R, C, A],
+    x, res: RtRight[float32, R, C, A]) {.device.} =
+  ## Per-element residual add over one register tile: `dst[r][c]` = the
+  ## fp16-rounded sum (x[r][c] + res[r][c]) re-promoted to fp32, the
+  ## exllamav3 RES_IN `add_resid_in` write shape (the fp32 add of the
+  ## fp16-exact operands is exact, one RNE fp16 round). The frag walk
+  ## follows the loadTile lane→element mapping, so x, res and dst agree
+  ## elementwise.
+  const rowTiles = R div A.getM()
+  const colTiles = C div A.getN()
+  const vpt = A.getVpt()
+  for m in 0 ..< colTiles:
+    for n in 0 ..< rowTiles:
+      for v in 0 ..< vpt:
+        let s = x.frags[m][n].frag[v] + res.frags[m][n].frag[v]
+        dst.frags[m][n].frag[v] = s.to(float16).to(float32)
+
+# ═════════════════════════════════════════════════════════════════════
+#  The kernel
+#  ═════════════════════════════════════════════════════════════════════
+
+proc rms_norm_res_in_fwd*(
+    Out: ptr UncheckedArray[float16],    # (M, C) fp16: the normed output
+    X: ptr UncheckedArray[float16],      # (M, C) fp16: the input rows
+    R: ptr UncheckedArray[float16],      # (M, C) fp16: the residual stream before the add
+    G: ptr UncheckedArray[float16],      # (C,) fp16: the norm weight
+    M, C: int32,
+    eps: float32,
+    TileC: static int) {.device.} =
+  ## Computes one fused residual-norm over the 8-row tile block
+  ## `threadgroup_position_in_grid.y`: the module doc's two-pass
+  ## sequence, `C div TileC` column blocks per pass. `TileC` is the
+  ## static tile width (128) and must divide C. Rows ≥ M are
+  ## zero-filled on load and skipped on store. The grid is
+  ## (1, ceil(M/8)) with a 32-lane threadgroup per tile.
+  let gid = int32(threadgroup_position_in_grid.y)
+  let colBlocks = C div int32(TileC)
+  let glX = gd(X, shape = (-1, -1, -1, -1), stride = (8 * C, 0, 1, C))
+  let glR = gd(R, shape = (-1, -1, -1, -1), stride = (8 * C, 0, 1, C))
+  let glG = gd(G, shape = (-1, -1, -1, -1), stride = (0, 0, 1, 0))
+  let glOut = gd(Out, shape = (-1, -1, -1, -1), stride = (8 * C, 0, 1, C))
+  var x_rtr: rt_r(float32, 8, TileC)
+  var res_rtr: rt_r(float32, 8, TileC)
+  var s_rtr: rt_r(float32, 8, TileC)
+  var sq_rtr: rt_r(float32, 8, TileC)
+  var gamma_rtr: rt_r(float32, 8, TileC)
+  var ss: rv(float32, 8, TileC)
+  ss.zero()
+  for cb in 0'i32 ..< colBlocks:
+    loadTileRows(x_rtr, glX, (0, 0, cb, gid), M)
+    loadTileRows(res_rtr, glR, (0, 0, cb, gid), M)
+    addResidF16(s_rtr, x_rtr, res_rtr)
+    sq_rtr.mul(s_rtr, s_rtr)
+    ss.row_sum(sq_rtr, ss)
+  let invC = 1.0'f32 / float32(C)
+  ss.mul(ss, invC)
+  ss.add(ss, eps)
+  ss.rsqrt(ss)
+  for cb in 0'i32 ..< colBlocks:
+    loadTileRows(x_rtr, glX, (0, 0, cb, gid), M)
+    loadTileRows(res_rtr, glR, (0, 0, cb, gid), M)
+    addResidF16(s_rtr, x_rtr, res_rtr)
+    s_rtr.mul_row(s_rtr, ss)
+    loadTile(gamma_rtr, glG, (0, 0, cb, 0))
+    s_rtr.mul(s_rtr, gamma_rtr)
+    storeTileRows(glOut, s_rtr, (0, 0, cb, gid), M)

--- a/workspace/positron/src/kernels/ceramic/silu_and_mul.nim
+++ b/workspace/positron/src/kernels/ceramic/silu_and_mul.nim
@@ -1,0 +1,119 @@
+## Tattletale
+## Copyright (c) 2026 Mamy André-Ratsimbazafy
+## Licensed and distributed under either of
+##   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+##   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+## at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+# ############################################################
+#
+#     Fused SiLU × Mul (silu_and_mul): Tile API port
+#
+# ############################################################
+
+## Fused GatedMLP activation on the ceramic Tile API:
+## `Out[r][c] = silu(X[r][c]) · X[r][N + c]` over one fp16 input
+## buffer X of shape (M, 2N) holding the gate in cols [0, N) and the
+## up in cols [N, 2N), one fp16 output (M, N). The FlashInfer
+## `silu_and_mul` convention.
+## Experimental: not a production kernel, known gaps below, not fixed.
+##
+## Per-element semantics:
+##   - silu computed in fp32 from the fp16 gate (exact promotion) as
+##     `g / (1 + exp2(−g·log2e))` with log2e = 1.4426950408889634'f32
+##     and the backend's native exp2 (1-ulp class, not a bit-exact
+##     Taylor form)
+##   - the silu result rounds to fp16, then the optional `actLimit`
+##     clamp applies in fp32 arithmetic (skipped when 0). The final
+##     fp16×fp16 multiply performs one rounding (fp32 product of the
+##     fp16-rounded operands, one RNE round)
+##
+## Tile geometry:
+##   - one 8-row × TileC-col tile per threadgroup, grid
+##     (N div TileC, ceil(M/8)), the atom's 32 lanes
+##   - TileC: the static tile width (launchers instantiate 64) and
+##     must divide N
+##   - one gd view over X with row stride 2N carries both operands:
+##     the gate tile loads at X col origin tx, the up tile at col
+##     origin tx + N div TileC (the view's element (r, c) is
+##     X[r·2N + c], so the col origin N + tx·TileC selects the up half)
+##   - the store writes the out tile at col origin tx into a (M, N)
+##     row-major view
+##   - rows beyond M are zero-filled on load and skipped on store, so
+##     the batch needs no host padding
+##
+## Known production gaps (documented, not fixed):
+##   - N must be a multiple of TileC. A partial last column block is
+##     out of contract
+##   - the shared tile_algebra has no silu, elementwise tile add or
+##     elementwise tile div, so the fusion walks the register frags in
+##     a module-local device proc instead of tile-op maps
+##   - concrete fp16 in / fp16 out only, no fp32 path
+
+import workspace/crucible
+import workspace/ceramic
+import ./tile_io_rows
+
+export int_tuples, layouts, layout_constructors, layout_indexing, tensors,
+       ptr_arithmetic, tile_algebra
+
+# ═════════════════════════════════════════════════════════════════════
+#  Local device extensions: the tile API gaps the fusion needs
+#  ═════════════════════════════════════════════════════════════════════
+
+proc siluAndMulElem*[R, C: static int; A: static MmaAtom](
+    dst: var RtLeft[float16, R, C, A],
+    gate, up: RtLeft[float16, R, C, A],
+    actLimit: float32) {.device.} =
+  ## Per-element fused silu·mul over one register tile: `dst[r][c] =
+  ## silu(gate[r][c]) · up[r][c]` per the module doc's semantics. The
+  ## frag walk follows the loadTile lane→element mapping, so gate, up
+  ## and dst agree elementwise.
+  const M = A.getM()
+  const N = A.getN()
+  const rowTiles = R div M
+  const colTiles = C div N
+  const vpt = A.getVpt()
+  for n in 0 ..< rowTiles:
+    for m in 0 ..< colTiles:
+      for v in 0 ..< vpt:
+        let g32 = gate.frags[n][m].frag[v].to(float32)
+        let u32 = up.frags[n][m].frag[v].to(float32)
+        var s = g32 / (1.0'f32 + exp2(-g32 * 1.4426950408889634'f32))
+        var u = u32
+        if actLimit != 0.0'f32:
+          s = min(s, actLimit)
+          u = min(max(u, -actLimit), actLimit)
+        let s16 = s.to(float16)
+        let u16 = u.to(float16)
+        dst.frags[n][m].frag[v] =
+          (s16.to(float32) * u16.to(float32)).to(float16)
+
+# ═════════════════════════════════════════════════════════════════════
+#  The kernel
+#  ═════════════════════════════════════════════════════════════════════
+
+proc silu_and_mul_fwd*(
+    Out: ptr UncheckedArray[float16],    # (M, N): the silu(gate)·up output
+    X: ptr UncheckedArray[float16],      # (M, 2N): gate cols [0, N), up cols [N, 2N)
+    M, N: int32,
+    actLimit: float32,
+    TileC: static int) {.device.} =
+  ## Computes one 8×TileC silu-mul tile per threadgroup: grid
+  ## (N div TileC, ceil(M/8)), `tx` the TileC-col block, `ty` the
+  ## 8-row block. The gate tile loads at X col origin tx, the up tile
+  ## at col origin tx + N div TileC, the store writes the out tile at
+  ## col origin tx (see the module doc). Rows ≥ M are zero-filled on
+  ## load and skipped on store, so partial-M batches need no host
+  ## padding. `TileC` must divide N.
+  let tx = int32(threadgroup_position_in_grid.x)
+  let ty = int32(threadgroup_position_in_grid.y)
+  let glX = gd(X, shape = (-1, -1, -1, -1), stride = (8 * 2 * N, 0, 2 * N, 1))
+  let glOut = gd(Out, shape = (-1, -1, -1, -1), stride = (8 * N, 0, N, 1))
+  var gate: rt_l(float16, 8, TileC)
+  var up: rt_l(float16, 8, TileC)
+  var outT: rt_l(float16, 8, TileC)
+  loadTileRows(gate, glX, (0, 0, ty, tx), M)
+  loadTileRows(up, glX, (0, 0, ty, tx + N div TileC), M)
+  siluAndMulElem(outT, gate, up, actLimit)
+  storeTileRows(glOut, outT, (0, 0, ty, tx), M)

--- a/workspace/positron/src/kernels/ceramic/tile_io_rows.nim
+++ b/workspace/positron/src/kernels/ceramic/tile_io_rows.nim
@@ -1,0 +1,200 @@
+## Tattletale
+## Copyright (c) 2026 Mamy André-Ratsimbazafy
+## Licensed and distributed under either of
+##   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+##   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+## at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+# ############################################################
+#
+#     Row-bounded tile load/store (positron local extension)
+#
+# ############################################################
+
+## Row-bounded variants of the tile_io `loadTile`/`storeTile` for the positron
+## kernels' partial-row-block contract (a decode q block, a partial last batch
+## tile). Elements whose tile-plane row is at or above `rowLimit` are
+## zero-filled on load and not written on store.
+##
+## The bodies delegate to the tile_io facilities, keeping the lane-to-cell mapping and the `to` conversion chokepoint.
+## The guard lives in the epilogue position. A straddling tile
+## zeroes its out-of-range rows after the load (`zeroRows`).
+## The store writes only the in-range rows (`storeRows`). Each lane
+## evaluates the guard once per sub-tile row, since the guard is
+## uniform across the lane's columns and values.
+##
+## Plane-row convention: the tile's first plane row is `origin[2]·R`
+## for the RtLeft variants and `origin[3]·R` for the RtRight
+## variants, the same side convention loadTile uses
+## (`local_tile_dyn(gl, R, C, o)` versus `(gl, C, R, o)`).
+##
+## The row-bounded load reads the whole tile, out-of-range rows
+## included, then zeroes those rows. Metal performs bounds checking
+## on buffer accesses: out-of-bounds reads return 0 and writes are discarded,
+## so the extra reads stay invisible.
+##
+## Local to positron: the shared tile_algebra (tile_io.nim) is owned
+## elsewhere, so the bounded variants live here.
+
+import workspace/crucible
+import workspace/ceramic
+
+# ═════════════════════════════════════════════════════════════════════
+#  RtLeft variants (unswapped views, guard on origin[2])
+#  ═════════════════════════════════════════════════════════════════════
+
+proc zeroRows[R, C: static int; A: static MmaAtom](
+    tile: var RtLeft[float16, R, C, A],
+    r0, rowLimit: int32) {.device.} =
+  ## Zeroes the tile's rows with plane row >= rowLimit. `r0` is the tile's
+  ## first plane row (origin[2]·R).
+  const M = A.getM()
+  const N = A.getN()
+  const rowTiles = R div M
+  const colTiles = C div N
+  const vpt = A.getVpt()
+  let lane = int(thread_index_in_threadgroup)
+  let cell = crd2idx(A.getLayoutA(), (lane, 0)).toIntVal()
+  let row = cell mod M
+  for n in 0 ..< rowTiles:
+    if r0 + int32(n * M + row) >= rowLimit:
+      for m in 0 ..< colTiles:
+        for v in 0 ..< vpt:
+          tile.frags[n][m].frag[v] = 0'u16.asFp16()
+
+proc loadTileRows*[R, C: static int; A: static MmaAtom](
+    tile: var RtLeft[float16, R, C, A],
+    gl: GlView[float16],
+    origin: tuple,
+    rowLimit: int32) {.device.} =
+  ## Row-bounded loadTile: tile-plane rows origin[2]·R + r at or above
+  ## `rowLimit` are zero-filled instead of read.
+  loadTile(tile, gl, origin)
+  let r0 = int32(origin[2]) * int32(R)
+  if r0 + int32(R) > rowLimit:
+    zeroRows(tile, r0, rowLimit)
+
+proc storeRows[TIn; R, C: static int; A: static MmaAtom](
+    gl: GlView[float16],
+    tile: RtLeft[TIn, R, C, A],
+    origin: tuple,
+    r0, rowLimit: int32) {.device.} =
+  ## Stores only the tile's in-range rows (plane row < rowLimit).
+  ## The fp32 tile quantizes to fp16 (RNE) via the `to` chokepoint.
+  ## An fp16 tile round-trips unchanged.
+  const M = A.getM()
+  const N = A.getN()
+  const rowTiles = R div M
+  const colTiles = C div N
+  const vpt = A.getVpt()
+  let lane = int(thread_index_in_threadgroup)
+  let cell = crd2idx(A.getLayoutA(), (lane, 0)).toIntVal()
+  let row = cell mod M
+  let col = cell div M
+  let o = (int(origin[0]), int(origin[1]), int(origin[2]), int(origin[3]))
+  var dst = local_tile_dyn(gl, R, C, o)
+  for n in 0 ..< rowTiles:
+    if r0 + int32(n * M + row) < rowLimit:
+      for m in 0 ..< colTiles:
+        for v in 0 ..< vpt:
+          dst[row + n * M, col + m * N + v] =
+            tile.frags[n][m].frag[v].to(float16)
+
+proc storeTileRows*[R, C: static int; A: static MmaAtom](
+    gl: GlView[float16],
+    tile: RtLeft[float32, R, C, A],
+    origin: tuple,
+    rowLimit: int32) {.device.} =
+  ## Row-bounded storeTile: rows at or above `rowLimit` are not written.
+  ## A tile fully inside the limit stores through the facility. A straddling tile writes only its in-range rows.
+  let r0 = int32(origin[2]) * int32(R)
+  if r0 + int32(R) <= rowLimit:
+    storeTile(gl, tile, origin)
+  else:
+    storeRows(gl, tile, origin, r0, rowLimit)
+
+proc storeTileRows*[R, C: static int; A: static MmaAtom](
+    gl: GlView[float16],
+    tile: RtLeft[float16, R, C, A],
+    origin: tuple,
+    rowLimit: int32) {.device.} =
+  ## Row-bounded storeTile for fp16 tiles. The `to` round trip is the identity.
+  let r0 = int32(origin[2]) * int32(R)
+  if r0 + int32(R) <= rowLimit:
+    storeTile(gl, tile, origin)
+  else:
+    storeRows(gl, tile, origin, r0, rowLimit)
+
+# ═════════════════════════════════════════════════════════════════════
+#  RtRight variants (swapped views, guard on origin[3])
+#  ═════════════════════════════════════════════════════════════════════
+
+proc zeroRows[T; R, C: static int; A: static MmaAtom](
+    tile: var RtRight[T, R, C, A],
+    r0, rowLimit: int32) {.device.} =
+  ## Zeroes the tile's rows with plane row >= rowLimit, following the RtRight
+  ## frag ordering (col-tile m outer, row-tile n inner).
+  const M = A.getM()
+  const N = A.getN()
+  const rowTiles = R div M
+  const colTiles = C div N
+  const vpt = A.getVpt()
+  let lane = int(thread_index_in_threadgroup)
+  let cell = crd2idx(A.getLayoutA(), (lane, 0)).toIntVal()
+  let row = cell mod M
+  for n in 0 ..< rowTiles:
+    if r0 + int32(n * M + row) >= rowLimit:
+      for m in 0 ..< colTiles:
+        for v in 0 ..< vpt:
+          tile.frags[m][n].frag[v] =
+            when T is float16: 0'u16.asFp16()
+            else: T(0)
+
+proc loadTileRows*[TIn, TOut; R, C: static int; A: static MmaAtom](
+    tile: var RtRight[TOut, R, C, A],
+    gl: GlView[TIn],
+    origin: tuple,
+    rowLimit: int32) {.device.} =
+  ## Row-bounded loadTile for the swapped rmsnorm views: tile-plane
+  ## rows origin[3]·R + r at or above `rowLimit` are zero-filled instead of read.
+  loadTile(tile, gl, origin)
+  let r0 = int32(origin[3]) * int32(R)
+  if r0 + int32(R) > rowLimit:
+    zeroRows(tile, r0, rowLimit)
+
+proc storeRows[TIn; R, C: static int; A: static MmaAtom](
+    gl: GlView[float16],
+    tile: RtRight[TIn, R, C, A],
+    origin: tuple,
+    r0, rowLimit: int32) {.device.} =
+  ## Stores only the tile's in-range rows (plane row < rowLimit),
+  ## with the RtRight frag ordering and the swapped-view indexing.
+  const M = A.getM()
+  const N = A.getN()
+  const rowTiles = R div M
+  const colTiles = C div N
+  const vpt = A.getVpt()
+  let lane = int(thread_index_in_threadgroup)
+  let cell = crd2idx(A.getLayoutA(), (lane, 0)).toIntVal()
+  let row = cell mod M
+  let col = cell div M
+  let o = (int(origin[0]), int(origin[1]), int(origin[2]), int(origin[3]))
+  var dst = local_tile_dyn(gl, C, R, o)
+  for n in 0 ..< rowTiles:
+    if r0 + int32(n * M + row) < rowLimit:
+      for m in 0 ..< colTiles:
+        for v in 0 ..< vpt:
+          dst[col + m * N + v, row + n * M] =
+            tile.frags[m][n].frag[v].to(float16)
+
+proc storeTileRows*[R, C: static int; A: static MmaAtom](
+    gl: GlView[float16],
+    tile: RtRight[float32, R, C, A],
+    origin: tuple,
+    rowLimit: int32) {.device.} =
+  ## Row-bounded storeTile for the swapped rmsnorm views: rows at or above `rowLimit` are not written.
+  let r0 = int32(origin[3]) * int32(R)
+  if r0 + int32(R) <= rowLimit:
+    storeTile(gl, tile, origin)
+  else:
+    storeRows(gl, tile, origin, r0, rowLimit)

--- a/workspace/positron/tests/manual_gated_mlp_silu_fp16.nim
+++ b/workspace/positron/tests/manual_gated_mlp_silu_fp16.nim
@@ -1,0 +1,105 @@
+## Tattletale
+## Copyright (c) 2026 Mamy André-Ratsimbazafy
+## Licensed and distributed under either of
+##   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+##   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+## at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+##
+## Run: nim cpp -r --hints:off --warnings:off \
+##   --outdir:build/wip \
+##   --nimcache:nimcache/wip \
+##   workspace/positron/tests/manual_gated_mlp_silu_fp16.nim
+
+import std/strformat
+import workspace/crucible
+import workspace/ceramic
+import workspace/libtorch
+import workspace/libtorch as F
+import workspace/libtorch_testutils
+from workspace/libtorch/src/raw_libtorch import manual_seed
+import ../../ceramic/tests/tile_test_utils
+import ../src/kernels/ceramic/gated_mlp_silu
+
+const mlpMsl = metal:
+  proc gatedMlpSiluKernel(
+      Out: ptr UncheckedArray[float16],
+      X, wg, wu, wd: ptr UncheckedArray[float16],
+      M, K, NIntm, NOut: int32) {.global.} =
+    gated_mlp_silu_fwd(Out, X, wg, wu, wd, M, K, NIntm, NOut, 32)
+
+proc scaledRand(rows, cols: int, scaleF: float32): seq[float32] =
+  ## rand(rows, cols) shifted host-side to [-scaleF, scaleF). The
+  ## kernel buffer and the reference tensors derive from the same seq.
+  let t = rand(rows, cols)
+  let p = t.contiguous().data_ptr(float32)
+  result = newSeq[float32](rows * cols)
+  for i in 0 ..< rows * cols:
+    result[i] = (p[i] - 0.5'f32) * (2.0'f32 * scaleF)
+
+proc worstAbsDiff(a, b: F.Tensor): float32 =
+  ## Largest |a[i] - b[i]| over all elements.
+  let ap = a.contiguous().data_ptr(float32)
+  let bp = b.contiguous().data_ptr(float32)
+  result = 0.0'f32
+  for i in 0 ..< a.numel():
+    let d = abs(ap[i] - bp[i])
+    if d > result: result = d
+
+proc gatedMlpSiluKernel(xf, wgf, wuf, wdf: seq[float32], M, K, NIntm, NOut: int): F.Tensor =
+  ## Runs gatedMlpSiluKernel on the fp16-rounded inputs; returns the
+  ## fp16 output converted to fp32.
+  var engine = bkMetal.init()
+  engine.ingest(mlpMsl)
+  var xb = newSeq[uint16](M * K)
+  var wgb = newSeq[uint16](K * NIntm)
+  var wub = newSeq[uint16](K * NIntm)
+  var wdb = newSeq[uint16](NIntm * NOut)
+  for i in 0 ..< M * K:
+    xb[i] = fp32ToFp16(xf[i])
+  for i in 0 ..< K * NIntm:
+    wgb[i] = fp32ToFp16(wgf[i])
+    wub[i] = fp32ToFp16(wuf[i])
+  for i in 0 ..< NIntm * NOut:
+    wdb[i] = fp32ToFp16(wdf[i])
+  var outO = newSeq[uint16](M * NOut)
+  let args = (xb, wgb, wub, wdb, int32(M), int32(K), int32(NIntm), int32(NOut))
+  engine.run << (grid: (NOut div 32, (M + 31) div 32, 1), blk: (32, 1)) >> ("gatedMlpSiluKernel", outO, args)
+  var outF = newSeq[float32](M * NOut)
+  for i in 0 ..< M * NOut:
+    outF[i] = fp16ToFp32(outO[i])
+  result = toTensor(outF).reshape(M, NOut)
+
+proc gatedMlpSiluReference(xf, wgf, wuf, wdf: seq[float32], M, K, NIntm, NOut: int): F.Tensor =
+  ## The mlp.nim:82 reference out = down(silu(x·wg)·(x·wu)): torch
+  ## linear over the same fp16-rounded inputs, weights transposed to
+  ## linear's (out, in) layout.
+  let xh = toTensor(xf).reshape(M, K).to(kFloat16)
+  let wgh = toTensor(wgf).reshape(K, NIntm).to(kFloat16)
+  let wuh = toTensor(wuf).reshape(K, NIntm).to(kFloat16)
+  let wdh = toTensor(wdf).reshape(NIntm, NOut).to(kFloat16)
+  let x32 = xh.to(kFloat32)
+  let g = F.linear(x32, wgh.to(kFloat32).transpose(0, 1))
+  let u = F.linear(x32, wuh.to(kFloat32).transpose(0, 1))
+  let act = F.silu(g) * u
+  result = F.linear(act, wdh.to(kFloat32).transpose(0, 1))
+
+proc checkGatedMlpSilu(): bool =
+  ## One random batch: kernel output vs the torch reference.
+  Torch.manual_seed(0x5EED'u64)
+  let M = 32
+  let K = 64
+  let NIntm = 128
+  let NOut = 128
+  let xf = scaledRand(M, K, 0.5'f32)
+  let wgf = scaledRand(K, NIntm, 0.5'f32)
+  let wuf = scaledRand(K, NIntm, 0.5'f32)
+  let wdf = scaledRand(NIntm, NOut, 0.5'f32)
+  let actual = gatedMlpSiluKernel(xf, wgf, wuf, wdf, M, K, NIntm, NOut)
+  let expected = gatedMlpSiluReference(xf, wgf, wuf, wdf, M, K, NIntm, NOut)
+  echo &"  worst |Δ| = {worstAbsDiff(actual, expected)} (tolerance 5e-3)"
+  assertAllClose(actual, expected, rtol = 0.0'f64, abstol = 5e-3'f64)
+  result = true
+
+when isMainModule:
+  runCppTest("gated_mlp_silu vs the torch reference (mlp.nim:82)", checkGatedMlpSilu)

--- a/workspace/positron/tests/manual_paged_attn_fp16.nim
+++ b/workspace/positron/tests/manual_paged_attn_fp16.nim
@@ -1,0 +1,174 @@
+## Tattletale
+## Copyright (c) 2026 Mamy André-Ratsimbazafy
+## Licensed and distributed under either of
+##   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+##   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+## at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+##
+## Run: nim cpp -r --hints:off --warnings:off \
+##   --outdir:build/wip \
+##   --nimcache:nimcache/wip \
+##   workspace/positron/tests/manual_paged_attn_fp16.nim
+
+import std/[strformat, options, math, sequtils]
+import workspace/crucible
+import workspace/libtorch
+import workspace/libtorch as F
+import workspace/libtorch_testutils
+from workspace/libtorch/src/raw_libtorch import manual_seed
+import ../../ceramic/tests/tile_test_utils
+import ../src/kernels/ceramic/paged_attn
+
+const pagedMsl = metal:
+  proc pagedD128(
+      o, q: ptr UncheckedArray[float16],
+      k_cache, v_cache: ptr UncheckedArray[float16],
+      block_table, cache_seqlens, cu_seqlens_q: ptr UncheckedArray[int32],
+      num_seqs, H, Nkv, max_pages, page_size: int32) {.global.} =
+    paged_attn_fwd(o, q, k_cache, v_cache, block_table, cache_seqlens,
+                   cu_seqlens_q, num_seqs, H, Nkv, max_pages, page_size, 128)
+
+proc scaledRand(rows, cols: int, scaleF: float32): seq[float32] =
+  ## rand(rows, cols) shifted host-side to [-scaleF, scaleF). The
+  ## kernel buffer and the reference tensors derive from the same seq.
+  let t = rand(rows, cols)
+  let p = t.contiguous().data_ptr(float32)
+  result = newSeq[float32](rows * cols)
+  for i in 0 ..< rows * cols:
+    result[i] = (p[i] - 0.5'f32) * (2.0'f32 * scaleF)
+
+proc worstAbsDiff(a, b: F.Tensor): float32 =
+  ## Largest |a[i] - b[i]| over all elements.
+  let ap = a.contiguous().data_ptr(float32)
+  let bp = b.contiguous().data_ptr(float32)
+  result = 0.0'f32
+  for i in 0 ..< a.numel():
+    let d = abs(ap[i] - bp[i])
+    if d > result: result = d
+
+proc gatherKv(src: F.Tensor, blockTable: seq[int32], maxPages, pageSize, covered, s: int): F.Tensor =
+  ## The seq's contiguous K or V: the flat (num_pages·page_size, Nkv, D)
+  ## slab indexed by block_table[s, t div page_size]·page_size +
+  ## t mod page_size for t in [0, covered), the same address math the
+  ## kernel's per-block fetch uses.
+  var idx = newSeq[int64](covered)
+  for t in 0 ..< covered:
+    let pageIdx = t div pageSize
+    let inPage = t mod pageSize
+    idx[t] = int64(blockTable[s * maxPages + pageIdx] * pageSize + inPage)
+  src.index_select(0, toTensor(idx))
+
+proc sdpaDecode(qt, kt, vt: F.Tensor, H, Nkv: int): F.Tensor =
+  ## q (1, H, 1, D), k/v (covered, Nkv, D), causal off, GQA on.
+  let k2 = kt.reshape(1, kt.size(0), Nkv, kt.size(2)).transpose(1, 2)
+  let v2 = vt.reshape(1, vt.size(0), Nkv, vt.size(2)).transpose(1, 2)
+  scaled_dot_product_attention(qt, k2, v2, enable_gqa = H > Nkv)
+
+proc sdpaPrefill(qt, kt, vt: F.Tensor, cacheSeqlen, qLen, H, Nkv: int): F.Tensor =
+  ## q (1, H, qLen, D), k/v (covered, Nkv, D), banded causal mask over
+  ## [0, cache_seqlen + q_len), GQA on.
+  let covered = cacheSeqlen + qLen
+  var maskF = newSeq[float32](qLen * covered)
+  for j in 0 ..< qLen:
+    for k in 0 ..< covered:
+      maskF[j * covered + k] = if k <= cacheSeqlen + j: 0.0'f32 else: float32(NegInf)
+  let k2 = kt.reshape(1, covered, Nkv, kt.size(2)).transpose(1, 2)
+  let v2 = vt.reshape(1, covered, Nkv, vt.size(2)).transpose(1, 2)
+  let mt = toTensor(maskF).reshape(1, qLen, covered)
+  scaled_dot_product_attention(qt, k2, v2, attn_mask = some(mt), enable_gqa = H > Nkv)
+
+proc pagedAttnKernel(
+    qf, kf, vf: seq[float32],
+    blockTable, cacheSeqlens, cuSeqlensQ: seq[int32],
+    numSeqs, H, Nkv, maxPages, pageSize, nQo, D: int): F.Tensor =
+  ## Runs pagedD128 on the fp16-rounded inputs; returns the fp16
+  ## output converted to fp32.
+  var engine = bkMetal.init()
+  engine.ingest(pagedMsl)
+  var kSlab = newSeq[uint16](kf.len)
+  var vSlab = newSeq[uint16](vf.len)
+  var q = newSeq[uint16](qf.len)
+  for i in 0 ..< kf.len:
+    kSlab[i] = fp32ToFp16(kf[i])
+    vSlab[i] = fp32ToFp16(vf[i])
+  for i in 0 ..< qf.len:
+    q[i] = fp32ToFp16(qf[i])
+  var outO = newSeq[uint16](nQo * H * D)
+  let args = (q, kSlab, vSlab, blockTable, cacheSeqlens, cuSeqlensQ,
+              int32(numSeqs), int32(H), int32(Nkv), int32(maxPages),
+              int32(pageSize))
+  engine.run << (grid: (1, H, numSeqs), blk: (32, 1)) >> ("pagedD128", outO, args)
+  var outF = newSeq[float32](nQo * H * D)
+  for i in 0 ..< nQo * H * D:
+    outF[i] = fp16ToFp32(outO[i])
+  result = toTensor(outF).reshape(nQo, H, D)
+
+proc pagedAttnReference(
+    qf, kf, vf: seq[float32],
+    blockTable, cacheSeqlens, cuSeqlensQ, qLens: seq[int32],
+    numPages, maxPages, pageSize, numSeqs, H, Nkv, nQo, D: int): F.Tensor =
+  ## torch SDPA over the same fp16-rounded values, per seq: decode
+  ## (q_len = 1) causal off, prefill (q_len >= 2) banded causal over
+  ## [0, cache_seqlen + q_len). SDPA wants (1, H, q_len, D), so the
+  ## prefill q is transposed from the kernel's (q, H, D) order.
+  let kT = toTensor(kf).reshape(numPages * pageSize, Nkv, D).to(kFloat16).to(kFloat32)
+  let vT = toTensor(vf).reshape(numPages * pageSize, Nkv, D).to(kFloat16).to(kFloat32)
+  let qT = toTensor(qf).reshape(nQo, H, D).to(kFloat16).to(kFloat32)
+  var oRef = newSeq[float32](nQo * H * D)
+  for s in 0 ..< numSeqs:
+    let covered = cacheSeqlens[s].int + qLens[s].int - (if qLens[s] == 1: 1 else: 0)
+    let kt = gatherKv(kT, blockTable, maxPages, pageSize, covered, s)
+    let vt = gatherKv(vT, blockTable, maxPages, pageSize, covered, s)
+    let q0 = cuSeqlensQ[s].int
+    let qLen = qLens[s].int
+    let qp = qT.contiguous().data_ptr(float32)
+    let qt = if qLen == 1:
+               qT.narrow(0, q0, 1).reshape(1, H, 1, D)
+             else:
+               var qf2 = newSeq[float32](qLen * H * D)
+               for h in 0 ..< H:
+                 for j in 0 ..< qLen:
+                   for dd in 0 ..< D:
+                     qf2[(h * qLen + j) * D + dd] = qp[((q0 + j) * H + h) * D + dd]
+               toTensor(qf2).reshape(1, H, qLen, D)
+    let ot = if qLen == 1: sdpaDecode(qt, kt, vt, H, Nkv)
+             else: sdpaPrefill(qt, kt, vt, cacheSeqlens[s].int, qLen, H, Nkv)
+    let p = ot.contiguous().data_ptr(float32)
+    for h in 0 ..< H:
+      for j in 0 ..< qLen:
+        for dd in 0 ..< D:
+          oRef[((q0 + j) * H + h) * D + dd] = p[(h * qLen + j) * D + dd]
+  result = toTensor(oRef).reshape(nQo, H, D)
+
+proc checkPagedAttn(): bool =
+  ## One mixed batch (decode and prefill seqs under one cu_seqlens_q):
+  ## kernel output vs torch SDPA per seq.
+  Torch.manual_seed(0x5EED'u64)
+  let numSeqs = 3
+  let H = 4
+  let Nkv = 2
+  let D = 128
+  let pageSize = 16
+  let maxPages = 3
+  let numPages = 7
+  let nQo = 5
+  let cacheSeqlens = [20'i32, 5, 33].toSeq()
+  let qLens = [1'i32, 3, 1].toSeq()
+  let blockTable = [0'i32, 1, -1, 2, 3, -1, 4, 5, 6].toSeq()
+  let cuSeqlensQ = [0'i32, 1, 4, 5].toSeq()
+  let kf = scaledRand(numPages * pageSize, Nkv * D, 2.0'f32)
+  let vf = scaledRand(numPages * pageSize, Nkv * D, 2.0'f32)
+  let qf = scaledRand(nQo, H * D, 2.0'f32)
+  let actual = pagedAttnKernel(qf, kf, vf, blockTable, cacheSeqlens,
+                               cuSeqlensQ, numSeqs, H, Nkv, maxPages,
+                               pageSize, nQo, D)
+  let expected = pagedAttnReference(qf, kf, vf, blockTable, cacheSeqlens,
+                                    cuSeqlensQ, qLens, numPages, maxPages,
+                                    pageSize, numSeqs, H, Nkv, nQo, D)
+  echo &"  worst |Δ| = {worstAbsDiff(actual, expected)} (tolerance 5e-3)"
+  assertAllClose(actual, expected, rtol = 0.0'f64, abstol = 5e-3'f64)
+  result = true
+
+when isMainModule:
+  runCppTest("paged_attn vs torch SDPA (decode + prefill)", checkPagedAttn)

--- a/workspace/positron/tests/manual_rms_norm_res_in_fp16.nim
+++ b/workspace/positron/tests/manual_rms_norm_res_in_fp16.nim
@@ -1,0 +1,101 @@
+## Tattletale
+## Copyright (c) 2026 Mamy André-Ratsimbazafy
+## Licensed and distributed under either of
+##   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+##   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+## at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+##
+## Run: nim cpp -r --hints:off --warnings:off \
+##   --outdir:build/wip \
+##   --nimcache:nimcache/wip \
+##   workspace/positron/tests/manual_rms_norm_res_in_fp16.nim
+
+import std/strformat
+import workspace/crucible
+import workspace/libtorch
+import workspace/libtorch as F
+import workspace/libtorch_testutils
+from workspace/libtorch/src/raw_libtorch import manual_seed
+import ../../ceramic/tests/tile_test_utils
+import ../src/kernels/ceramic/rms_norm_res_in
+
+const rmsMsl = metal:
+  proc rmsNormResInKernel(
+      Out: ptr UncheckedArray[float16],
+      X, R, G: ptr UncheckedArray[float16],
+      M, C: int32,
+      eps: float32) {.global.} =
+    rms_norm_res_in_fwd(Out, X, R, G, M, C, eps, 128)
+
+proc scaledRand(rows, cols: int, scaleF: float32): seq[float32] =
+  ## rand(rows, cols) shifted host-side to [-scaleF, scaleF). The
+  ## kernel buffer and the reference tensors derive from the same seq.
+  let t = rand(rows, cols)
+  let p = t.contiguous().data_ptr(float32)
+  result = newSeq[float32](rows * cols)
+  for i in 0 ..< rows * cols:
+    result[i] = (p[i] - 0.5'f32) * (2.0'f32 * scaleF)
+
+proc worstAbsDiff(a, b: F.Tensor): float32 =
+  ## Largest |a[i] - b[i]| over all elements.
+  let ap = a.contiguous().data_ptr(float32)
+  let bp = b.contiguous().data_ptr(float32)
+  result = 0.0'f32
+  for i in 0 ..< a.numel():
+    let d = abs(ap[i] - bp[i])
+    if d > result: result = d
+
+proc rmsNormResInKernel(Xh, Rh, Gh: seq[uint16], M, C: int, eps: float32): F.Tensor =
+  ## Runs rmsNormResInKernel on the fp16 buffers; returns the fp16
+  ## output converted to fp32.
+  var engine = bkMetal.init()
+  engine.ingest(rmsMsl)
+  var outO = newSeq[uint16](M * C)
+  engine.run << (grid: (1, (M + 7) div 8), blk: (32, 1)) >> ("rmsNormResInKernel", outO, (Xh, Rh, Gh, int32(M), int32(C), eps))
+  var outF = newSeq[float32](M * C)
+  for i in 0 ..< M * C:
+    outF[i] = fp16ToFp32(outO[i])
+  result = toTensor(outF).reshape(M, C)
+
+proc rmsNormResInReference(M, C: int, Xh, Rh, Gh: seq[uint16], eps: float32): F.Tensor =
+  ## y = rms_norm(x + res, γ, ε) via libtorch: the fp16 residual add
+  ## (one RNE round, the same intermediate the kernel materializes),
+  ## then fp32 rms_norm on the widened sum.
+  var xf = newSeq[float32](M * C)
+  var rf = newSeq[float32](M * C)
+  var gf = newSeq[float32](C)
+  for i in 0 ..< M * C:
+    xf[i] = fp16ToFp32(Xh[i])
+    rf[i] = fp16ToFp32(Rh[i])
+  for c in 0 ..< C:
+    gf[c] = fp16ToFp32(Gh[c])
+  let sum = toTensor(xf).reshape(M, C).to(kFloat16) + toTensor(rf).reshape(M, C).to(kFloat16)
+  result = rms_norm(sum.to(kFloat32), C, toTensor(gf), float64(eps))
+
+proc checkRmsNormResIn(): bool =
+  ## One random (M, C) batch: kernel output vs torch rms_norm(x + res).
+  Torch.manual_seed(0x5EED'u64)
+  let M = 19            # partial last row tile
+  let C = 2048          # 16 column blocks of 128
+  let eps = 1e-2'f32
+  let n = M * C
+  let xs = scaledRand(M, C, 2.0'f32)
+  let rs = scaledRand(M, C, 2.0'f32)
+  let gs = scaledRand(1, C, 1.0'f32)
+  var Xh = newSeq[uint16](n)
+  var Rh = newSeq[uint16](n)
+  var Gh = newSeq[uint16](C)
+  for i in 0 ..< n:
+    Xh[i] = fp32ToFp16(xs[i])
+    Rh[i] = fp32ToFp16(rs[i])
+  for c in 0 ..< C:
+    Gh[c] = fp32ToFp16(gs[c])
+  let actual = rmsNormResInKernel(Xh, Rh, Gh, M, C, eps)
+  let expected = rmsNormResInReference(M, C, Xh, Rh, Gh, eps)
+  echo &"  worst |Δ| = {worstAbsDiff(actual, expected)} (tolerance 5e-3)"
+  assertAllClose(actual, expected, rtol = 0.0'f64, abstol = 5e-3'f64)
+  result = true
+
+when isMainModule:
+  runCppTest("rms_norm_res_in vs torch rms_norm(x + res)", checkRmsNormResIn)

--- a/workspace/positron/tests/manual_silu_and_mul_fp16.nim
+++ b/workspace/positron/tests/manual_silu_and_mul_fp16.nim
@@ -1,0 +1,87 @@
+## Tattletale
+## Copyright (c) 2026 Mamy André-Ratsimbazafy
+## Licensed and distributed under either of
+##   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+##   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+## at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+##
+## Run: nim cpp -r --hints:off --warnings:off \
+##   --outdir:build/wip \
+##   --nimcache:nimcache/wip \
+##   workspace/positron/tests/manual_silu_and_mul_fp16.nim
+
+import std/strformat
+import workspace/crucible
+import workspace/libtorch
+import workspace/libtorch as F
+import workspace/libtorch_testutils
+from workspace/libtorch/src/raw_libtorch import manual_seed
+import ../../ceramic/tests/tile_test_utils
+import ../src/kernels/ceramic/silu_and_mul
+
+const siluMsl = metal:
+  proc siluAndMulKernel(
+      Out: ptr UncheckedArray[float16],
+      X: ptr UncheckedArray[float16],
+      M, N: int32,
+      actLimit: float32) {.global.} =
+    silu_and_mul_fwd(Out, X, M, N, actLimit, 64)
+
+proc scaledRand(rows, cols: int, scaleF: float32): seq[float32] =
+  ## rand(rows, cols) shifted host-side to [-scaleF, scaleF). The
+  ## kernel buffer and the reference tensors derive from the same seq.
+  let t = rand(rows, cols)
+  let p = t.contiguous().data_ptr(float32)
+  result = newSeq[float32](rows * cols)
+  for i in 0 ..< rows * cols:
+    result[i] = (p[i] - 0.5'f32) * (2.0'f32 * scaleF)
+
+proc worstAbsDiff(a, b: F.Tensor): float32 =
+  ## Largest |a[i] - b[i]| over all elements.
+  let ap = a.contiguous().data_ptr(float32)
+  let bp = b.contiguous().data_ptr(float32)
+  result = 0.0'f32
+  for i in 0 ..< a.numel():
+    let d = abs(ap[i] - bp[i])
+    if d > result: result = d
+
+proc siluAndMulKernel(gs, us: seq[float32], M, N: int): F.Tensor =
+  ## Runs siluAndMulKernel on the fp16-rounded (g, u) interleaved
+  ## buffer; returns the fp16 output converted to fp32.
+  var engine = bkMetal.init()
+  engine.ingest(siluMsl)
+  var X = newSeq[uint16](M * 2 * N)
+  for r in 0 ..< M:
+    for c in 0 ..< N:
+      X[r * 2 * N + c] = fp32ToFp16(gs[r * N + c])
+      X[r * 2 * N + N + c] = fp32ToFp16(us[r * N + c])
+  var outO = newSeq[uint16](M * N)
+  engine.run << (grid: (N div 64, (M + 7) div 8, 1), blk: (32, 1)) >> ("siluAndMulKernel", outO, (X, int32(M), int32(N), 0.0'f32))
+  var outF = newSeq[float32](M * N)
+  for i in 0 ..< M * N:
+    outF[i] = fp16ToFp32(outO[i])
+  result = toTensor(outF).reshape(M, N)
+
+proc siluAndMulReference(gs, us: seq[float32], M, N: int): F.Tensor =
+  ## The mlp.nim:82 reference act = silu(g)·u, composed in fp32 over
+  ## the same fp16-rounded inputs.
+  let gT = toTensor(gs).reshape(M, N).to(kFloat16)
+  let uT = toTensor(us).reshape(M, N).to(kFloat16)
+  result = F.silu(gT.to(kFloat32)) * uT.to(kFloat32)
+
+proc checkSiluAndMul(): bool =
+  ## One random (M, N) batch: kernel output vs the torch reference.
+  Torch.manual_seed(0x5EED'u64)
+  let M = 32
+  let N = 128
+  let gs = scaledRand(M, N, 2.0'f32)
+  let us = scaledRand(M, N, 2.0'f32)
+  let actual = siluAndMulKernel(gs, us, M, N)
+  let expected = siluAndMulReference(gs, us, M, N)
+  echo &"  worst |Δ| = {worstAbsDiff(actual, expected)} (tolerance 5e-3)"
+  assertAllClose(actual, expected, rtol = 0.0'f64, abstol = 5e-3'f64)
+  result = true
+
+when isMainModule:
+  runCppTest("silu_and_mul vs the torch reference (mlp.nim:82)", checkSiluAndMul)


### PR DESCRIPTION
This adds tile-based:
- Paged attention to replace: https://github.com/mratsim/tattletale/blob/10cb70a24ad0b56389d7ea8746ef8b0e1999f60f/workspace/transformers/src/layers/attn.nim#L221-L297
- silu_and_mul fusion kernel for: https://github.com/mratsim/tattletale/blob/10cb70a24ad0b56389d7ea8746ef8b0e1999f60f/workspace/transformers/src/layers/mlp.nim#L80-L82
- RMS_Norm fusion: https://github.com/mratsim/tattletale/blob/10cb70a24ad0b56389d7ea8746ef8b0e1999f60f/workspace/transformers/src/layers/norm.nim#L83-L86
- Full MLP layer fused: https://github.com/mratsim/tattletale/blob/10cb70a24ad0b56389d7ea8746ef8b0e1999f60f/workspace/transformers/src/layers/mlp.nim#L64-L83

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added fused FP16 kernels for gated MLP, SiLU multiplication, residual RMS normalization, and paged attention.
  - Added support for partial-row tile loading and storing.
  - Expanded public kernel exports for tiled GEMM, RMSNorm, and attention operations.

- **Tests**
  - Added reference-based validation tests for all new kernels, including decode and prefill attention scenarios.

- **Documentation**
  - Documented recommended patterns for kernel tests against reference implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->