### PR TITLE
[Kernels] Add Multi-Head latent Attention (MLA), Sliding Window Attention (SWA) and Mixture-of-Experts (MoE)

### DIFF
--- a/workspace/positron/src/kernels/ceramic/mla_latent_fwd.nim
+++ b/workspace/positron/src/kernels/ceramic/mla_latent_fwd.nim
@@ -11,63 +11,43 @@
 #
 # ############################################################
 
-## MLA latent projection forward on the ceramic Tile API: the
-## Glm4MoeLiteAttention low-rank chain rebuilds the per-head q/k/v
-## states from the fp16 hidden rows and writes them for the SDPA core.
+## MLA latent projection forward: the Glm4MoeLiteAttention low-rank chain rebuilds per-head q/k/v states for the SDPA core.
 ## Experimental: not a production kernel, known gaps below, not fixed.
 ##
-## The chain per token t (fp16 inputs, fp32 accumulation, one fp16
-## RNE round at every state store. The model's RMSNorm rounds once,
-## the `weight * x.to(dtype)` form):
+## Dataflow per token (fp16 inputs, fp32 accumulation, fp16 RNE round at every state store):
 ##
-##   qa  = qa_w @ x                     (768)
-##   qn  = rms_norm(qa, 768, qa_g)      -> fp16
-##   q   = qb_w @ qn                    (num_heads · 256)
-##   kv  = kva_w @ x                    (576 = 512 k_pass + 64 k_rot)
-##   kp  = rms_norm(kv[0:512], kva_g)   -> fp16
-##   kb  = kvb_w @ kp                   (num_heads · 448)
-##   per head: q_nope = q[0:192], q_rot = q[192:256]
-##             k_nope = kb[0:192], v = kb[192:448]
-##   rope (interleaved, below) on q_rot and the shared k_rot
-##   store qo = cat(q_nope, q_rot), ko = cat(k_nope, k_rot), vo = v,
-##   each (num_tokens, num_heads, 256) fp16.
+##   q chain:  x --> qa_w @ --> qa --> rms_norm(qa, 768, qa_g) --> qn --> qb_w @ --> q
+##   kv chain: x --> kva_w @ --> kv = (kp_part 512, k_rot 64)
+##             kv[0:512] --> rms_norm(kv, 512, kva_g) --> kp --> kvb_w @ --> kb
+##   per head: q = (q_nope 192, q_rot 64), kb = (k_nope 192, v 256)
+##             q_rot, k_rot --> interleaved rope
+##   stores:   qo = (q_nope, q_rot), ko = (k_nope, k_rot), vo = v
+##             each (num_tokens, num_heads, 256) fp16
 ##
-## Interleaved rope (the model's apply_rotary_pos_emb_interleave,
-## rope_interleave = true): the 64-dim rot part rotates in ADJACENT
-## pairs (2i, 2i+1), i in [0, 32), by pos · theta^(−2i/64) with theta
-## = 1e6. The cos/sin tables are (num_tokens, 64) fp32 with entry c
-## equal to cos/sin of freq (c mod 32) (the model's emb =
-## cat((freqs, freqs))). The kernel reads table col i for pair i.
-## k_rot is computed once per token and replicated across heads (the
-## model's `k_rot.expand`).
+## Buffers:
+##   - qo, ko, vo: (num_tokens, num_heads, 256) fp16 output states
+##   - x: (num_tokens, 2048) fp16 hidden rows
+##   - qa_w: (768, 2048) fp16, qa_g: (768,) fp16
+##   - qb_w: (num_heads·256, 768) fp16
+##   - kva_w: (576, 2048) fp16, kva_g: (512,) fp16
+##   - kvb_w: (num_heads·448, 512) fp16
+##   - cos_t, sin_t: (num_tokens, 64) fp32 rope tables
 ##
-## Grid (ceil(num_tokens/8), num_heads div HBLK, 1), 32 lanes, one
-## 8-token × HBLK-head block per threadgroup. HBLK = 2: the kv_b
-## accumulator alone is 8·(2·448) fp32 = 224 registers per lane. Do
-## not raise without re-checking the register budget. The shared
-## projections (qa, qn, kv, krot, kp) compute once per threadgroup,
-## the per-head parts for the block's HBLK heads.
-##
-## GEMM structure: the exl3 K-loop with mma_AB into fp32 accumulators.
-## The qa/kv chains step 16-wide x tiles over 2048 (128 steps) against
-## 16×32 weight tiles. The q/kv_b chains step the 8×32 activation
-## tiles over 768/512 (24/16 steps) against 32×32 weight tiles. Every
-## output width is an exact 32-multiple (768 = 24×32, 576 = 18×32,
-## 448 = 14×32), so no tail tiles.
-##
-## Local device procs: normRound16 (the one-rounding RMSNorm
-## epilogue) and ropeTile32 (the interleaved adjacent-pair rotation)
-## live in this module. The row-bounded load/store come from
-## tile_io_rows (positron local extension).
+## Semantics:
+##   - the interleaved rope rotates the 64-dim rot parts in adjacent pairs
+##     (2i, 2i+1), i in [0, 32), by pos·theta^(−2i/64)
+##     (theta = 1e6). Table entry c = cos/sin of freq (c mod 32).
+##     k_rot computes once per token and replicates across heads.
+##   - the RMSNorm rounds once (the model's `weight * x.to(dtype)`)
 ##
 ## Known production gaps (documented, not fixed):
 ##   - the states feed the SDPA core with scale 0.0625
-##     (= qk_head_dim^−0.5, a consumer concern, not applied here)
-##   - prefill contract: num_tokens = the kv length, no cache or
-##     position offsets. num_tokens must be a multiple of 8 for the
-##     k/v store (rows beyond it are zero-filled and skipped)
-##   - x and the weights re-read from global per projection (no
-##     threadgroup staging)
+##     (qk_head_dim^−0.5, a consumer concern, not applied here)
+##   - prefill contract: num_tokens = the kv length, no cache
+##     or position offsets. num_tokens must be a multiple of 8.
+##     The k/v store zero-fills and skips rows beyond it.
+##   - x and the weights re-read from global per projection
+##     (no threadgroup staging)
 
 import workspace/crucible
 import workspace/ceramic
@@ -76,12 +56,12 @@ import ./tile_io_rows
 export int_tuples, layouts, layout_constructors, layout_indexing, tensors,
        ptr_arithmetic, tile_algebra
 
-# The real GLM-4.7-Flash dims, baked as module constants. The kernel is
-# non-generic: its tile types cannot take the rt_l/rv default atoms
-# (those call getTileConfig, which asserts a metal:/cuda: block context,
-# and a non-generic proc body is typechecked on the host import). The
-# explicit universal-atom enum members below are exactly what the
-# defaults resolve to on the Metal and CUDA backends.
+# The real GLM-4.7-Flash dims, baked as module constants.
+# The kernel is non-generic: its tile types cannot take the rt_l/rv
+# default atoms, which call getTileConfig and assert a metal:/cuda:
+# block context. A non-generic proc body is typechecked on the host
+# import.
+# The explicit universal-atom enum members below are exactly what the defaults resolve to on the Metal and CUDA backends.
 
 const
   HiddenDim = 2048      # the model hidden size
@@ -105,10 +85,10 @@ proc normRound16[A: static MmaAtom](
     rowVals: Tensor[float32, (Int[1], Int[2]), (Int[2], Int[1])]) {.device.} =
   ## `dst[r][c] = fp16(src[r][c] · rowVals[r] · gamma[r][c])`: the MLA
   ## RMSNorm epilogue with one fp16 RNE round at the end (the model's
-  ## `weight * x.to(dtype)` rounding). `rowVals` is the
-  ## row-rsqrt'ed variance col-vec (fp32 variance mean(x²) + eps). The
-  ## frag walk follows the loadTile lane→element mapping, so src,
-  ## gamma and dst agree elementwise.
+  ## `weight * x.to(dtype)` rounding). `rowVals` is the row-rsqrt'ed
+  ## variance col-vec (fp32 variance mean(x²) + eps). The frag walk
+  ## follows the loadTile lane→element mapping, so src, gamma and dst
+  ## agree elementwise.
   const rowTiles = 8 div A.getM()
   const colTiles = 32 div A.getN()
   const vpt = A.getVpt()
@@ -124,12 +104,12 @@ proc ropeTile32[A: static MmaAtom](
     cosT, sinT: ptr UncheckedArray[float32],
     t0, pairOff: int32) {.device.} =
   ## In-place interleaved rope over one (8, 32) fp32 rot half-tile:
-  ## each lane owns one adjacent pair (the AC layout col pairs), so
-  ## the rotation needs no cross-lane data. The cos/sin for pair index
-  ## `pairOff + 4m + (cell div 16)` come from the (num_tokens, 64)
-  ## tables' col i (entry c = freq (c mod 32)). `t0` is the tile's
-  ## first token row. `pairOff` is 0 for the low half (pairs 0..15)
-  ## and 16 for the high half (pairs 16..31).
+  ## each lane owns one adjacent pair (the AC layout col pairs).
+  ## The rotation needs no cross-lane data. The cos/sin for the pair
+  ## index `pairOff + 4m + (cell div 16)` come from the tables' col i
+  ## (entry c = freq (c mod 32)).
+  ## `t0` is the tile's first token row. `pairOff` is 0 for the low
+  ## half (pairs 0..15) and 16 for the high half (pairs 16..31).
   const M = A.getM()
   const colTiles = 32 div A.getN()
   let lane = int(thread_index_in_threadgroup)
@@ -164,11 +144,27 @@ proc mla_latent_fwd*(
     num_tokens, num_heads: int32) {.device.} =
   ## Computes the module doc's contract for one 8-token × 2-head
   ## block: the qa/qn/q and kv/krot/kp/kb chains, the interleaved rope
-  ## on the in-register rot tiles, and the q/k/v stores (fp16 RNE at
-  ## every state store). The q/k/v views carry the (token, head, dim)
+  ## on the in-register rot tiles, and the q/k/v stores.
+  ##
+  ## Grid (ceil(num_tokens/8), num_heads div 2, 1), 32 lanes.
+  ## One 8-token × 2-head block per threadgroup. HBLK = 2 keeps the kv_b
+  ## accumulator at 224 fp32 registers per lane, the largest single accumulator.
+  ## Raising HBLK requires re-checking the register budget.
+  ## The full breakdown is inline at the accumulator declarations.
+  ## The shared projections (qa, qn, kv, k_rot, kp) compute once per threadgroup.
+  ## The per-head parts follow for the block's 2 heads.
+  ##
+  ## GEMM structure: the qa/kv chains step 16-wide x tiles over 2048
+  ## (128 steps) against 16×32 weight tiles. The q/kv_b chains step
+  ## the 8×32 activation tiles over 768/512 (24/16 steps) against
+  ## 32×32 weight tiles. Every output width is an exact 32-multiple
+  ## (768 = 24×32, 576 = 18×32, 448 = 14×32), so no tail tiles.
+  ##
+  ## Views: the q/k/v output views carry the (token, head, dim)
   ## strides. The qb_w/kvb_w views carry the head block in the batch
-  ## component (head0 · 256 or head0 · 448 rows), the rest are the
-  ## transposed B-operand views of the row-major (out, in) buffers.
+  ## component (head0 · 256 or head0 · 448 rows), the other weights
+  ## are transposed B-operand views of the row-major (out, in)
+  ## buffers.
   let tBlock = int32(threadgroup_position_in_grid.x)
   let hBlock = int32(threadgroup_position_in_grid.y)
   let head0 = hBlock * 2
@@ -266,9 +262,9 @@ proc mla_latent_fwd*(
     qAcc[hh * (QkHeadDim div 32) + QkNopeDim div 32].ropeTile32(cos_t, sin_t, tBlock * 8, 0)
     qAcc[hh * (QkHeadDim div 32) + QkNopeDim div 32 + 1].ropeTile32(cos_t, sin_t, tBlock * 8, 16)
 
-  # ── stores: the nope parts straight from the accumulators, the
-  #    roped rot tiles at the head's cols [192, 256), the shared
-  #    k_rot at both heads' rot cols ──
+  # ── stores: nope parts from the accumulators.
+  #    Roped rot tiles land in the head's cols [192, 256).
+  #    The shared k_rot lands in both heads' rot cols ──
   for hh in 0'i32 ..< 2:
     let head = head0 + hh
     let headTiles = QkHeadDim div 32

--- a/workspace/positron/src/kernels/ceramic/mla_latent_fwd.nim
+++ b/workspace/positron/src/kernels/ceramic/mla_latent_fwd.nim
@@ -1,0 +1,284 @@
+## Tattletale
+## Copyright (c) 2026 Mamy André-Ratsimbazafy
+## Licensed and distributed under either of
+##   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+##   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+## at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+# ############################################################
+#
+#     MLA latent projection forward (mla_latent_fwd): Tile API port
+#
+# ############################################################
+
+## MLA latent projection forward on the ceramic Tile API: the
+## Glm4MoeLiteAttention low-rank chain rebuilds the per-head q/k/v
+## states from the fp16 hidden rows and writes them for the SDPA core.
+## Experimental: not a production kernel, known gaps below, not fixed.
+##
+## The chain per token t (fp16 inputs, fp32 accumulation, one fp16
+## RNE round at every state store. The model's RMSNorm does ONE
+## rounding, unlike qk_norm_rope's two-rounding form):
+##
+##   qa  = qa_w @ x                     (768)
+##   qn  = rms_norm(qa, 768, qa_g)      -> fp16
+##   q   = qb_w @ qn                    (num_heads · 256)
+##   kv  = kva_w @ x                    (576 = 512 k_pass + 64 k_rot)
+##   kp  = rms_norm(kv[0:512], kva_g)   -> fp16
+##   kb  = kvb_w @ kp                   (num_heads · 448)
+##   per head: q_nope = q[0:192], q_rot = q[192:256]
+##             k_nope = kb[0:192], v = kb[192:448]
+##   rope (interleaved, below) on q_rot and the shared k_rot
+##   store qo = cat(q_nope, q_rot), ko = cat(k_nope, k_rot), vo = v,
+##   each (num_tokens, num_heads, 256) fp16.
+##
+## Interleaved rope (the model's apply_rotary_pos_emb_interleave,
+## rope_interleave = true): the 64-dim rot part rotates in ADJACENT
+## pairs (2i, 2i+1), i in [0, 32), by pos · theta^(−2i/64) with theta
+## = 1e6. The cos/sin tables are (num_tokens, 64) fp32 with entry c
+## equal to cos/sin of freq (c mod 32) (the model's emb =
+## cat((freqs, freqs))). The kernel reads table col i for pair i.
+## k_rot is computed once per token and replicated across heads (the
+## model's `k_rot.expand`).
+##
+## Grid (ceil(num_tokens/8), num_heads div HBLK, 1), 32 lanes, one
+## 8-token × HBLK-head block per threadgroup. HBLK = 2: the kv_b
+## accumulator alone is 8·(2·448) fp32 = 224 registers per lane. Do
+## not raise without re-checking the register budget. The shared
+## projections (qa, qn, kv, krot, kp) compute once per threadgroup,
+## the per-head parts for the block's HBLK heads.
+##
+## GEMM structure: the exl3 K-loop with mma_AB into fp32 accumulators.
+## The qa/kv chains step 16-wide x tiles over 2048 (128 steps) against
+## 16×32 weight tiles. The q/kv_b chains step the 8×32 activation
+## tiles over 768/512 (24/16 steps) against 32×32 weight tiles. Every
+## output width is an exact 32-multiple (768 = 24×32, 576 = 18×32,
+## 448 = 14×32), so no tail tiles.
+##
+## Local device procs: normRound16 (the one-rounding RMSNorm
+## epilogue) and ropeTile32 (the interleaved adjacent-pair rotation)
+## live in this module. The row-bounded load/store come from
+## tile_io_rows (positron local extension).
+##
+## Known production gaps (documented, not fixed):
+##   - the states feed the SDPA core with scale 0.0625
+##     (= qk_head_dim^−0.5, a consumer concern, not applied here)
+##   - prefill contract: num_tokens = the kv length, no cache or
+##     position offsets. num_tokens must be a multiple of 8 for the
+##     k/v store (rows beyond it are zero-filled and skipped)
+##   - x and the weights re-read from global per projection (no
+##     threadgroup staging)
+
+import workspace/crucible
+import workspace/ceramic
+import ./tile_io_rows
+
+export int_tuples, layouts, layout_constructors, layout_indexing, tensors,
+       ptr_arithmetic, tile_algebra
+
+# The real GLM-4.7-Flash dims, baked as module constants. The kernel is
+# non-generic: its tile types cannot take the rt_l/rv default atoms
+# (those call getTileConfig, which asserts a metal:/cuda: block context,
+# and a non-generic proc body is typechecked on the host import). The
+# explicit universal-atom enum members below are exactly what the
+# defaults resolve to on the Metal and CUDA backends.
+
+const
+  HiddenDim = 2048      # the model hidden size
+  QLoRARank = 768       # the q_a projection width
+  KvLoRARank = 512      # the kv_a k_pass width
+  QkRopeDim = 64        # the rotary head dim
+  QkNopeDim = 192       # the non-rotary q/k head dim
+  QkHeadDim = 256       # qk_nope + qk_rope, the stored q/k head width
+  VHeadDim = 256        # the stored v head width
+  KvAOut = 576          # KvLoRARank + QkRopeDim, the kv_a width
+  KvBPerHead = 448      # QkNopeDim + VHeadDim, the per-head kv_b width
+  RmsEps = 1e-5'f32     # rms_norm_eps
+
+# ═════════════════════════════════════════════════════════════════════
+#  Local device extensions: the fusion's per-element arithmetic
+#  ═════════════════════════════════════════════════════════════════════
+
+proc normRound16[A: static MmaAtom](
+    dst: var RtLeft[float16, 8, 32, A],
+    src: RtLeft[float32, 8, 32, A],
+    gamma: RtLeft[float16, 8, 32, A],
+    rowVals: Tensor[float32, (Int[1], Int[2]), (Int[2], Int[1])]) {.device.} =
+  ## `dst[r][c] = fp16(src[r][c] · rowVals[r] · gamma[r][c])`: the MLA
+  ## RMSNorm epilogue with ONE fp16 RNE round at the end (the model's
+  ## rounding, not the two-round qk_norm_rope form). `rowVals` is the
+  ## row-rsqrt'ed variance col-vec (fp32 variance mean(x²) + eps). The
+  ## frag walk follows the loadTile lane→element mapping, so src,
+  ## gamma and dst agree elementwise.
+  const rowTiles = 8 div A.getM()
+  const colTiles = 32 div A.getN()
+  const vpt = A.getVpt()
+  for n in 0 ..< rowTiles:
+    for m in 0 ..< colTiles:
+      for v in 0 ..< vpt:
+        let x = src.frags[n][m].frag[v] * rowVals.data[n * vpt + v]
+        dst.frags[n][m].frag[v] =
+          (x * gamma.frags[n][m].frag[v].to(float32)).to(float16)
+
+proc ropeTile32[A: static MmaAtom](
+    tile: var RtLeft[float32, 8, 32, A],
+    cosT, sinT: ptr UncheckedArray[float32],
+    t0, pairOff: int32) {.device.} =
+  ## In-place interleaved rope over one (8, 32) fp32 rot half-tile:
+  ## each lane owns one adjacent pair (the AC layout col pairs), so
+  ## the rotation needs no cross-lane data. The cos/sin for pair index
+  ## `pairOff + 4m + (cell div 16)` come from the (num_tokens, 64)
+  ## tables' col i (entry c = freq (c mod 32)). `t0` is the tile's
+  ## first token row. `pairOff` is 0 for the low half (pairs 0..15)
+  ## and 16 for the high half (pairs 16..31).
+  const M = A.getM()
+  const colTiles = 32 div A.getN()
+  let lane = int(thread_index_in_threadgroup)
+  let cell = crd2idx(A.getLayoutA(), (lane, 0)).toIntVal()
+  let row = cell mod M
+  let pairInFrag = cell div 16
+  for m in 0 ..< colTiles:
+    let i = pairOff + int32(4 * m + pairInFrag)
+    let c = cosT[(t0 + int32(row)) * 64 + i]
+    let s = sinT[(t0 + int32(row)) * 64 + i]
+    let v0 = tile.frags[0][m].frag[0]
+    let v1 = tile.frags[0][m].frag[1]
+    tile.frags[0][m].frag[0] = v0 * c - v1 * s
+    tile.frags[0][m].frag[1] = v1 * c + v0 * s
+
+# ═════════════════════════════════════════════════════════════════════
+#  The kernel
+#  ═════════════════════════════════════════════════════════════════════
+
+proc mla_latent_fwd*(
+    qo: ptr UncheckedArray[float16],   # (num_tokens, num_heads, 256) fp16
+    ko: ptr UncheckedArray[float16],   # (num_tokens, num_heads, 256) fp16
+    vo: ptr UncheckedArray[float16],   # (num_tokens, num_heads, 256) fp16
+    x: ptr UncheckedArray[float16],    # (num_tokens, 2048) fp16
+    qa_w: ptr UncheckedArray[float16], # (768, 2048) fp16 row-major (out, in)
+    qa_g: ptr UncheckedArray[float16], # (768) fp16 RMSNorm weight
+    qb_w: ptr UncheckedArray[float16], # (num_heads·256, 768) fp16
+    kva_w: ptr UncheckedArray[float16],# (576, 2048) fp16
+    kva_g: ptr UncheckedArray[float16],# (512) fp16 RMSNorm weight
+    kvb_w: ptr UncheckedArray[float16],# (num_heads·448, 512) fp16
+    cos_t, sin_t: ptr UncheckedArray[float32],  # (num_tokens, 64) fp32
+    num_tokens, num_heads: int32) {.device.} =
+  ## Computes the module doc's contract for one 8-token × 2-head
+  ## block: the qa/qn/q and kv/krot/kp/kb chains, the interleaved rope
+  ## on the in-register rot tiles, and the q/k/v stores (fp16 RNE at
+  ## every state store). The q/k/v views carry the (token, head, dim)
+  ## strides. The qb_w/kvb_w views carry the head block in the batch
+  ## component (head0 · 256 or head0 · 448 rows), the rest are the
+  ## transposed B-operand views of the row-major (out, in) buffers.
+  let tBlock = int32(threadgroup_position_in_grid.x)
+  let hBlock = int32(threadgroup_position_in_grid.y)
+  let head0 = hBlock * 2
+
+  let glQo = qo.gd(shape = (-1, -1, -1, -1), stride = (num_heads * 256, 256, num_heads * 256, 1))
+  let glKo = ko.gd(shape = (-1, -1, -1, -1), stride = (num_heads * 256, 256, num_heads * 256, 1))
+  let glVo = vo.gd(shape = (-1, -1, -1, -1), stride = (num_heads * 256, 256, num_heads * 256, 1))
+  let glX = x.gd(shape = (-1, -1, -1, -1), stride = (2048, 0, 2048, 1))
+  let glQaW = qa_w.gd(shape = (-1, -1, -1, -1), stride = (1, 0, 2048, 1))
+  let glQaG = qa_g.gd(shape = (-1, -1, -1, -1), stride = (0, 0, 0, 1))
+  let glQbW = qb_w.gd(shape = (-1, -1, -1, -1), stride = (256 * 768, 0, 768, 1))
+  let glKvaW = kva_w.gd(shape = (-1, -1, -1, -1), stride = (1, 0, 2048, 1))
+  let glKvaG = kva_g.gd(shape = (-1, -1, -1, -1), stride = (0, 0, 0, 1))
+  let glKvbW = kvb_w.gd(shape = (-1, -1, -1, -1), stride = (448 * 512, 0, 512, 1))
+
+  # The accumulator arrays: 32-wide N-tiles over the threadgroup's
+  # 8 tokens × 2 heads. Register budget per lane (fp32 units): qa 192,
+  # q 128, kv 144, kb 224, plus the qn/kp fp16 state and the B tiles.
+  var qaAcc: array[24, rt_l(float32, 8, 32, UNIVERSAL_8x8x8_F32F16F16F32)]
+  var qnT: array[24, rt_l(float16, 8, 32, UNIVERSAL_8x8x8_F32F16F16F32)]
+  var qAcc: array[16, rt_l(float32, 8, 32, UNIVERSAL_8x8x8_F32F16F16F32)]
+  var kvAcc: array[18, rt_l(float32, 8, 32, UNIVERSAL_8x8x8_F32F16F16F32)]
+  var kpT: array[16, rt_l(float16, 8, 32, UNIVERSAL_8x8x8_F32F16F16F32)]
+  var kbAcc: array[28, rt_l(float32, 8, 32, UNIVERSAL_8x8x8_F32F16F16F32)]
+
+  var a: rt_l(float16, 8, 16, UNIVERSAL_8x8x8_F32F16F16F32)
+  var b: rt_r(float16, 16, 32, UNIVERSAL_8x8x8_F32F16F16F32)
+  var b32: rt_r(float16, 32, 32, UNIVERSAL_8x8x8_F32F16F16F32)
+  var sq: rt_l(float32, 8, 32, UNIVERSAL_8x8x8_F32F16F16F32)
+  var ss: rv(float32, 8, 8, UNIVERSAL_8x8x8_F32F16F16F32)
+  var gammaT: rt_l(float16, 8, 32, UNIVERSAL_8x8x8_F32F16F16F32)
+
+  # ── qa = qa_w @ x, then the one-rounding RMSNorm over 768 ──
+  for nt in 0 ..< 24:
+    qaAcc[nt].zero()
+  for kk in 0'i32 ..< HiddenDim div 16:
+    a.loadTileRows(glX, (0, 0, tBlock, kk), num_tokens)
+    for nt in 0'i32 ..< 24:
+      b.loadTile(glQaW, (0, 0, nt, kk))
+      qaAcc[nt].mma_AB(a, b)
+  ss.zero()
+  for nt in 0 ..< 24:
+    sq.mul(qaAcc[nt], qaAcc[nt])
+    ss.row_sum(sq, ss)
+  ss.mul(ss, 1.0'f32 / 768.0'f32)
+  ss.add(ss, RmsEps)
+  ss.rsqrt(ss)
+  for nt in 0 ..< 24:
+    gammaT.loadTile(glQaG, (0, 0, 0, nt))
+    qnT[nt].normRound16(qaAcc[nt], gammaT, ss)
+
+  # ── q = qb_w @ qn (768-wide K, 16 N-tiles = 2 heads × 256) ──
+  for nt in 0 ..< 16:
+    qAcc[nt].zero()
+  for kk in 0'i32 ..< QLoRARank div 32:
+    for nt in 0'i32 ..< 16:
+      b32.loadTile(glQbW, (head0, 0, nt, kk))
+      qAcc[nt].mma_AB(qnT[kk], b32)
+
+  # ── kv = kva_w @ x (576 = 512 k_pass + 64 k_rot) ──
+  for nt in 0 ..< 18:
+    kvAcc[nt].zero()
+  for kk in 0'i32 ..< HiddenDim div 16:
+    a.loadTileRows(glX, (0, 0, tBlock, kk), num_tokens)
+    for nt in 0'i32 ..< 18:
+      b.loadTile(glKvaW, (0, 0, nt, kk))
+      kvAcc[nt].mma_AB(a, b)
+
+  # ── kp = rms_norm(kv[0:512], kva_g), one rounding ──
+  ss.zero()
+  for nt in 0 ..< 16:
+    sq.mul(kvAcc[nt], kvAcc[nt])
+    ss.row_sum(sq, ss)
+  ss.mul(ss, 1.0'f32 / 512.0'f32)
+  ss.add(ss, RmsEps)
+  ss.rsqrt(ss)
+  for nt in 0 ..< 16:
+    gammaT.loadTile(glKvaG, (0, 0, 0, nt))
+    kpT[nt].normRound16(kvAcc[nt], gammaT, ss)
+
+  # ── kb = kvb_w @ kp (512-wide K, 28 N-tiles = 2 heads × 448) ──
+  for nt in 0 ..< 28:
+    kbAcc[nt].zero()
+  for kk in 0'i32 ..< KvLoRARank div 32:
+    for nt in 0'i32 ..< 28:
+      b32.loadTile(glKvbW, (head0, 0, nt, kk))
+      kbAcc[nt].mma_AB(kpT[kk], b32)
+
+  # ── interleaved rope, in place on the rot accumulator tiles:
+  #    kvAcc[16..17] = the shared k_rot (pairs 0..15, 16..31),
+  #    qAcc[hh·8 + 6..7] = head hh's q_rot halves ──
+  kvAcc[16].ropeTile32(cos_t, sin_t, tBlock * 8, 0)
+  kvAcc[17].ropeTile32(cos_t, sin_t, tBlock * 8, 16)
+  for hh in 0 ..< 2:
+    qAcc[hh * 8 + 6].ropeTile32(cos_t, sin_t, tBlock * 8, 0)
+    qAcc[hh * 8 + 7].ropeTile32(cos_t, sin_t, tBlock * 8, 16)
+
+  # ── stores: the nope parts straight from the accumulators, the
+  #    roped rot tiles at the head's cols [192, 256), the shared
+  #    k_rot at both heads' rot cols ──
+  for hh in 0'i32 ..< 2:
+    let head = head0 + hh
+    for nt in 0'i32 ..< 6:
+      glQo.storeTileRows(qAcc[hh * 8 + nt], (0, head, tBlock, nt), num_tokens)
+    glQo.storeTileRows(qAcc[hh * 8 + 6], (0, head, tBlock, 6), num_tokens)
+    glQo.storeTileRows(qAcc[hh * 8 + 7], (0, head, tBlock, 7), num_tokens)
+    for nt in 0'i32 ..< 6:
+      glKo.storeTileRows(kbAcc[hh * 14 + nt], (0, head, tBlock, nt), num_tokens)
+    glKo.storeTileRows(kvAcc[16], (0, head, tBlock, 6), num_tokens)
+    glKo.storeTileRows(kvAcc[17], (0, head, tBlock, 7), num_tokens)
+    for nt in 0'i32 ..< 8:
+      glVo.storeTileRows(kbAcc[hh * 14 + 6 + nt], (0, head, tBlock, nt), num_tokens)

--- a/workspace/positron/src/kernels/ceramic/mla_latent_fwd.nim
+++ b/workspace/positron/src/kernels/ceramic/mla_latent_fwd.nim
@@ -17,8 +17,8 @@
 ## Experimental: not a production kernel, known gaps below, not fixed.
 ##
 ## The chain per token t (fp16 inputs, fp32 accumulation, one fp16
-## RNE round at every state store. The model's RMSNorm does ONE
-## rounding, unlike qk_norm_rope's two-rounding form):
+## RNE round at every state store. The model's RMSNorm rounds once,
+## the `weight * x.to(dtype)` form):
 ##
 ##   qa  = qa_w @ x                     (768)
 ##   qn  = rms_norm(qa, 768, qa_g)      -> fp16
@@ -87,11 +87,10 @@ const
   HiddenDim = 2048      # the model hidden size
   QLoRARank = 768       # the q_a projection width
   KvLoRARank = 512      # the kv_a k_pass width
-  QkRopeDim = 64        # the rotary head dim
   QkNopeDim = 192       # the non-rotary q/k head dim
   QkHeadDim = 256       # qk_nope + qk_rope, the stored q/k head width
   VHeadDim = 256        # the stored v head width
-  KvAOut = 576          # KvLoRARank + QkRopeDim, the kv_a width
+  KvAOut = 576          # KvLoRARank + the 64-dim rotary, the kv_a width
   KvBPerHead = 448      # QkNopeDim + VHeadDim, the per-head kv_b width
   RmsEps = 1e-5'f32     # rms_norm_eps
 
@@ -105,8 +104,8 @@ proc normRound16[A: static MmaAtom](
     gamma: RtLeft[float16, 8, 32, A],
     rowVals: Tensor[float32, (Int[1], Int[2]), (Int[2], Int[1])]) {.device.} =
   ## `dst[r][c] = fp16(src[r][c] · rowVals[r] · gamma[r][c])`: the MLA
-  ## RMSNorm epilogue with ONE fp16 RNE round at the end (the model's
-  ## rounding, not the two-round qk_norm_rope form). `rowVals` is the
+  ## RMSNorm epilogue with one fp16 RNE round at the end (the model's
+  ## `weight * x.to(dtype)` rounding). `rowVals` is the
   ## row-rsqrt'ed variance col-vec (fp32 variance mean(x²) + eps). The
   ## frag walk follows the loadTile lane→element mapping, so src,
   ## gamma and dst agree elementwise.
@@ -174,26 +173,26 @@ proc mla_latent_fwd*(
   let hBlock = int32(threadgroup_position_in_grid.y)
   let head0 = hBlock * 2
 
-  let glQo = qo.gd(shape = (-1, -1, -1, -1), stride = (num_heads * 256, 256, num_heads * 256, 1))
-  let glKo = ko.gd(shape = (-1, -1, -1, -1), stride = (num_heads * 256, 256, num_heads * 256, 1))
-  let glVo = vo.gd(shape = (-1, -1, -1, -1), stride = (num_heads * 256, 256, num_heads * 256, 1))
+  let glQo = qo.gd(shape = (-1, -1, -1, -1), stride = (num_heads * QkHeadDim, QkHeadDim, num_heads * QkHeadDim, 1))
+  let glKo = ko.gd(shape = (-1, -1, -1, -1), stride = (num_heads * QkHeadDim, QkHeadDim, num_heads * QkHeadDim, 1))
+  let glVo = vo.gd(shape = (-1, -1, -1, -1), stride = (num_heads * VHeadDim, VHeadDim, num_heads * VHeadDim, 1))
   let glX = x.gd(shape = (-1, -1, -1, -1), stride = (2048, 0, 2048, 1))
   let glQaW = qa_w.gd(shape = (-1, -1, -1, -1), stride = (1, 0, 2048, 1))
   let glQaG = qa_g.gd(shape = (-1, -1, -1, -1), stride = (0, 0, 0, 1))
-  let glQbW = qb_w.gd(shape = (-1, -1, -1, -1), stride = (256 * 768, 0, 768, 1))
+  let glQbW = qb_w.gd(shape = (-1, -1, -1, -1), stride = (QkHeadDim * QLoRARank, 0, QLoRARank, 1))
   let glKvaW = kva_w.gd(shape = (-1, -1, -1, -1), stride = (1, 0, 2048, 1))
   let glKvaG = kva_g.gd(shape = (-1, -1, -1, -1), stride = (0, 0, 0, 1))
-  let glKvbW = kvb_w.gd(shape = (-1, -1, -1, -1), stride = (448 * 512, 0, 512, 1))
+  let glKvbW = kvb_w.gd(shape = (-1, -1, -1, -1), stride = (KvBPerHead * KvLoRARank, 0, KvLoRARank, 1))
 
   # The accumulator arrays: 32-wide N-tiles over the threadgroup's
   # 8 tokens × 2 heads. Register budget per lane (fp32 units): qa 192,
   # q 128, kv 144, kb 224, plus the qn/kp fp16 state and the B tiles.
   var qaAcc: array[24, rt_l(float32, 8, 32, UNIVERSAL_8x8x8_F32F16F16F32)]
   var qnT: array[24, rt_l(float16, 8, 32, UNIVERSAL_8x8x8_F32F16F16F32)]
-  var qAcc: array[16, rt_l(float32, 8, 32, UNIVERSAL_8x8x8_F32F16F16F32)]
-  var kvAcc: array[18, rt_l(float32, 8, 32, UNIVERSAL_8x8x8_F32F16F16F32)]
-  var kpT: array[16, rt_l(float16, 8, 32, UNIVERSAL_8x8x8_F32F16F16F32)]
-  var kbAcc: array[28, rt_l(float32, 8, 32, UNIVERSAL_8x8x8_F32F16F16F32)]
+  var qAcc: array[2 * QkHeadDim div 32, rt_l(float32, 8, 32, UNIVERSAL_8x8x8_F32F16F16F32)]
+  var kvAcc: array[KvAOut div 32, rt_l(float32, 8, 32, UNIVERSAL_8x8x8_F32F16F16F32)]
+  var kpT: array[KvLoRARank div 32, rt_l(float16, 8, 32, UNIVERSAL_8x8x8_F32F16F16F32)]
+  var kbAcc: array[2 * KvBPerHead div 32, rt_l(float32, 8, 32, UNIVERSAL_8x8x8_F32F16F16F32)]
 
   var a: rt_l(float16, 8, 16, UNIVERSAL_8x8x8_F32F16F16F32)
   var b: rt_r(float16, 16, 32, UNIVERSAL_8x8x8_F32F16F16F32)
@@ -203,26 +202,26 @@ proc mla_latent_fwd*(
   var gammaT: rt_l(float16, 8, 32, UNIVERSAL_8x8x8_F32F16F16F32)
 
   # ── qa = qa_w @ x, then the one-rounding RMSNorm over 768 ──
-  for nt in 0 ..< 24:
+  for nt in 0 ..< QLoRARank div 32:
     qaAcc[nt].zero()
   for kk in 0'i32 ..< HiddenDim div 16:
     a.loadTileRows(glX, (0, 0, tBlock, kk), num_tokens)
-    for nt in 0'i32 ..< 24:
+    for nt in 0'i32 ..< QLoRARank div 32:
       b.loadTile(glQaW, (0, 0, nt, kk))
       qaAcc[nt].mma_AB(a, b)
   ss.zero()
-  for nt in 0 ..< 24:
+  for nt in 0 ..< QLoRARank div 32:
     sq.mul(qaAcc[nt], qaAcc[nt])
     ss.row_sum(sq, ss)
-  ss.mul(ss, 1.0'f32 / 768.0'f32)
+  ss.mul(ss, 1.0'f32 / float32(QLoRARank))
   ss.add(ss, RmsEps)
   ss.rsqrt(ss)
-  for nt in 0 ..< 24:
+  for nt in 0 ..< QLoRARank div 32:
     gammaT.loadTile(glQaG, (0, 0, 0, nt))
     qnT[nt].normRound16(qaAcc[nt], gammaT, ss)
 
   # ── q = qb_w @ qn (768-wide K, 16 N-tiles = 2 heads × 256) ──
-  for nt in 0 ..< 16:
+  for nt in 0 ..< 2 * QkHeadDim div 32:
     qAcc[nt].zero()
   for kk in 0'i32 ..< QLoRARank div 32:
     for nt in 0'i32 ..< 16:
@@ -230,55 +229,57 @@ proc mla_latent_fwd*(
       qAcc[nt].mma_AB(qnT[kk], b32)
 
   # ── kv = kva_w @ x (576 = 512 k_pass + 64 k_rot) ──
-  for nt in 0 ..< 18:
+  for nt in 0 ..< KvAOut div 32:
     kvAcc[nt].zero()
   for kk in 0'i32 ..< HiddenDim div 16:
     a.loadTileRows(glX, (0, 0, tBlock, kk), num_tokens)
-    for nt in 0'i32 ..< 18:
+    for nt in 0'i32 ..< KvAOut div 32:
       b.loadTile(glKvaW, (0, 0, nt, kk))
       kvAcc[nt].mma_AB(a, b)
 
   # ── kp = rms_norm(kv[0:512], kva_g), one rounding ──
   ss.zero()
-  for nt in 0 ..< 16:
+  for nt in 0 ..< KvLoRARank div 32:
     sq.mul(kvAcc[nt], kvAcc[nt])
     ss.row_sum(sq, ss)
-  ss.mul(ss, 1.0'f32 / 512.0'f32)
+  ss.mul(ss, 1.0'f32 / float32(KvLoRARank))
   ss.add(ss, RmsEps)
   ss.rsqrt(ss)
-  for nt in 0 ..< 16:
+  for nt in 0 ..< KvLoRARank div 32:
     gammaT.loadTile(glKvaG, (0, 0, 0, nt))
     kpT[nt].normRound16(kvAcc[nt], gammaT, ss)
 
   # ── kb = kvb_w @ kp (512-wide K, 28 N-tiles = 2 heads × 448) ──
-  for nt in 0 ..< 28:
+  for nt in 0 ..< 2 * KvBPerHead div 32:
     kbAcc[nt].zero()
   for kk in 0'i32 ..< KvLoRARank div 32:
-    for nt in 0'i32 ..< 28:
+    for nt in 0'i32 ..< 2 * KvBPerHead div 32:
       b32.loadTile(glKvbW, (head0, 0, nt, kk))
       kbAcc[nt].mma_AB(kpT[kk], b32)
 
   # ── interleaved rope, in place on the rot accumulator tiles:
   #    kvAcc[16..17] = the shared k_rot (pairs 0..15, 16..31),
   #    qAcc[hh·8 + 6..7] = head hh's q_rot halves ──
-  kvAcc[16].ropeTile32(cos_t, sin_t, tBlock * 8, 0)
-  kvAcc[17].ropeTile32(cos_t, sin_t, tBlock * 8, 16)
+  kvAcc[KvLoRARank div 32].ropeTile32(cos_t, sin_t, tBlock * 8, 0)
+  kvAcc[KvLoRARank div 32 + 1].ropeTile32(cos_t, sin_t, tBlock * 8, 16)
   for hh in 0 ..< 2:
-    qAcc[hh * 8 + 6].ropeTile32(cos_t, sin_t, tBlock * 8, 0)
-    qAcc[hh * 8 + 7].ropeTile32(cos_t, sin_t, tBlock * 8, 16)
+    qAcc[hh * (QkHeadDim div 32) + QkNopeDim div 32].ropeTile32(cos_t, sin_t, tBlock * 8, 0)
+    qAcc[hh * (QkHeadDim div 32) + QkNopeDim div 32 + 1].ropeTile32(cos_t, sin_t, tBlock * 8, 16)
 
   # ── stores: the nope parts straight from the accumulators, the
   #    roped rot tiles at the head's cols [192, 256), the shared
   #    k_rot at both heads' rot cols ──
   for hh in 0'i32 ..< 2:
     let head = head0 + hh
-    for nt in 0'i32 ..< 6:
-      glQo.storeTileRows(qAcc[hh * 8 + nt], (0, head, tBlock, nt), num_tokens)
-    glQo.storeTileRows(qAcc[hh * 8 + 6], (0, head, tBlock, 6), num_tokens)
-    glQo.storeTileRows(qAcc[hh * 8 + 7], (0, head, tBlock, 7), num_tokens)
-    for nt in 0'i32 ..< 6:
-      glKo.storeTileRows(kbAcc[hh * 14 + nt], (0, head, tBlock, nt), num_tokens)
-    glKo.storeTileRows(kvAcc[16], (0, head, tBlock, 6), num_tokens)
-    glKo.storeTileRows(kvAcc[17], (0, head, tBlock, 7), num_tokens)
-    for nt in 0'i32 ..< 8:
-      glVo.storeTileRows(kbAcc[hh * 14 + 6 + nt], (0, head, tBlock, nt), num_tokens)
+    let headTiles = QkHeadDim div 32
+    let nopeTiles = QkNopeDim div 32
+    for nt in 0'i32 ..< nopeTiles:
+      glQo.storeTileRows(qAcc[hh * headTiles + nt], (0, head, tBlock, nt), num_tokens)
+    glQo.storeTileRows(qAcc[hh * headTiles + nopeTiles], (0, head, tBlock, nopeTiles), num_tokens)
+    glQo.storeTileRows(qAcc[hh * headTiles + nopeTiles + 1], (0, head, tBlock, nopeTiles + 1), num_tokens)
+    for nt in 0'i32 ..< nopeTiles:
+      glKo.storeTileRows(kbAcc[hh * (KvBPerHead div 32) + nt], (0, head, tBlock, nt), num_tokens)
+    glKo.storeTileRows(kvAcc[KvLoRARank div 32], (0, head, tBlock, nopeTiles), num_tokens)
+    glKo.storeTileRows(kvAcc[KvLoRARank div 32 + 1], (0, head, tBlock, nopeTiles + 1), num_tokens)
+    for nt in 0'i32 ..< VHeadDim div 32:
+      glVo.storeTileRows(kbAcc[hh * (KvBPerHead div 32) + nopeTiles + nt], (0, head, tBlock, nt), num_tokens)

--- a/workspace/positron/src/kernels/ceramic/moe_fwd.nim
+++ b/workspace/positron/src/kernels/ceramic/moe_fwd.nim
@@ -11,59 +11,38 @@
 #
 # ############################################################
 
-## Mixture-of-experts forward on the ceramic Tile API: the
-## Glm4MoeLiteMoE routing + NaiveMoe experts + shared MLP for the
-## GLM-4.7-Flash dims. Experimental: not a production kernel, known
-## gaps below, not fixed.
+## Mixture-of-experts forward on the ceramic Tile API.
+## Implements the Glm4MoeLiteMoE routing, the NaiveMoe experts and the shared MLP for the GLM-4.7-Flash dims.
+## Experimental: not a production kernel, known gaps below, not fixed.
 ##
-## Per token t, fp32 arithmetic over fp16-rounded inputs:
+## Dataflow per token (fp32 arithmetic over fp16-rounded inputs):
 ##
-##   logits = router_w @ x                     (64)
-##   s      = sigmoid(logits)                  (in-kernel exp)
-##   top4   = the 4 largest s, lowest-index tiebreak
-##   w      = s[top4]
-##   w      = w / (sum(w) + 1e-20) · 1.8
-##   per slot e = top4[slot]:
-##     gHalf, uHalf = gate_up_w[e] @ x         (gate cols 0:1536, up cols 1536:3072)
-##     h            = silu(gHalf) · uHalf      (1536), fp16 round -> h_scratch[t, slot]
-##   routed = Σ_slot w[slot] · (down_w[e] @ h_scratch[t, slot])
-##   gs, us = shared_gate_up_w @ x
-##   hs     = silu(gs) · us (fp16 round -> hs_scratch[t])
-##   out_r[t] = fp16(routed + shared_down_w @ hs_scratch[t])
+##   router:  x --> router_w @ --> logits (64) --> sigmoid --> s
+##            top-4 of s (lowest-index tiebreak) --> w = s/(sum(w)+1e-20)·1.8
+##   experts: per slot e = top4[slot]:
+##            x --> gate_up_w[e] @ --> (gHalf, uHalf)
+##                  --> h = silu(gHalf)·uHalf (1536) --> fp16 round
+##                  --> h_scratch[t, slot]
+##            routed = Σ_slot w[slot] · (down_w[e] @ h_scratch[t, slot])
+##   shared:  x --> shared_gate_up_w @ --> (gs, us)
+##                  --> hs = silu(gs)·us (1536) --> fp16 round
+##                  --> hs_scratch[t]
+##            out_r[t] = fp16(routed + shared_down_w @ hs_scratch[t])
 ##
-## The model's group gating (n_group = 1, topk_group = 1, zero bias)
-## selects all 64 experts, so the group step is a no-op and folds into
-## the plain top-4 over the sigmoid scores.
+## The model's group selection (n_group = 1, topk_group = 1, zero bias)
+## selects all 64 experts, so the group step is a no-op.
+## The top-4 runs directly over the sigmoid scores.
 ##
-## Routing: the router GEMV fills a (32, 64) accumulator with only
-## row 0 real (the exl3 MMODE-0 trick: the 32-row x tiles load
-## row-bounded to 1). The 64 row-0 logits are redistributed into an
-## (8, 8) score tile, 2 values per lane across the 32 lanes, then the
-## top-4 runs as 4 passes over the tile: local max of the lane's 2
-## scores, a 5-step simdShuffleDown max tree, the holding expert
-## (lowest index on ties), and a −inf mask in the selection copy (the
-## original sigmoid values stay for the weights).
-##
-## Grid (num_tokens, 1, 1), 32 lanes, one token per threadgroup: the
-## expert sets differ per token, so a shared-B tile across rows is
-## impossible. Every tile load/store carries the token in the origin's
-## batch component (the tile's 32 plane rows have only row 0 real, and
-## origin[2] steps in 32-row units).
-##
-## GEMMs: the exl3_gemv MMODE-0 trick (32-row tiles, `loadTileRows`
-## rowLimit 1), 16-wide K-steps (HiddenDim div 16 = 128 over 2048)
-## with mma_AB into fp32 accumulators. Register budget: at most ~2
-## live 32×32 fp32 accumulators (the gHalf/uHalf pair) plus
-## transients. The h intermediates round to fp16 and land in the
-## working buffers (h_scratch (num_tokens, 4, 1536), hs_scratch
-## (num_tokens, 1536)). They are not caller padding or a ragged
-## strategy.
-##
-## Local device procs: siluMul16 (the expert activation), accScale
-## (the weighted routed accumulation), addStore16 (the output round),
-## gatherScores (the logit redistribution) and topk4 (the register
-## selection) live in this module. The row-bounded load/store come
-## from tile_io_rows (positron local extension).
+## Buffers:
+##   - out_r: (num_tokens, 2048) fp16 routed + shared output
+##   - x: (num_tokens, 2048) fp16
+##   - router_w: (64, 2048) fp16
+##   - gate_up_w: (64, 3072, 2048) fp16 fused g|up weight (g 0:1536, up 1536:3072)
+##   - down_w: (64, 2048, 1536) fp16
+##   - shared_gate_up_w: (3072, 2048) fp16
+##   - shared_down_w: (2048, 1536) fp16
+##   - h_scratch: (num_tokens, 4, 1536) fp16 working buffer
+##   - hs_scratch: (num_tokens, 1536) fp16 working buffer
 ##
 ## Known production gaps (documented, not fixed):
 ##   - one token per threadgroup: no expert-batched B tiles, no x
@@ -80,12 +59,12 @@ import ./tile_io_rows
 export int_tuples, layouts, layout_constructors, layout_indexing, tensors,
        ptr_arithmetic, tile_algebra
 
-# The real GLM-4.7-Flash dims, baked as module constants. The kernel
-# is non-generic: its tile types cannot take the rt_l/rv default atoms
-# (those call getTileConfig, which asserts a metal:/cuda: block context,
-# and a non-generic proc body is typechecked on the host import). The
-# explicit universal-atom enum members below are exactly what the
-# defaults resolve to on the Metal and CUDA backends.
+# The real GLM-4.7-Flash dims, baked as module constants.
+# The kernel is non-generic: its tile types cannot take the rt_l/rv
+# default atoms, which call getTileConfig and assert a metal:/cuda:
+# block context. A non-generic proc body is typechecked on the host
+# import.
+# The explicit universal-atom enum members below are exactly what the defaults resolve to on the Metal and CUDA backends.
 
 const
   HiddenDim = 2048          # the model hidden size
@@ -103,11 +82,10 @@ proc siluMul16[A: static MmaAtom](
     dst: var RtLeft[float16, 32, 32, A],
     gHalf, uHalf: RtLeft[float32, 32, 32, A]) {.device.} =
   ## `dst[r][c] = fp16(silu(gHalf[r][c]) · uHalf[r][c])`: the expert
-  ## activation with one fp16 RNE round (the h_scratch contract). The
-  ## silu is fp32 from the fp32 gHalf operand (g / (1 + exp2(−g·log2e))),
-  ## the product is fp32, one fp16 round at the end. The frag walk
-  ## follows the loadTile lane→element mapping, so the operands agree
-  ## elementwise.
+  ## activation with one fp16 RNE round (the h_scratch contract).
+  ## The silu is fp32 from the fp32 gHalf operand, g / (1 + exp2(−g·log2e)),
+  ## and the product is fp32 with one fp16 round at the end.
+  ## The frag walk follows the loadTile lane→element mapping, so the operands agree elementwise.
   const rowTiles = 32 div A.getM()
   const colTiles = 32 div A.getN()
   const vpt = A.getVpt()
@@ -136,8 +114,7 @@ proc accScale[A: static MmaAtom](
 proc addStore16[A: static MmaAtom](
     dst: var RtLeft[float16, 32, 32, A],
     routed, shared: RtLeft[float32, 32, 32, A]) {.device.} =
-  ## `dst[r][c] = fp16(routed[r][c] + shared[r][c])`: the output's one
-  ## fp16 RNE round.
+  ## `dst[r][c] = fp16(routed[r][c] + shared[r][c])`: the output's one fp16 RNE round.
   const rowTiles = 32 div A.getM()
   const colTiles = 32 div A.getN()
   const vpt = A.getVpt()
@@ -153,12 +130,12 @@ proc gatherScores[AL, AS: static MmaAtom](
   ## Redistributes the 64 row-0 router logits of the (32, 64)
   ## accumulator into the (8, 8) score tile: element (r, c) holds
   ## sigmoid(logit of expert 8r + c), 2 values per lane across all 32
-  ## lanes. The row-0 logits live in the accumulator's lanes {0, 1, 8,
-  ## 9} (2 per col-frag). Destination lane d pulls its pair from the
-  ## source lane `d and 9` (the row-0 owner of the same col pair).
-  ## The lane→expert mapping follows the universal AC fragment layout
-  ## of both tiles (a wrong mapping shows up as a routing mismatch,
-  ## not a value error).
+  ## lanes. The row-0 logits live in the accumulator's lanes
+  ## {0, 1, 8, 9} (2 per col-frag). Destination lane d pulls its pair
+  ## from the source lane `d and 9` (the row-0 owner of the same col
+  ## pair). The lane→expert mapping follows the universal AC fragment
+  ## layout of both tiles (a wrong mapping shows up as a routing
+  ## mismatch, not a value error).
   static:
     doAssert AL.getM() == AS.getM() and AL.getN() == AS.getN() and
       AL.getVpt() == AS.getVpt(),
@@ -180,15 +157,15 @@ proc topk4[A: static MmaAtom](
     scores: RtLeft[float32, 8, 8, A],
     top4: var array[4, int32],
     w: var array[4, float32]) {.device.} =
-  ## Selects the 4 largest router scores of the (8, 8) score tile, the
-  ## top-4 of the sigmoid values with the lowest-index tiebreak. The
-  ## weights come from the original tile. The selection runs on a
-  ## masked copy. Per pass: the local max of the lane's 2 scores, a
-  ## 5-step simdShuffleDown max tree (deltas 16, 8, 4, 2, 1)
+  ## Selects the 4 largest router scores of the (8, 8) score tile:
+  ## the top-4 of the sigmoid values with the lowest-index tiebreak.
+  ## The weights come from the original tile. The selection runs on
+  ## a masked copy. Per pass: the local max of the lane's 2 scores,
+  ## a 5-step simdShuffleDown max tree (deltas 16, 8, 4, 2, 1)
   ## broadcast from lane 0, the candidate expert indices where
   ## score == max (no match = 64) reduced by a 5-step min tree
-  ## broadcast from lane 0, and the found expert masked to −inf in the
-  ## selection copy.
+  ## broadcast from lane 0, and the found expert masked to −inf in
+  ## the selection copy.
   var sel: RtLeft[float32, 8, 8, A]
   sel.frags[0][0].frag[0] = scores.frags[0][0].frag[0]
   sel.frags[0][0].frag[1] = scores.frags[0][0].frag[1]
@@ -245,12 +222,28 @@ proc moe_fwd*(
     h_scratch: ptr UncheckedArray[float16],  # (num_tokens, 4, 1536) fp16 working buffer
     hs_scratch: ptr UncheckedArray[float16], # (num_tokens, 1536) fp16 working buffer
     num_tokens: int32) {.device.} =
-  ## Computes the module doc's contract for one token: the router
-  ## GEMV + in-register top-4, the 4 per-slot expert activations into
-  ## h_scratch, the shared expert activation into hs_scratch, the
-  ## weighted routed + shared down projections, and the fp16 output
-  ## store. Every tile carries the token (or h_scratch row) in the
-  ## origin's batch component.
+  ## Computes the module doc's contract for one token:
+  ##   - the router GEMV + in-register top-4
+  ##   - the 4 per-slot expert activations into h_scratch
+  ##   - the shared expert activation into hs_scratch
+  ##   - the weighted routed + shared down projections
+  ##   - the fp16 output store
+  ##
+  ## Grid (num_tokens, 1, 1), 32 lanes, one token per threadgroup.
+  ## The expert sets differ per token, so a shared-B tile across rows
+  ## is impossible. Every tile load/store carries the token
+  ## or the h_scratch row in the origin's batch component. The tile's
+  ## 32 plane rows have only row 0 real, and origin[2] steps in 32-row
+  ## units.
+  ##
+  ## GEMMs: 32-row tiles loaded row-bounded to 1 (only row 0 real),
+  ## 16-wide K-steps (128 over 2048) with mma_AB into fp32
+  ## accumulators. The router GEMV fills a (32, 64) accumulator.
+  ## The 64 row-0 logits redistribute into an (8, 8) score tile,
+  ## 2 values per lane. The top-4 runs as 4 passes over the tile
+  ## (the gatherScores and topk4 device procs).
+  ## Register budget: ~2 live 32×32 fp32 accumulators (the gHalf/uHalf pair) plus transients.
+  ## The h intermediates round to fp16 and land in the working buffers, which are not caller padding.
   let t = int32(threadgroup_position_in_grid.x)
 
   let glX = x.gd(shape = (-1, -1, -1, -1), stride = (2048, 0, 2048, 1))

--- a/workspace/positron/src/kernels/ceramic/moe_fwd.nim
+++ b/workspace/positron/src/kernels/ceramic/moe_fwd.nim
@@ -1,0 +1,336 @@
+## Tattletale
+## Copyright (c) 2026 Mamy André-Ratsimbazafy
+## Licensed and distributed under either of
+##   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+##   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+## at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+# ############################################################
+#
+#     Mixture-of-experts forward (moe_fwd): Tile API port
+#
+# ############################################################
+
+## Mixture-of-experts forward on the ceramic Tile API: the
+## Glm4MoeLiteMoE routing + NaiveMoe experts + shared MLP for the
+## GLM-4.7-Flash dims. Experimental: not a production kernel, known
+## gaps below, not fixed.
+##
+## Per token t, fp32 arithmetic over fp16-rounded inputs:
+##
+##   logits = router_w @ x                     (64)
+##   s      = sigmoid(logits)                  (in-kernel exp)
+##   top4   = the 4 largest s, lowest-index tiebreak
+##   w      = s[top4]
+##   w      = w / (sum(w) + 1e-20) · 1.8
+##   per slot e = top4[slot]:
+##     gHalf, uHalf = gate_up_w[e] @ x         (gate cols 0:1536, up cols 1536:3072)
+##     h            = silu(gHalf) · uHalf      (1536), fp16 round -> h_scratch[t, slot]
+##   routed = Σ_slot w[slot] · (down_w[e] @ h_scratch[t, slot])
+##   gs, us = shared_gate_up_w @ x
+##   hs     = silu(gs) · us (fp16 round -> hs_scratch[t])
+##   out_r[t] = fp16(routed + shared_down_w @ hs_scratch[t])
+##
+## The model's group gating (n_group = 1, topk_group = 1, zero bias)
+## selects all 64 experts, so the group step is a no-op and folds into
+## the plain top-4 over the sigmoid scores.
+##
+## Routing: the router GEMV fills a (32, 64) accumulator with only
+## row 0 real (the exl3 MMODE-0 trick: the 32-row x tiles load
+## row-bounded to 1). The 64 row-0 logits are redistributed into an
+## (8, 8) score tile, 2 values per lane across the 32 lanes, then the
+## top-4 runs as 4 passes over the tile: local max of the lane's 2
+## scores, a 5-step simdShuffleDown max tree, the holding expert
+## (lowest index on ties), and a −inf mask in the selection copy (the
+## original sigmoid values stay for the weights).
+##
+## Grid (num_tokens, 1, 1), 32 lanes, ONE token per threadgroup: the
+## expert sets differ per token, so a shared-B tile across rows is
+## impossible. Every tile load/store carries the token in the origin's
+## batch component (the tile's 32 plane rows have only row 0 real, and
+## origin[2] steps in 32-row units).
+##
+## GEMMs: the exl3_gemv MMODE-0 trick (32-row tiles, `loadTileRows`
+## rowLimit 1), 16-wide K-steps (HiddenDim div 16 = 128 over 2048)
+## with mma_AB into fp32 accumulators. Register budget: at most ~2
+## live 32×32 fp32 accumulators (the gHalf/uHalf pair) plus
+## transients. The h intermediates round to fp16 and land in the
+## working buffers (h_scratch (num_tokens, 4, 1536), hs_scratch
+## (num_tokens, 1536)). They are NOT caller padding or a ragged
+## strategy.
+##
+## Local device procs: siluMul16 (the expert activation), accScale
+## (the weighted routed accumulation), addStore16 (the output round),
+## gatherScores (the logit redistribution) and topk4 (the register
+## selection) live in this module. The row-bounded load/store come
+## from tile_io_rows (positron local extension).
+##
+## Known production gaps (documented, not fixed):
+##   - one token per threadgroup: no expert-batched B tiles, no x
+##     reuse across the per-slot projections (x re-read from global
+##     per N-tile)
+##   - the router weight is fp16 (the reference router is fp32)
+##   - the top-4 is a fixed 4-pass register selection, no score
+##     sorting output
+
+import workspace/crucible
+import workspace/ceramic
+import ./tile_io_rows
+
+export int_tuples, layouts, layout_constructors, layout_indexing, tensors,
+       ptr_arithmetic, tile_algebra
+
+# The real GLM-4.7-Flash dims, baked as module constants. The kernel
+# is non-generic: its tile types cannot take the rt_l/rv default atoms
+# (those call getTileConfig, which asserts a metal:/cuda: block context,
+# and a non-generic proc body is typechecked on the host import). The
+# explicit universal-atom enum members below are exactly what the
+# defaults resolve to on the Metal and CUDA backends.
+
+const
+  HiddenDim = 2048          # the model hidden size
+  NumRoutedExperts = 64     # n_routed_experts
+  MoeIntermediate = 1536    # moe_intermediate_size, also the shared MLP width
+  TopK = 4                  # num_experts_per_tok
+  GateUpOut = 3072          # 2 · MoeIntermediate, the fused g|u width
+  RoutedScaling = 1.8'f32   # routed_scaling_factor
+
+# ═════════════════════════════════════════════════════════════════════
+#  Local device extensions: the routing and activation arithmetic
+#  ═════════════════════════════════════════════════════════════════════
+
+proc siluMul16[A: static MmaAtom](
+    dst: var RtLeft[float16, 32, 32, A],
+    gHalf, uHalf: RtLeft[float32, 32, 32, A]) {.device.} =
+  ## `dst[r][c] = fp16(silu(gHalf[r][c]) · uHalf[r][c])`: the expert
+  ## activation with ONE fp16 RNE round (the h_scratch contract). The
+  ## silu is fp32 from the fp32 gHalf operand (g / (1 + exp2(−g·log2e))),
+  ## the product is fp32, one fp16 round at the end. The frag walk
+  ## follows the loadTile lane→element mapping, so the operands agree
+  ## elementwise.
+  const rowTiles = 32 div A.getM()
+  const colTiles = 32 div A.getN()
+  const vpt = A.getVpt()
+  for n in 0 ..< rowTiles:
+    for m in 0 ..< colTiles:
+      for v in 0 ..< vpt:
+        let g = gHalf.frags[n][m].frag[v]
+        let s = g / (1.0'f32 + exp2(-g * 1.4426950408889634'f32))
+        dst.frags[n][m].frag[v] = (s * uHalf.frags[n][m].frag[v]).to(float16)
+
+proc accScale[A: static MmaAtom](
+    dst: var RtLeft[float32, 32, 32, A],
+    src: RtLeft[float32, 32, 32, A],
+    s: float32) {.device.} =
+  ## `dst[r][c] += s · src[r][c]`: the weighted routed accumulation
+  ## over the 4 slots.
+  const rowTiles = 32 div A.getM()
+  const colTiles = 32 div A.getN()
+  const vpt = A.getVpt()
+  for n in 0 ..< rowTiles:
+    for m in 0 ..< colTiles:
+      for v in 0 ..< vpt:
+        dst.frags[n][m].frag[v] =
+          dst.frags[n][m].frag[v] + s * src.frags[n][m].frag[v]
+
+proc addStore16[A: static MmaAtom](
+    dst: var RtLeft[float16, 32, 32, A],
+    routed, shared: RtLeft[float32, 32, 32, A]) {.device.} =
+  ## `dst[r][c] = fp16(routed[r][c] + shared[r][c])`: the output's one
+  ## fp16 RNE round.
+  const rowTiles = 32 div A.getM()
+  const colTiles = 32 div A.getN()
+  const vpt = A.getVpt()
+  for n in 0 ..< rowTiles:
+    for m in 0 ..< colTiles:
+      for v in 0 ..< vpt:
+        dst.frags[n][m].frag[v] =
+          (routed.frags[n][m].frag[v] + shared.frags[n][m].frag[v]).to(float16)
+
+proc gatherScores[AL, AS: static MmaAtom](
+    scores: var RtLeft[float32, 8, 8, AS],
+    logits: RtLeft[float32, 32, 64, AL]) {.device.} =
+  ## Redistributes the 64 row-0 router logits of the (32, 64)
+  ## accumulator into the (8, 8) score tile: element (r, c) holds
+  ## sigmoid(logit of expert 8r + c), 2 values per lane across all 32
+  ## lanes. The row-0 logits live in the accumulator's lanes {0, 1, 8,
+  ## 9} (2 per col-frag). Destination lane d pulls its pair from the
+  ## source lane `d and 9` (the row-0 owner of the same col pair).
+  ## The lane→expert mapping follows the universal AC fragment layout
+  ## of both tiles (a wrong mapping shows up as a routing mismatch,
+  ## not a value error).
+  static:
+    doAssert AL.getM() == AS.getM() and AL.getN() == AS.getN() and
+      AL.getVpt() == AS.getVpt(),
+      "gatherScores: both atoms must share the lane→fragment cell mapping"
+  let lane = int(thread_index_in_threadgroup)
+  let cell = crd2idx(AL.getLayoutA(), (lane, 0)).toIntVal()
+  let r = cell mod 8          # the destination row = expert div 8
+  let srcLane = lane and 9    # the row-0 owner of the lane's col pair
+  for m in 0 ..< 8:
+    let g0 = simdShuffle(logits.frags[0][m].frag[0], uint32(srcLane))
+    let g1 = simdShuffle(logits.frags[0][m].frag[1], uint32(srcLane))
+    if m == r:
+      scores.frags[0][0].frag[0] =
+        1.0'f32 / (1.0'f32 + exp2(-g0 * 1.4426950408889634'f32))
+      scores.frags[0][0].frag[1] =
+        1.0'f32 / (1.0'f32 + exp2(-g1 * 1.4426950408889634'f32))
+
+proc topk4[A: static MmaAtom](
+    scores: RtLeft[float32, 8, 8, A],
+    top4: var array[4, int32],
+    w: var array[4, float32]) {.device.} =
+  ## Selects the 4 largest router scores of the (8, 8) score tile, the
+  ## top-4 of the sigmoid values with the lowest-index tiebreak. The
+  ## weights come from the original tile. The selection runs on a
+  ## masked copy. Per pass: the local max of the lane's 2 scores, a
+  ## 5-step simdShuffleDown max tree (deltas 16, 8, 4, 2, 1)
+  ## broadcast from lane 0, the candidate expert indices where
+  ## score == max (no match = 64) reduced by a 5-step min tree
+  ## broadcast from lane 0, and the found expert masked to −inf in the
+  ## selection copy.
+  var sel: RtLeft[float32, 8, 8, A]
+  sel.frags[0][0].frag[0] = scores.frags[0][0].frag[0]
+  sel.frags[0][0].frag[1] = scores.frags[0][0].frag[1]
+  let lane = int(thread_index_in_threadgroup)
+  let cell = crd2idx(A.getLayoutA(), (lane, 0)).toIntVal()
+  let r = cell mod 8
+  let c0 = cell div 8
+  let e0 = int32(8 * r + c0)
+  let e1 = e0 + 1
+  for slot in 0 ..< 4:
+    var lm = max(sel.frags[0][0].frag[0], sel.frags[0][0].frag[1])
+    lm = max(lm, simdShuffleDown(lm, 16'u32))
+    lm = max(lm, simdShuffleDown(lm, 8'u32))
+    lm = max(lm, simdShuffleDown(lm, 4'u32))
+    lm = max(lm, simdShuffleDown(lm, 2'u32))
+    lm = max(lm, simdShuffleDown(lm, 1'u32))
+    lm = simdShuffle(lm, 0'u32)
+    var cand = 64'i32
+    if sel.frags[0][0].frag[0] == lm:
+      cand = e0
+    if sel.frags[0][0].frag[1] == lm:
+      cand = min(cand, e1)
+    cand = min(cand, simdShuffleDown(cand, 16'u32))
+    cand = min(cand, simdShuffleDown(cand, 8'u32))
+    cand = min(cand, simdShuffleDown(cand, 4'u32))
+    cand = min(cand, simdShuffleDown(cand, 2'u32))
+    cand = min(cand, simdShuffleDown(cand, 1'u32))
+    cand = simdShuffle(cand, 0'u32)
+    top4[slot] = cand
+    let rw = int(cand div 8)
+    let cw = int(cand mod 8)
+    let own = (cw div 2 mod 2) + 2 * (rw mod 2) + 4 * ((rw div 2) mod 2) +
+              8 * (cw div 4 mod 2) + 16 * ((rw div 4) mod 2)
+    let w0 = simdShuffle(scores.frags[0][0].frag[0], uint32(own))
+    let w1 = simdShuffle(scores.frags[0][0].frag[1], uint32(own))
+    w[slot] = if (cw mod 2) == 0: w0 else: w1
+    if e0 == cand:
+      sel.frags[0][0].frag[0] = -3.402823466e38'f32
+    if e1 == cand:
+      sel.frags[0][0].frag[1] = -3.402823466e38'f32
+
+# ═════════════════════════════════════════════════════════════════════
+#  The kernel
+#  ═════════════════════════════════════════════════════════════════════
+
+proc moe_fwd*(
+    out_r: ptr UncheckedArray[float16],   # (num_tokens, 2048) fp16 routed+shared output
+    x: ptr UncheckedArray[float16],       # (num_tokens, 2048) fp16
+    router_w: ptr UncheckedArray[float16],# (64, 2048) fp16
+    gate_up_w: ptr UncheckedArray[float16],# (64, 3072, 2048) fp16 (expert, g|up)
+    down_w: ptr UncheckedArray[float16],  # (64, 2048, 1536) fp16
+    shared_gate_up_w: ptr UncheckedArray[float16], # (3072, 2048) fp16
+    shared_down_w: ptr UncheckedArray[float16],    # (2048, 1536) fp16
+    h_scratch: ptr UncheckedArray[float16],  # (num_tokens, 4, 1536) fp16 working buffer
+    hs_scratch: ptr UncheckedArray[float16], # (num_tokens, 1536) fp16 working buffer
+    num_tokens: int32) {.device.} =
+  ## Computes the module doc's contract for one token: the router
+  ## GEMV + in-register top-4, the 4 per-slot expert activations into
+  ## h_scratch, the shared expert activation into hs_scratch, the
+  ## weighted routed + shared down projections, and the fp16 output
+  ## store. Every tile carries the token (or h_scratch row) in the
+  ## origin's batch component.
+  let t = int32(threadgroup_position_in_grid.x)
+
+  let glX = x.gd(shape = (-1, -1, -1, -1), stride = (2048, 0, 2048, 1))
+  let glOut = out_r.gd(shape = (-1, -1, -1, -1), stride = (2048, 0, 2048, 1))
+  let glRouter = router_w.gd(shape = (-1, -1, -1, -1), stride = (1, 0, 2048, 1))
+  let glGu = gate_up_w.gd(shape = (-1, -1, -1, -1), stride = (3072 * 2048, 0, 2048, 1))
+  let glDown = down_w.gd(shape = (-1, -1, -1, -1), stride = (2048 * 1536, 0, 1536, 1))
+  let glSgu = shared_gate_up_w.gd(shape = (-1, -1, -1, -1), stride = (1, 0, 2048, 1))
+  let glSd = shared_down_w.gd(shape = (-1, -1, -1, -1), stride = (1, 0, 1536, 1))
+  let glH = h_scratch.gd(shape = (-1, -1, -1, -1), stride = (1536, 1536, 1536, 1))
+  let glHs = hs_scratch.gd(shape = (-1, -1, -1, -1), stride = (1536, 0, 1536, 1))
+
+  var dR: rt_l(float32, 32, 64, UNIVERSAL_8x8x8_F32F16F16F32)
+  var a: rt_l(float16, 32, 16, UNIVERSAL_8x8x8_F32F16F16F32)
+  var b16: rt_r(float16, 16, 32, UNIVERSAL_8x8x8_F32F16F16F32)
+  var b64: rt_r(float16, 16, 64, UNIVERSAL_8x8x8_F32F16F16F32)
+  var scores: rt_l(float32, 8, 8, UNIVERSAL_8x8x8_F32F32F32F32)
+  var top4: array[4, int32]
+  var w: array[4, float32]
+  var gHalf: rt_l(float32, 32, 32, UNIVERSAL_8x8x8_F32F16F16F32)
+  var uHalf: rt_l(float32, 32, 32, UNIVERSAL_8x8x8_F32F16F16F32)
+  var h16: rt_l(float16, 32, 32, UNIVERSAL_8x8x8_F32F16F16F32)
+  var routed: rt_l(float32, 32, 32, UNIVERSAL_8x8x8_F32F16F16F32)
+  var d: rt_l(float32, 32, 32, UNIVERSAL_8x8x8_F32F16F16F32)
+  var sh: rt_l(float32, 32, 32, UNIVERSAL_8x8x8_F32F16F16F32)
+  var out16: rt_l(float16, 32, 32, UNIVERSAL_8x8x8_F32F16F16F32)
+
+  # ── router GEMV (64 outputs, row 0 real) + sigmoid top-4 ──
+  dR.zero()
+  for kk in 0'i32 ..< HiddenDim div 16:
+    a.loadTileRows(glX, (t, 0, 0, kk), 1)
+    b64.loadTile(glRouter, (0, 0, 0, kk))
+    dR.mma_AB(a, b64)
+  scores.gatherScores(dR)
+  scores.topk4(top4, w)
+  var sumW = w[0] + w[1] + w[2] + w[3] + 1e-20'f32
+  for slot in 0 ..< 4:
+    w[slot] = w[slot] / sumW * RoutedScaling
+
+  # ── shared expert activation: hs = silu(gs) · us -> hs_scratch ──
+  for nt in 0'i32 ..< MoeIntermediate div 32:
+    gHalf.zero()
+    uHalf.zero()
+    for kk in 0'i32 ..< HiddenDim div 16:
+      a.loadTileRows(glX, (t, 0, 0, kk), 1)
+      b16.loadTile(glSgu, (0, 0, nt, kk))
+      gHalf.mma_AB(a, b16)
+      b16.loadTile(glSgu, (0, 0, nt + MoeIntermediate div 32, kk))
+      uHalf.mma_AB(a, b16)
+    h16.siluMul16(gHalf, uHalf)
+    glHs.storeTileRows(h16, (t, 0, 0, nt), 1)
+
+  # ── the 4 routed expert activations -> h_scratch[t, slot] ──
+  for slot in 0 ..< 4:
+    for nt in 0'i32 ..< MoeIntermediate div 32:
+      gHalf.zero()
+      uHalf.zero()
+      for kk in 0'i32 ..< HiddenDim div 16:
+        a.loadTileRows(glX, (t, 0, 0, kk), 1)
+        b16.loadTile(glGu, (top4[slot], 0, nt, kk))
+        gHalf.mma_AB(a, b16)
+        b16.loadTile(glGu, (top4[slot], 0, nt + MoeIntermediate div 32, kk))
+        uHalf.mma_AB(a, b16)
+      h16.siluMul16(gHalf, uHalf)
+      glH.storeTileRows(h16, (t * 4 + slot, 0, 0, nt), 1)
+
+  # ── output: routed = Σ w[slot]·down_w[e] @ h, + shared, fp16 store ──
+  for nt in 0'i32 ..< HiddenDim div 32:
+    routed.zero()
+    for slot in 0 ..< 4:
+      d.zero()
+      for kk in 0'i32 ..< MoeIntermediate div 16:
+        a.loadTileRows(glH, (t * 4 + slot, 0, 0, kk), 1)
+        b16.loadTile(glDown, (top4[slot], 0, nt, kk))
+        d.mma_AB(a, b16)
+      routed.accScale(d, w[slot])
+    sh.zero()
+    for kk in 0'i32 ..< MoeIntermediate div 16:
+      a.loadTileRows(glHs, (t, 0, 0, kk), 1)
+      b16.loadTile(glSd, (0, 0, nt, kk))
+      sh.mma_AB(a, b16)
+    out16.addStore16(routed, sh)
+    glOut.storeTileRows(out16, (t, 0, 0, nt), 1)

--- a/workspace/positron/src/kernels/ceramic/moe_fwd.nim
+++ b/workspace/positron/src/kernels/ceramic/moe_fwd.nim
@@ -44,7 +44,7 @@
 ## (lowest index on ties), and a −inf mask in the selection copy (the
 ## original sigmoid values stay for the weights).
 ##
-## Grid (num_tokens, 1, 1), 32 lanes, ONE token per threadgroup: the
+## Grid (num_tokens, 1, 1), 32 lanes, one token per threadgroup: the
 ## expert sets differ per token, so a shared-B tile across rows is
 ## impossible. Every tile load/store carries the token in the origin's
 ## batch component (the tile's 32 plane rows have only row 0 real, and
@@ -56,7 +56,7 @@
 ## live 32×32 fp32 accumulators (the gHalf/uHalf pair) plus
 ## transients. The h intermediates round to fp16 and land in the
 ## working buffers (h_scratch (num_tokens, 4, 1536), hs_scratch
-## (num_tokens, 1536)). They are NOT caller padding or a ragged
+## (num_tokens, 1536)). They are not caller padding or a ragged
 ## strategy.
 ##
 ## Local device procs: siluMul16 (the expert activation), accScale
@@ -103,7 +103,7 @@ proc siluMul16[A: static MmaAtom](
     dst: var RtLeft[float16, 32, 32, A],
     gHalf, uHalf: RtLeft[float32, 32, 32, A]) {.device.} =
   ## `dst[r][c] = fp16(silu(gHalf[r][c]) · uHalf[r][c])`: the expert
-  ## activation with ONE fp16 RNE round (the h_scratch contract). The
+  ## activation with one fp16 RNE round (the h_scratch contract). The
   ## silu is fp32 from the fp32 gHalf operand (g / (1 + exp2(−g·log2e))),
   ## the product is fp32, one fp16 round at the end. The frag walk
   ## follows the loadTile lane→element mapping, so the operands agree
@@ -256,17 +256,17 @@ proc moe_fwd*(
   let glX = x.gd(shape = (-1, -1, -1, -1), stride = (2048, 0, 2048, 1))
   let glOut = out_r.gd(shape = (-1, -1, -1, -1), stride = (2048, 0, 2048, 1))
   let glRouter = router_w.gd(shape = (-1, -1, -1, -1), stride = (1, 0, 2048, 1))
-  let glGu = gate_up_w.gd(shape = (-1, -1, -1, -1), stride = (3072 * 2048, 0, 2048, 1))
+  let glGu = gate_up_w.gd(shape = (-1, -1, -1, -1), stride = (GateUpOut * 2048, 0, 2048, 1))
   let glDown = down_w.gd(shape = (-1, -1, -1, -1), stride = (2048 * 1536, 0, 1536, 1))
   let glSgu = shared_gate_up_w.gd(shape = (-1, -1, -1, -1), stride = (1, 0, 2048, 1))
   let glSd = shared_down_w.gd(shape = (-1, -1, -1, -1), stride = (1, 0, 1536, 1))
   let glH = h_scratch.gd(shape = (-1, -1, -1, -1), stride = (1536, 1536, 1536, 1))
   let glHs = hs_scratch.gd(shape = (-1, -1, -1, -1), stride = (1536, 0, 1536, 1))
 
-  var dR: rt_l(float32, 32, 64, UNIVERSAL_8x8x8_F32F16F16F32)
+  var dR: rt_l(float32, 32, NumRoutedExperts, UNIVERSAL_8x8x8_F32F16F16F32)
   var a: rt_l(float16, 32, 16, UNIVERSAL_8x8x8_F32F16F16F32)
   var b16: rt_r(float16, 16, 32, UNIVERSAL_8x8x8_F32F16F16F32)
-  var b64: rt_r(float16, 16, 64, UNIVERSAL_8x8x8_F32F16F16F32)
+  var b64: rt_r(float16, 16, NumRoutedExperts, UNIVERSAL_8x8x8_F32F16F16F32)
   var scores: rt_l(float32, 8, 8, UNIVERSAL_8x8x8_F32F32F32F32)
   var top4: array[4, int32]
   var w: array[4, float32]
@@ -304,7 +304,7 @@ proc moe_fwd*(
     glHs.storeTileRows(h16, (t, 0, 0, nt), 1)
 
   # ── the 4 routed expert activations -> h_scratch[t, slot] ──
-  for slot in 0 ..< 4:
+  for slot in 0 ..< TopK:
     for nt in 0'i32 ..< MoeIntermediate div 32:
       gHalf.zero()
       uHalf.zero()
@@ -320,7 +320,7 @@ proc moe_fwd*(
   # ── output: routed = Σ w[slot]·down_w[e] @ h, + shared, fp16 store ──
   for nt in 0'i32 ..< HiddenDim div 32:
     routed.zero()
-    for slot in 0 ..< 4:
+    for slot in 0 ..< TopK:
       d.zero()
       for kk in 0'i32 ..< MoeIntermediate div 16:
         a.loadTileRows(glH, (t * 4 + slot, 0, 0, kk), 1)

--- a/workspace/positron/src/kernels/ceramic/swa_attn.nim
+++ b/workspace/positron/src/kernels/ceramic/swa_attn.nim
@@ -11,14 +11,22 @@
 #
 # ############################################################
 
-## Sliding-window attention forward on the ceramic Tile API: the
-## Gemma-4-E2B text sliding-layer attention. One 8×D q tile per
-## threadgroup, K/V fetched per 8-row block over the window band,
-## online softmax in the exp2 form. The Gemma-4 text attention scale
-## is 1.0 (`self.scaling = 1.0`, no 1/sqrt(D) division), so q_mul =
-## log2(e) scales the fp32 S tile after the mma. The mma consumes
-## fp16 Q unscaled.
+## Sliding-window attention forward on the ceramic Tile API.
+## Gemma-4-E2B text sliding-layer attention, one 8×D q tile per threadgroup.
 ## Experimental: not a production kernel, known gaps below, not fixed.
+##
+## Dataflow per threadgroup:
+##
+##   q (8×D) --Q·Kᵀ--> S (8×8) --·log2(e)--> band mask --> softmax --> P (8×8) fp16
+##   k: 8-row blocks over the window band --------------------------------+
+##   P --P·V mma--> O (8×D) fp32 --÷ row norm--> fp16 store
+##   v: 8-row blocks over the window band -----------------+
+##
+## The softmax is online: each kv block rescales O and the row sum
+## by exp2(m_prev − m_cur). The Gemma-4 text scale is 1.0
+## (`self.scaling = 1.0`, no 1/sqrt(D) division), so q_mul = log2(e)
+## scales the fp32 S tile after the mma and the mma consumes fp16 Q
+## unscaled.
 ##
 ## Buffers, fp16 first then scalars:
 ##   - o, q: (num_qo, H, D) row-major
@@ -27,42 +35,32 @@
 ##   - D: static int, 64 or 128 (tile geometry). No generic brackets,
 ##     no stride or scratch parameters.
 ##
-## Semantics (transformers `sliding_window_causal_mask_function`):
-## query row i sits at absolute position p = q_offset + i and attends
-## key rows j with max(0, p − window + 1) <= j <= min(num_kv − 1, p),
-## causal AND j > p − window. GQA: kv_head = h div (H div Nkv).
-## num_kv >= q_offset + num_qo.
+## Window band (query row i, absolute position p = q_offset + i):
 ##
-## Grid (ceil(num_qo/8), H, 1), 32 lanes, one 8×D q tile per
-## threadgroup. The q/o tiles load and store row-bounded by num_qo.
-## The KV loop covers blocks [kvStart, kvEnd):
-##   - qAbs = q_offset + qBlock·8
-##   - kvStart = max(0, qAbs − window + 1) div 8
-##   - kvEnd = (min(num_kv − 1, qAbs + 7)) div 8 + 1
-## The last block may extend up to 7 rows past num_kv − 1: those rows
-## load as zero (Metal bounds-checks buffer reads) and the causal
-## bound excludes them, the paged_attn garbage-row convention.
+##   attended keys j: max(0, p − window + 1) <= j <= min(num_kv − 1, p)
+##
+##   key rows:  0 ...... p−window+1 ...... p ...... num_kv−1
+##              |           |            |          |
+##              +-- masked -+--- band ---+-- masked+
+##
+##   GQA: kv_head = h div (H div Nkv). num_kv >= q_offset + num_qo.
 ##
 ## Numerics:
-##   - online softmax in TM's exp2 shape, q_mul = log2(e) applied to
-##     the fp32 S tile after the mma (exp2(S·q_mul − m) is the
-##     exp(S·scale) convention with scale = 1.0)
+##   - online softmax in the exp2 shape. q_mul = log2(e) applies in fp32
+##     after the mma, so exp2(S·q_mul − m) is the exp(S·scale)
+##     convention with scale = 1.0
 ##   - masked S elements are the most-negative finite fp32
-##     (−3.402823466e38), so the running row max ignores them and
+##     (−3.402823466e38). The running row max ignores them.
 ##     exp2(S − m) underflows to exact +0.0
 ##   - P downcast to fp16 (`convert`) before the P·V mma. The output
 ##     store quantizes the fp32 O tile to fp16 (RNE) through the `to`
 ##     chokepoint
 ##
-## Local device procs: the shared tile_algebra lacks the banded window
-## mask, so the module carries maskBand locally. The row-bounded
-## load/store come from tile_io_rows (positron local extension).
-##
 ## Known production gaps (documented, not fixed):
-##   - D ∈ {64, 128} only. Gemma-4's real head_dim is 256. The
-##     window/scale/GQA semantics are D-independent.
+##   - D ∈ {64, 128} only. Gemma-4's real head_dim is 256.
+##     The window/scale/GQA semantics are D-independent.
 ##   - Single sequence: one (num_qo, H, D) q buffer, no batch dim.
-##   - k/v not projected in-kernel (the paged_attn convention).
+##   - k/v not projected in-kernel.
 
 import workspace/crucible
 import workspace/ceramic
@@ -78,16 +76,15 @@ export int_tuples, layouts, layout_constructors, layout_indexing, tensors,
 proc maskBand[A: static MmaAtom](
     tile: var RtLeft[float32, 8, 8, A],
     limit, window: int32) {.device.} =
-  ## Banded sliding-window mask on an 8×8 S tile: element (r, c) is
-  ## attended iff c <= limit + r AND c >= limit + r − window + 1.
+  ## Banded sliding-window mask on an 8×8 S tile.
+  ## Element (r, c) is attended iff c <= limit + r and c >= limit + r − window + 1.
   ## Masked elements become the most-negative finite fp32
-  ## (−3.402823466e38), so the online softmax excludes them (the row
-  ## max ignores them, exp2(S − m) underflows to exact +0.0). `limit`
-  ## is the block's band offset (qAbs − kv_idx·8), signed: a negative
-  ## limit masks every column of the row, where an unsigned wrap would
-  ## leave them attended. The frag walk follows the loadTile
-  ## lane→element mapping, so the mask hits exactly the elements the
-  ## Q·Kᵀ mma produced.
+  ## (−3.402823466e38). The online softmax excludes them: the row max
+  ## ignores them and exp2(S − m) underflows to exact +0.0. `limit`
+  ## is the block's band offset (qAbs − kv_idx·8), signed. A negative limit
+  ## masks every column of the row. An unsigned wrap leaves them attended.
+  ## The frag walk follows the loadTile lane→element mapping, so the mask
+  ## hits exactly the elements that the Q·Kᵀ mma produced.
   const M = A.getM()
   const N = A.getN()
   const rowTiles = 8 div M
@@ -117,18 +114,26 @@ proc swa_attn_fwd*(
     num_qo, num_kv, q_offset, H, Nkv, window: int32,
     D: static int) {.device.} =
   ## One grid point = one (head, 8-row q block), following the module
-  ## doc's contract: the q tile loads row-bounded by num_qo, the KV
-  ## loop covers the window band blocks [kvStart, kvEnd), and the fp16
+  ## doc's contract: the q tile loads row-bounded by num_qo. The KV
+  ## loop covers the window band blocks [kvStart, kvEnd). The fp16
   ## store writes only the q rows below num_qo.
+  ##
+  ## Grid (ceil(num_qo/8), H, 1), 32 lanes. The KV loop covers the blocks
+  ## [kvStart, kvEnd):
+  ##   - qAbs = q_offset + qBlock·8
+  ##   - kvStart = max(0, qAbs − window + 1) div 8
+  ##   - kvEnd = (min(num_kv − 1, qAbs + 7)) div 8 + 1
+  ## The last block may extend up to 7 rows past num_kv − 1.
+  ## Overhang rows load as zero (Metal bounds-checks buffer reads).
+  ## The causal bound excludes them.
   static: doAssert D == 64 or D == 128
 
   let qBlock = int32(threadgroup_position_in_grid.x)
   let head = int32(threadgroup_position_in_grid.y)
 
   # The q/o views carry the (q row, head, dim) strides. The K/V views
-  # carry the buffer row stride and take the per-block base as the
-  # origin's batch component (the module doc's kvStart/kvEnd fetch
-  # formula).
+  # carry the buffer row stride. Their per-block base is the origin's
+  # batch component (the kvStart/kvEnd fetch formula).
   let gl_q = q.gd(shape = (-1, -1, -1, -1), stride = (H * D, D, H * D, 1))
   let gl_o = o.gd(shape = (-1, -1, -1, -1), stride = (H * D, D, H * D, 1))
   let gl_k = k.gd(shape = (-1, -1, -1, -1), stride = (1, 1, Nkv * D, 1))
@@ -158,9 +163,8 @@ proc swa_attn_fwd*(
   max_vec.neg_infty()
   norm_vec.zero()
   o_reg.zero()
-  # log2(e), the exp2-form scale: Gemma-4 text attention uses scale
-  # 1.0, so the fp32 S tile carries the 1.0 dot product and q_mul
-  # applies in fp32 after the mma, keeping Q unscaled in fp16
+  # log2(e), the exp2-form scale. Gemma-4 text attention uses scale 1.0,
+  # so q_mul applies in fp32 after the mma, keeping the fp16 Q unscaled.
   let q_mul = 1.44269504089'f32
   for kv_idx in kvStart ..< kvEnd:
     let base = kv_idx * 8 * rowStride + kvHead * int32(D)

--- a/workspace/positron/src/kernels/ceramic/swa_attn.nim
+++ b/workspace/positron/src/kernels/ceramic/swa_attn.nim
@@ -1,0 +1,185 @@
+## Tattletale
+## Copyright (c) 2026 Mamy André-Ratsimbazafy
+## Licensed and distributed under either of
+##   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+##   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+## at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+# ############################################################
+#
+#     Sliding-window attention forward (Tile API port)
+#
+# ############################################################
+
+## Sliding-window attention forward on the ceramic Tile API: the
+## Gemma-4-E2B text sliding-layer attention. One 8×D q tile per
+## threadgroup, K/V fetched per 8-row block over the window band,
+## online softmax in the exp2 form. The Gemma-4 text attention scale
+## is 1.0 (`self.scaling = 1.0`, no 1/sqrt(D) division), so q_mul =
+## log2(e) scales the fp32 S tile after the mma. The mma consumes
+## fp16 Q unscaled.
+## Experimental: not a production kernel, known gaps below, not fixed.
+##
+## Buffers, fp16 first then scalars:
+##   - o, q: (num_qo, H, D) row-major
+##   - k, v: (num_kv, Nkv, D) row-major
+##   - num_qo, num_kv, q_offset, H, Nkv, window: int32
+##   - D: static int, 64 or 128 (tile geometry). No generic brackets,
+##     no stride or scratch parameters.
+##
+## Semantics (transformers `sliding_window_causal_mask_function`):
+## query row i sits at absolute position p = q_offset + i and attends
+## key rows j with max(0, p − window + 1) <= j <= min(num_kv − 1, p),
+## causal AND j > p − window. GQA: kv_head = h div (H div Nkv).
+## num_kv >= q_offset + num_qo.
+##
+## Grid (ceil(num_qo/8), H, 1), 32 lanes, one 8×D q tile per
+## threadgroup. The q/o tiles load and store row-bounded by num_qo.
+## The KV loop covers blocks [kvStart, kvEnd):
+##   - qAbs = q_offset + qBlock·8
+##   - kvStart = max(0, qAbs − window + 1) div 8
+##   - kvEnd = (min(num_kv − 1, qAbs + 7)) div 8 + 1
+## The last block may extend up to 7 rows past num_kv − 1: those rows
+## load as zero (Metal bounds-checks buffer reads) and the causal
+## bound excludes them, the paged_attn garbage-row convention.
+##
+## Numerics:
+##   - online softmax in TM's exp2 shape, q_mul = log2(e) applied to
+##     the fp32 S tile after the mma (exp2(S·q_mul − m) is the
+##     exp(S·scale) convention with scale = 1.0)
+##   - masked S elements are the most-negative finite fp32
+##     (−3.402823466e38), so the running row max ignores them and
+##     exp2(S − m) underflows to exact +0.0
+##   - P downcast to fp16 (`convert`) before the P·V mma. The output
+##     store quantizes the fp32 O tile to fp16 (RNE) through the `to`
+##     chokepoint
+##
+## Local device procs: the shared tile_algebra lacks the banded window
+## mask, so the module carries maskBand locally. The row-bounded
+## load/store come from tile_io_rows (positron local extension).
+##
+## Known production gaps (documented, not fixed):
+##   - D ∈ {64, 128} only. Gemma-4's real head_dim is 256. The
+##     window/scale/GQA semantics are D-independent.
+##   - Single sequence: one (num_qo, H, D) q buffer, no batch dim.
+##   - k/v not projected in-kernel (the paged_attn convention).
+
+import workspace/crucible
+import workspace/ceramic
+import ./tile_io_rows
+
+export int_tuples, layouts, layout_constructors, layout_indexing, tensors,
+       ptr_arithmetic, tile_algebra
+
+# ═════════════════════════════════════════════════════════════════════
+#  Local device extension: the banded window mask
+#  ═════════════════════════════════════════════════════════════════════
+
+proc maskBand[A: static MmaAtom](
+    tile: var RtLeft[float32, 8, 8, A],
+    limit, window: int32) {.device.} =
+  ## Banded sliding-window mask on an 8×8 S tile: element (r, c) is
+  ## attended iff c <= limit + r AND c >= limit + r − window + 1.
+  ## Masked elements become the most-negative finite fp32
+  ## (−3.402823466e38), so the online softmax excludes them (the row
+  ## max ignores them, exp2(S − m) underflows to exact +0.0). `limit`
+  ## is the block's band offset (qAbs − kv_idx·8), signed: a negative
+  ## limit masks every column of the row, where an unsigned wrap would
+  ## leave them attended. The frag walk follows the loadTile
+  ## lane→element mapping, so the mask hits exactly the elements the
+  ## Q·Kᵀ mma produced.
+  const M = A.getM()
+  const N = A.getN()
+  const rowTiles = 8 div M
+  const colTiles = 8 div N
+  const vpt = A.getVpt()
+  let lane = int(thread_index_in_threadgroup)
+  let cell = crd2idx(A.getLayoutA(), (lane, 0)).toIntVal()
+  let row = cell mod M
+  let col = cell div M
+  for n in 0 ..< rowTiles:
+    for m in 0 ..< colTiles:
+      for v in 0 ..< vpt:
+        let p = limit + int32(row + n * M)
+        let c = int32(col + m * N + v)
+        if c > p or c < p - window + 1:
+          tile.frags[n][m].frag[v] = -3.402823466e38'f32
+
+# ═════════════════════════════════════════════════════════════════════
+#  The kernel
+#  ═════════════════════════════════════════════════════════════════════
+
+proc swa_attn_fwd*(
+    o: ptr UncheckedArray[float16],     # (num_qo, H, D) fp16 output
+    q: ptr UncheckedArray[float16],     # (num_qo, H, D) fp16 queries, already projected
+    k: ptr UncheckedArray[float16],     # (num_kv, Nkv, D) fp16 keys, already projected
+    v: ptr UncheckedArray[float16],     # (num_kv, Nkv, D) fp16 values, already projected
+    num_qo, num_kv, q_offset, H, Nkv, window: int32,
+    D: static int) {.device.} =
+  ## One grid point = one (head, 8-row q block), following the module
+  ## doc's contract: the q tile loads row-bounded by num_qo, the KV
+  ## loop covers the window band blocks [kvStart, kvEnd), and the fp16
+  ## store writes only the q rows below num_qo.
+  static: doAssert D == 64 or D == 128
+
+  let qBlock = int32(threadgroup_position_in_grid.x)
+  let head = int32(threadgroup_position_in_grid.y)
+
+  # The q/o views carry the (q row, head, dim) strides. The K/V views
+  # carry the buffer row stride and take the per-block base as the
+  # origin's batch component (the module doc's kvStart/kvEnd fetch
+  # formula).
+  let gl_q = q.gd(shape = (-1, -1, -1, -1), stride = (H * D, D, H * D, 1))
+  let gl_o = o.gd(shape = (-1, -1, -1, -1), stride = (H * D, D, H * D, 1))
+  let gl_k = k.gd(shape = (-1, -1, -1, -1), stride = (1, 1, Nkv * D, 1))
+  # The V view is the transposed slab view: the RtRight loadTile
+  # hands Vᵀ to the P·V mma.
+  let gl_v = v.gd(shape = (-1, -1, -1, -1), stride = (1, 1, 1, Nkv * D))
+
+  let kvHead = head div (H div Nkv)
+  let qAbs = q_offset + qBlock * 8
+  let lo = qAbs - window + 1
+  let kvStart = (if lo > 0: lo else: 0) div 8
+  let hi = (if num_kv - 1 < qAbs + 7: num_kv - 1 else: qAbs + 7)
+  let kvEnd = hi div 8 + 1
+  let rowStride = Nkv * int32(D)
+
+  var q_reg: rt_l(float16, 8, D)
+  var k_reg: rt_r(float16, D, 8)
+  var v_reg: rt_r(float16, 8, D)
+  var att_block: rt_l(float32, 8, 8, getTileConfig(float32, float16))
+  var p_reg: rt_l(float16, 8, 8)
+  var o_reg: rt_l(float32, 8, D, getTileConfig(float32, float16))
+  var max_vec_last: rv(float32, 8, 8)
+  var max_vec: rv(float32, 8, 8)
+  var norm_vec: rv(float32, 8, 8)
+
+  q_reg.loadTileRows(gl_q, (0, head, qBlock, 0), num_qo)
+  max_vec.neg_infty()
+  norm_vec.zero()
+  o_reg.zero()
+  # log2(e), the exp2-form scale: Gemma-4 text attention uses scale
+  # 1.0, so the fp32 S tile carries the 1.0 dot product and q_mul
+  # applies in fp32 after the mma, keeping Q unscaled in fp16
+  let q_mul = 1.44269504089'f32
+  for kv_idx in kvStart ..< kvEnd:
+    let base = kv_idx * 8 * rowStride + kvHead * int32(D)
+    k_reg.loadTile(gl_k, (base, 0, 0, 0))
+    att_block.zero()
+    att_block.mma_AB(q_reg, k_reg)
+    att_block.mul(att_block, q_mul)
+    att_block.maskBand(qAbs - kv_idx * 8, window)
+    max_vec_last.copy(max_vec)
+    max_vec.row_max(att_block, max_vec)
+    max_vec_last.sub(max_vec_last, max_vec)
+    max_vec_last.exp2(max_vec_last)
+    att_block.sub_row(att_block, max_vec)
+    att_block.exp2(att_block)
+    norm_vec.mul(norm_vec, max_vec_last)
+    norm_vec.row_sum(att_block, norm_vec)
+    p_reg.convert(att_block)
+    o_reg.mul_row(o_reg, max_vec_last)
+    v_reg.loadTile(gl_v, (base, 0, 0, 0))
+    o_reg.mma_AB(p_reg, v_reg)
+  o_reg.div_row(o_reg, norm_vec)
+  gl_o.storeTileRows(o_reg, (0, head, qBlock, 0), num_qo)

--- a/workspace/positron/src/kernels/ceramic/swa_attn.nim
+++ b/workspace/positron/src/kernels/ceramic/swa_attn.nim
@@ -29,11 +29,20 @@
 ## unscaled.
 ##
 ## Buffers, fp16 first then scalars:
-##   - o, q: (num_qo, H, D) row-major
-##   - k, v: (num_kv, Nkv, D) row-major
+##   - o: (num_qo, H, D) row-major, written row-bounded
+##   - q: (pad_qo, H, D) row-major, pad_qo = ceil(num_qo/8)·8
+##   - k, v: (pad_kv, Nkv, D) row-major, pad_kv = ceil(num_kv/8)·8
 ##   - num_qo, num_kv, q_offset, H, Nkv, window: int32
 ##   - D: static int, 64 or 128 (tile geometry). No generic brackets,
 ##     no stride or scratch parameters.
+##
+## Padding contract: the q, k and v buffers hold an 8-row multiple.
+## The tile loads fetch full 8-row blocks, so a partial trailing block
+## would read past the buffer end. Callers zero-fill the padding rows.
+## The padding rows are inert: the band mask excludes them from the
+## softmax (the upper band edge is min(num_kv − 1, p) and the GQA
+## contract num_kv >= q_offset + num_qo keeps every real query row
+## below num_kv), and the zero v rows add nothing to the P·V mma.
 ##
 ## Window band (query row i, absolute position p = q_offset + i):
 ##
@@ -124,8 +133,9 @@ proc swa_attn_fwd*(
   ##   - kvStart = max(0, qAbs − window + 1) div 8
   ##   - kvEnd = (min(num_kv − 1, qAbs + 7)) div 8 + 1
   ## The last block may extend up to 7 rows past num_kv − 1.
-  ## Overhang rows load as zero (Metal bounds-checks buffer reads).
-  ## The causal bound excludes them.
+  ## Those rows are the caller's zero padding (the module doc's padding
+  ## contract). The band mask excludes them from the softmax, and the
+  ## zero v rows add nothing to the P·V mma.
   static: doAssert D == 64 or D == 128
 
   let qBlock = int32(threadgroup_position_in_grid.x)

--- a/workspace/positron/tests/attn_test_utils.nim
+++ b/workspace/positron/tests/attn_test_utils.nim
@@ -45,6 +45,12 @@ proc fp32sToFp16*(fs: seq[float32]): seq[uint16] =
   for i in 0 ..< fs.len:
     result[i] = fp32ToFp16(fs[i])
 
+proc w32*(fs: seq[float32], shape: varargs[int]): F.Tensor =
+  ## Rebuilds an fp16-rounded weight/input tensor from the shared
+  ## fp32 seq: the kernel buffer and the reference tensors derive
+  ## from the same fp16 values.
+  result = toTensor(fp16sToF32(fp32sToFp16(fs))).reshape(shape)
+
 proc buildRopeCosSin*(rows, dim: int, theta: float32): tuple[cosT, sinT: seq[float32]] =
   ## Returns the NEOX fp32 cos/sin tables: row r carries cos/sin of
   ## inv_freq[t]·r with inv_freq[t] = theta^(−2t/dim), t in

--- a/workspace/positron/tests/attn_test_utils.nim
+++ b/workspace/positron/tests/attn_test_utils.nim
@@ -1,0 +1,59 @@
+## Tattletale
+## Copyright (c) 2026 Mamy André-Ratsimbazafy
+## Licensed and distributed under either of
+##   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+##   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+## at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+## Shared attention-test support: the fp16-rounded random input
+## generator, the fp16 seq converters, the worst-difference metric and
+## the NEOX rotary tables that the manual attention tests share.
+
+import std/math
+import workspace/libtorch
+import workspace/libtorch as F
+import ../../ceramic/tests/tile_test_utils
+
+proc scaledRand*(rows, cols: int, scaleF: float32): seq[float32] =
+  ## Returns rand(rows, cols) shifted host-side to [-scaleF, scaleF):
+  ## the kernel buffer and the reference tensors derive from the same
+  ## seq.
+  let t = rand(rows, cols)
+  let p = t.contiguous().data_ptr(float32)
+  result = newSeq[float32](rows * cols)
+  for i in 0 ..< rows * cols:
+    result[i] = (p[i] - 0.5'f32) * (2.0'f32 * scaleF)
+
+proc worstAbsDiff*(a, b: F.Tensor): float32 =
+  ## Returns the largest |a[i] - b[i]| over all elements.
+  let ap = a.contiguous().data_ptr(float32)
+  let bp = b.contiguous().data_ptr(float32)
+  result = 0.0'f32
+  for i in 0 ..< a.numel():
+    let d = abs(ap[i] - bp[i])
+    if d > result: result = d
+
+proc fp16sToF32*(hs: seq[uint16]): seq[float32] =
+  ## Widens an fp16 bit-pattern buffer to fp32 values.
+  result = newSeq[float32](hs.len)
+  for i in 0 ..< hs.len:
+    result[i] = fp16ToFp32(hs[i])
+
+proc fp32sToFp16*(fs: seq[float32]): seq[uint16] =
+  ## Rounds an fp32 value buffer down to fp16 bit patterns (RNE).
+  result = newSeq[uint16](fs.len)
+  for i in 0 ..< fs.len:
+    result[i] = fp32ToFp16(fs[i])
+
+proc buildRopeCosSin*(rows, dim: int, theta: float32): tuple[cosT, sinT: seq[float32]] =
+  ## Returns the NEOX fp32 cos/sin tables: row r carries cos/sin of
+  ## inv_freq[t]·r with inv_freq[t] = theta^(−2t/dim), t in
+  ## [0, dim/2).
+  let half = dim shr 1
+  result.cosT = newSeq[float32](rows * half)
+  result.sinT = newSeq[float32](rows * half)
+  for r in 0 ..< rows:
+    for t in 0 ..< half:
+      let ang = pow(float64(theta), -float64(2 * t) / float64(dim)).float32 * float32(r)
+      result.cosT[r * half + t] = cos(ang)
+      result.sinT[r * half + t] = sin(ang)

--- a/workspace/positron/tests/attn_test_utils.nim
+++ b/workspace/positron/tests/attn_test_utils.nim
@@ -26,12 +26,18 @@ proc scaledRand*(rows, cols: int, scaleF: float32): seq[float32] =
 
 proc worstAbsDiff*(a, b: F.Tensor): float32 =
   ## Returns the largest |a[i] - b[i]| over all elements.
+  ## `a` and `b` must have the same element count.
+  if a.numel() != b.numel():
+    raise newException(ValueError,
+      "worstAbsDiff: element count mismatch, got " & $a.numel() &
+      " vs " & $b.numel())
   let ap = a.contiguous().data_ptr(float32)
   let bp = b.contiguous().data_ptr(float32)
   result = 0.0'f32
   for i in 0 ..< a.numel():
     let d = abs(ap[i] - bp[i])
-    if d > result: result = d
+    if d > result:
+      result = d
 
 proc fp16sToF32*(hs: seq[uint16]): seq[float32] =
   ## Widens an fp16 bit-pattern buffer to fp32 values.

--- a/workspace/positron/tests/manual_mla_latent_fp16.nim
+++ b/workspace/positron/tests/manual_mla_latent_fp16.nim
@@ -20,8 +20,6 @@ const mlaMsl = metal:
     let n = num_tokens * num_heads * 256
     mla_latent_fwd(combined, combined +% int(n), combined +% (2 * int(n)),
       x, qa_w, qa_g, qb_w, kva_w, kva_g, kvb_w, cos_t, sin_t, num_tokens, num_heads)
-proc w32(fs: seq[float32], shape: varargs[int]): F.Tensor =
-  toTensor(fp16sToF32(fp32sToFp16(fs))).reshape(shape)
 proc dup64(a: seq[float32], T: int): seq[float32] =
   ## The model's emb = cat((freqs, freqs)): entry c = freq (c mod 32).
   for r in 0 ..< T:
@@ -73,7 +71,7 @@ proc mlaReference(g: tuple[xf, qaWF, qaGF, qbWF, kvaWF, kvaGF, kvbWF: seq[float3
 proc checkMlaLatent(): bool =
   ## T=8/H=4 and T=16/H=20 (the real head count). The 1e-2 bound
   ## covers 4 chained matmuls, 2 norms and the rope at the 0.125 scale
-  ## (observed worst ~1e-3).
+  ## (observed worst ~4e-3).
   Torch.manual_seed(0x5EED'u64)
   for (T, H) in [(8, 4), (16, 20)]:
     let g = genIn(T, H)

--- a/workspace/positron/tests/manual_mla_latent_fp16.nim
+++ b/workspace/positron/tests/manual_mla_latent_fp16.nim
@@ -1,0 +1,87 @@
+## Tattletale
+## Copyright (c) 2026 Mamy André-Ratsimbazafy
+## Licensed and distributed under either of
+##   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+##   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+## at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+##
+## Run: nim cpp -r --hints:off --warnings:off --outdir:build/wip --nimcache:nimcache/wip \
+##   workspace/positron/tests/manual_mla_latent_fp16.nim
+import std/strformat
+import workspace/[crucible, libtorch, libtorch_testutils]
+import workspace/libtorch as F
+from workspace/libtorch/src/raw_libtorch import manual_seed
+import ../src/kernels/ceramic/mla_latent_fwd
+import ./attn_test_utils
+const mlaMsl = metal:
+  proc mlaLatent(combined: ptr UncheckedArray[float16], x, qa_w, qa_g, qb_w, kva_w, kva_g, kvb_w: ptr UncheckedArray[float16],
+      cos_t, sin_t: ptr UncheckedArray[float32], num_tokens, num_heads: int32) {.global.} =
+    let n = num_tokens * num_heads * 256
+    mla_latent_fwd(combined, combined +% int(n), combined +% (2 * int(n)),
+      x, qa_w, qa_g, qb_w, kva_w, kva_g, kvb_w, cos_t, sin_t, num_tokens, num_heads)
+proc w32(fs: seq[float32], shape: varargs[int]): F.Tensor =
+  toTensor(fp16sToF32(fp32sToFp16(fs))).reshape(shape)
+proc dup64(a: seq[float32], T: int): seq[float32] =
+  ## The model's emb = cat((freqs, freqs)): entry c = freq (c mod 32).
+  for r in 0 ..< T:
+    for half in 0 ..< 2:
+      for c in 0 ..< 32:
+        result.add a[r * 32 + c]
+proc gammaVals(n: int): seq[float32] =
+  for c in 0 ..< n:
+    result.add 0.5'f32 + float32(((7 * c + 55 + 13 * (c div 32)) mod 16)) / 16.0'f32
+proc ropePairs(r, cos32, sin32: F.Tensor): F.Tensor =
+  let rb = r.reshape(r.size(0), r.size(1), 32, 2)
+  let c32 = cos32.unsqueeze(1)
+  let s32 = sin32.unsqueeze(1)
+  let a = rb.narrow(3, 0, 1).squeeze(3)
+  let b = rb.narrow(3, 1, 1).squeeze(3)
+  F.cat([(a * c32 - b * s32).unsqueeze(3), (b * c32 + a * s32).unsqueeze(3)], 3).reshape(r.size(0), r.size(1), 64)
+proc genIn(T, H: int): tuple[xf, qaWF, qaGF, qbWF, kvaWF, kvaGF, kvbWF: seq[float32]] =
+  (scaledRand(T, 2048, 0.125'f32), scaledRand(768, 2048, 0.125'f32), gammaVals(768),
+   scaledRand(H * 256, 768, 0.125'f32), scaledRand(576, 2048, 0.125'f32), gammaVals(512),
+   scaledRand(H * 448, 512, 0.125'f32))
+proc mlaKernel(g: tuple[xf, qaWF, qaGF, qbWF, kvaWF, kvaGF, kvbWF: seq[float32]],
+               cosF, sinF: seq[float32], T, H: int): F.Tensor =
+  var engine = bkMetal.init()
+  engine.ingest(mlaMsl)
+  var outAll = newSeq[uint16](3 * T * H * 256)
+  engine.run << (grid: (T div 8, H div 2, 1), blk: (32, 1)) >> ("mlaLatent", outAll,
+    (fp32sToFp16(g.xf), fp32sToFp16(g.qaWF), fp32sToFp16(g.qaGF), fp32sToFp16(g.qbWF),
+     fp32sToFp16(g.kvaWF), fp32sToFp16(g.kvaGF), fp32sToFp16(g.kvbWF), cosF, sinF,
+     int32(T), int32(H)))
+  let n = T * H * 256
+  let q = toTensor(fp16sToF32(outAll[0 ..< n])).reshape(T, H, 256)
+  F.cat([q, toTensor(fp16sToF32(outAll[n ..< 2 * n])).reshape(T, H, 256),
+         toTensor(fp16sToF32(outAll[2 * n ..< 3 * n])).reshape(T, H, 256)], 0).reshape(-1)
+proc mlaReference(g: tuple[xf, qaWF, qaGF, qbWF, kvaWF, kvaGF, kvbWF: seq[float32]],
+                  cos32, sin32: seq[float32], T, H: int): F.Tensor =
+  let x32 = w32(g.xf, T, 2048)
+  let qn = F.rms_norm(F.linear(x32, w32(g.qaWF, 768, 2048)), 768, w32(g.qaGF, 768), 1e-5).to(kFloat16).to(kFloat32)
+  let q = F.linear(qn, w32(g.qbWF, H * 256, 768)).reshape(T, H, 256)
+  let kv = F.linear(x32, w32(g.kvaWF, 576, 2048))
+  let kp = F.rms_norm(kv.narrow(1, 0, 512), 512, w32(g.kvaGF, 512), 1e-5).to(kFloat16).to(kFloat32)
+  let kb = F.linear(kp, w32(g.kvbWF, H * 448, 512)).reshape(T, H, 448)
+  let c32 = toTensor(cos32).reshape(T, 32)
+  let s32 = toTensor(sin32).reshape(T, 32)
+  let qRotR = ropePairs(q.narrow(2, 192, 64), c32, s32)
+  let kRotR = ropePairs(kv.narrow(1, 512, 64).unsqueeze(1), c32, s32).expand(T, H, 64, implicit = false)
+  F.cat([F.cat([q.narrow(2, 0, 192), qRotR], 2).to(kFloat16).to(kFloat32),
+         F.cat([kb.narrow(2, 0, 192), kRotR], 2).to(kFloat16).to(kFloat32),
+         kb.narrow(2, 192, 256).to(kFloat16).to(kFloat32)], 0).reshape(-1)
+proc checkMlaLatent(): bool =
+  ## T=8/H=4 and T=16/H=20 (the real head count). The 1e-2 bound
+  ## covers 4 chained matmuls, 2 norms and the rope at the 0.125 scale
+  ## (observed worst ~1e-3).
+  Torch.manual_seed(0x5EED'u64)
+  for (T, H) in [(8, 4), (16, 20)]:
+    let g = genIn(T, H)
+    let (cos32, sin32) = buildRopeCosSin(T, 64, 1e6'f32)
+    let actual = mlaKernel(g, dup64(cos32, T), dup64(sin32, T), T, H)
+    let expected = mlaReference(g, cos32, sin32, T, H)
+    echo &"  T={T} H={H}: worst |Δ| = {worstAbsDiff(actual, expected)}"
+    assertAllClose(actual, expected, rtol = 0.0'f64, abstol = 1e-2'f64)
+  result = true
+when isMainModule:
+  runCppTest("mla_latent_fwd vs the torch reference", checkMlaLatent)

--- a/workspace/positron/tests/manual_mla_latent_fp16.nim
+++ b/workspace/positron/tests/manual_mla_latent_fp16.nim
@@ -8,27 +8,32 @@
 ##
 ## Run: nim cpp -r --hints:off --warnings:off --outdir:build/wip --nimcache:nimcache/wip \
 ##   workspace/positron/tests/manual_mla_latent_fp16.nim
+
 import std/strformat
 import workspace/[crucible, libtorch, libtorch_testutils]
 import workspace/libtorch as F
 from workspace/libtorch/src/raw_libtorch import manual_seed
 import ../src/kernels/ceramic/mla_latent_fwd
 import ./attn_test_utils
+
 const mlaMsl = metal:
   proc mlaLatent(combined: ptr UncheckedArray[float16], x, qa_w, qa_g, qb_w, kva_w, kva_g, kvb_w: ptr UncheckedArray[float16],
       cos_t, sin_t: ptr UncheckedArray[float32], num_tokens, num_heads: int32) {.global.} =
     let n = num_tokens * num_heads * 256
     mla_latent_fwd(combined, combined +% int(n), combined +% (2 * int(n)),
       x, qa_w, qa_g, qb_w, kva_w, kva_g, kvb_w, cos_t, sin_t, num_tokens, num_heads)
+
 proc dup64(a: seq[float32], T: int): seq[float32] =
   ## The model's emb = cat((freqs, freqs)): entry c = freq (c mod 32).
   for r in 0 ..< T:
     for half in 0 ..< 2:
       for c in 0 ..< 32:
         result.add a[r * 32 + c]
+
 proc gammaVals(n: int): seq[float32] =
   for c in 0 ..< n:
     result.add 0.5'f32 + float32(((7 * c + 55 + 13 * (c div 32)) mod 16)) / 16.0'f32
+
 proc ropePairs(r, cos32, sin32: F.Tensor): F.Tensor =
   let rb = r.reshape(r.size(0), r.size(1), 32, 2)
   let c32 = cos32.unsqueeze(1)
@@ -36,10 +41,12 @@ proc ropePairs(r, cos32, sin32: F.Tensor): F.Tensor =
   let a = rb.narrow(3, 0, 1).squeeze(3)
   let b = rb.narrow(3, 1, 1).squeeze(3)
   F.cat([(a * c32 - b * s32).unsqueeze(3), (b * c32 + a * s32).unsqueeze(3)], 3).reshape(r.size(0), r.size(1), 64)
+
 proc genIn(T, H: int): tuple[xf, qaWF, qaGF, qbWF, kvaWF, kvaGF, kvbWF: seq[float32]] =
   (scaledRand(T, 2048, 0.125'f32), scaledRand(768, 2048, 0.125'f32), gammaVals(768),
    scaledRand(H * 256, 768, 0.125'f32), scaledRand(576, 2048, 0.125'f32), gammaVals(512),
    scaledRand(H * 448, 512, 0.125'f32))
+
 proc mlaKernel(g: tuple[xf, qaWF, qaGF, qbWF, kvaWF, kvaGF, kvbWF: seq[float32]],
                cosF, sinF: seq[float32], T, H: int): F.Tensor =
   var engine = bkMetal.init()
@@ -53,6 +60,7 @@ proc mlaKernel(g: tuple[xf, qaWF, qaGF, qbWF, kvaWF, kvaGF, kvbWF: seq[float32]]
   let q = toTensor(fp16sToF32(outAll[0 ..< n])).reshape(T, H, 256)
   F.cat([q, toTensor(fp16sToF32(outAll[n ..< 2 * n])).reshape(T, H, 256),
          toTensor(fp16sToF32(outAll[2 * n ..< 3 * n])).reshape(T, H, 256)], 0).reshape(-1)
+
 proc mlaReference(g: tuple[xf, qaWF, qaGF, qbWF, kvaWF, kvaGF, kvbWF: seq[float32]],
                   cos32, sin32: seq[float32], T, H: int): F.Tensor =
   let x32 = w32(g.xf, T, 2048)
@@ -68,6 +76,7 @@ proc mlaReference(g: tuple[xf, qaWF, qaGF, qbWF, kvaWF, kvaGF, kvbWF: seq[float3
   F.cat([F.cat([q.narrow(2, 0, 192), qRotR], 2).to(kFloat16).to(kFloat32),
          F.cat([kb.narrow(2, 0, 192), kRotR], 2).to(kFloat16).to(kFloat32),
          kb.narrow(2, 192, 256).to(kFloat16).to(kFloat32)], 0).reshape(-1)
+
 proc checkMlaLatent(): bool =
   ## T=8/H=4 and T=16/H=20 (the real head count). The 1e-2 bound
   ## covers 4 chained matmuls, 2 norms and the rope at the 0.125 scale
@@ -81,5 +90,6 @@ proc checkMlaLatent(): bool =
     echo &"  T={T} H={H}: worst |Δ| = {worstAbsDiff(actual, expected)}"
     assertAllClose(actual, expected, rtol = 0.0'f64, abstol = 1e-2'f64)
   result = true
+
 when isMainModule:
   runCppTest("mla_latent_fwd vs the torch reference", checkMlaLatent)

--- a/workspace/positron/tests/manual_moe_fp16.nim
+++ b/workspace/positron/tests/manual_moe_fp16.nim
@@ -8,22 +8,27 @@
 ##
 ## Run: nim cpp -r --hints:off --warnings:off --outdir:build/wip --nimcache:nimcache/wip \
 ##   workspace/positron/tests/manual_moe_fp16.nim
+
 import std/strformat
 import workspace/[crucible, libtorch, libtorch_testutils]
 import workspace/libtorch as F
 from workspace/libtorch/src/raw_libtorch import manual_seed
 import ../src/kernels/ceramic/moe_fwd
 import ./attn_test_utils
+
 const moeMsl = metal:
   proc moeRun(out_r, x, router_w, gate_up_w, down_w, shared_gate_up_w, shared_down_w,
       h_scratch, hs_scratch: ptr UncheckedArray[float16], num_tokens: int32) {.global.} =
     moe_fwd(out_r, x, router_w, gate_up_w, down_w, shared_gate_up_w, shared_down_w,
       h_scratch, hs_scratch, num_tokens)
+
 type MoEG = tuple[xf, rwf, guf, dnf, sguf, sdwf: seq[float32]]
+
 proc genMoE(T: int): MoEG =
   (scaledRand(T, 2048, 0.3'f32), scaledRand(64, 2048, 0.125'f32),
    scaledRand(64 * 3072, 2048, 0.125'f32), scaledRand(64 * 2048, 1536, 0.125'f32),
    scaledRand(3072, 2048, 0.125'f32), scaledRand(2048, 1536, 0.125'f32))
+
 proc moeKernel(g: MoEG, T: int): F.Tensor =
   var engine = bkMetal.init()
   engine.ingest(moeMsl)
@@ -34,6 +39,7 @@ proc moeKernel(g: MoEG, T: int): F.Tensor =
     (fp32sToFp16(g.xf), fp32sToFp16(g.rwf), fp32sToFp16(g.guf), fp32sToFp16(g.dnf),
      fp32sToFp16(g.sguf), fp32sToFp16(g.sdwf), hScr, hsScr, int32(T)))
   toTensor(fp16sToF32(outO)).reshape(T, 2048)
+
 proc moeReference(g: MoEG, T: int): F.Tensor =
   let x32 = w32(g.xf, T, 2048)
   let logits = F.linear(x32, w32(g.rwf, 64, 2048))
@@ -56,12 +62,13 @@ proc moeReference(g: MoEG, T: int): F.Tensor =
   let hs = F.silu(sgu[0]) * sgu[1]
   let shared = F.linear(hs.to(kFloat16).to(kFloat32), w32(g.sdwf, 2048, 1536))
   (routed + shared).to(kFloat16).to(kFloat32)
+
 proc checkMoe(): bool =
-  ## T=8 and T=4 against the torch reference. The 1e-2 bound covers the
-  ## 4-slot routed chain (gate_up, silu with one fp16 h round, down),
-  ## the weighted sum and the shared MLP at the 0.125 weight scale. A
-  ## wrong top-4 set, expert index mapping or scale shows up as O(1)
-  ## errors.
+  ## T=8 and T=4 against the torch reference.
+  ## The 1e-2 bound covers the 4-slot routed chain: gate_up, silu,
+  ## one fp16 h round, and down. The weighted sum and the shared MLP
+  ## fit within the bound at the 0.125 weight scale. A wrong top-4
+  ## set, expert index mapping or scale shows up as O(1) errors.
   Torch.manual_seed(0x5EED'u64)
   for T in [8, 4]:
     let g = genMoE(T)
@@ -70,5 +77,6 @@ proc checkMoe(): bool =
     echo &"  T={T}: worst |Δ| = {worstAbsDiff(actual, expected)}"
     assertAllClose(actual, expected, rtol = 0.0'f64, abstol = 1e-2'f64)
   result = true
+
 when isMainModule:
   runCppTest("moe_fwd vs the torch reference", checkMoe)

--- a/workspace/positron/tests/manual_moe_fp16.nim
+++ b/workspace/positron/tests/manual_moe_fp16.nim
@@ -1,0 +1,76 @@
+## Tattletale
+## Copyright (c) 2026 Mamy André-Ratsimbazafy
+## Licensed and distributed under either of
+##   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+##   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+## at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+##
+## Run: nim cpp -r --hints:off --warnings:off --outdir:build/wip --nimcache:nimcache/wip \
+##   workspace/positron/tests/manual_moe_fp16.nim
+import std/strformat
+import workspace/[crucible, libtorch, libtorch_testutils]
+import workspace/libtorch as F
+from workspace/libtorch/src/raw_libtorch import manual_seed
+import ../src/kernels/ceramic/moe_fwd
+import ./attn_test_utils
+const moeMsl = metal:
+  proc moeRun(out_r, x, router_w, gate_up_w, down_w, shared_gate_up_w, shared_down_w,
+      h_scratch, hs_scratch: ptr UncheckedArray[float16], num_tokens: int32) {.global.} =
+    moe_fwd(out_r, x, router_w, gate_up_w, down_w, shared_gate_up_w, shared_down_w,
+      h_scratch, hs_scratch, num_tokens)
+type MoEG = tuple[xf, rwf, guf, dnf, sguf, sdwf: seq[float32]]
+proc w32(fs: seq[float32], rows, cols: int): F.Tensor =
+  toTensor(fp16sToF32(fp32sToFp16(fs))).reshape(rows, cols)
+proc genMoE(T: int): MoEG =
+  (scaledRand(T, 2048, 0.3'f32), scaledRand(64, 2048, 0.125'f32),
+   scaledRand(64 * 3072, 2048, 0.125'f32), scaledRand(64 * 2048, 1536, 0.125'f32),
+   scaledRand(3072, 2048, 0.125'f32), scaledRand(2048, 1536, 0.125'f32))
+proc moeKernel(g: MoEG, T: int): F.Tensor =
+  var engine = bkMetal.init()
+  engine.ingest(moeMsl)
+  var outO = newSeq[uint16](T * 2048)
+  var hScr = newSeq[uint16](T * 4 * 1536)
+  var hsScr = newSeq[uint16](T * 1536)
+  engine.run << (grid: (T, 1, 1), blk: (32, 1)) >> ("moeRun", outO,
+    (fp32sToFp16(g.xf), fp32sToFp16(g.rwf), fp32sToFp16(g.guf), fp32sToFp16(g.dnf),
+     fp32sToFp16(g.sguf), fp32sToFp16(g.sdwf), hScr, hsScr, int32(T)))
+  toTensor(fp16sToF32(outO)).reshape(T, 2048)
+proc moeReference(g: MoEG, T: int): F.Tensor =
+  let x32 = w32(g.xf, T, 2048)
+  let logits = F.linear(x32, w32(g.rwf, 64, 2048))
+  let s = (1.0'f32 + (-logits).exp()).reciprocal()
+  let (_, idx) = F.sort(s, axis = 1, descending = true)
+  let top4 = idx.narrow(1, 0, 4)
+  var w = s.gather(1, top4)
+  w = w / (w.sum(1, keepdim = true) + 1e-20'f32)
+  w = w * 1.8'f32
+  let xg = x32.unsqueeze(1).expand(T, 4, 2048, implicit = false).reshape(T * 4, 2048)
+  let gu4 = toTensor(fp16sToF32(fp32sToFp16(g.guf))).reshape(64, 3072, 2048)
+    .index_select(0, top4.reshape(-1))
+  let gu = F.bmm(xg.unsqueeze(1), gu4.transpose(1, 2)).squeeze(1).chunk(2, dim = 1)
+  let h16 = (F.silu(gu[0]) * gu[1]).to(kFloat16).to(kFloat32)
+  let dn4 = toTensor(fp16sToF32(fp32sToFp16(g.dnf))).reshape(64, 2048, 1536)
+    .index_select(0, top4.reshape(-1))
+  let oe = F.bmm(h16.unsqueeze(1), dn4.transpose(1, 2)).squeeze(1).reshape(T, 4, 2048)
+  let routed = (oe * w.unsqueeze(2)).sum(1)
+  let sgu = F.linear(x32, w32(g.sguf, 3072, 2048)).chunk(2, dim = 1)
+  let hs = F.silu(sgu[0]) * sgu[1]
+  let shared = F.linear(hs.to(kFloat16).to(kFloat32), w32(g.sdwf, 2048, 1536))
+  (routed + shared).to(kFloat16).to(kFloat32)
+proc checkMoe(): bool =
+  ## T=8 and T=4 against the torch reference. The 1e-2 bound covers the
+  ## 4-slot routed chain (gate_up, silu with one fp16 h round, down),
+  ## the weighted sum and the shared MLP at the 0.125 weight scale. A
+  ## wrong top-4 set, expert index mapping or scale shows up as O(1)
+  ## errors.
+  Torch.manual_seed(0x5EED'u64)
+  for T in [8, 4]:
+    let g = genMoE(T)
+    let actual = moeKernel(g, T)
+    let expected = moeReference(g, T)
+    echo &"  T={T}: worst |Δ| = {worstAbsDiff(actual, expected)}"
+    assertAllClose(actual, expected, rtol = 0.0'f64, abstol = 1e-2'f64)
+  result = true
+when isMainModule:
+  runCppTest("moe_fwd vs the torch reference", checkMoe)

--- a/workspace/positron/tests/manual_moe_fp16.nim
+++ b/workspace/positron/tests/manual_moe_fp16.nim
@@ -20,8 +20,6 @@ const moeMsl = metal:
     moe_fwd(out_r, x, router_w, gate_up_w, down_w, shared_gate_up_w, shared_down_w,
       h_scratch, hs_scratch, num_tokens)
 type MoEG = tuple[xf, rwf, guf, dnf, sguf, sdwf: seq[float32]]
-proc w32(fs: seq[float32], rows, cols: int): F.Tensor =
-  toTensor(fp16sToF32(fp32sToFp16(fs))).reshape(rows, cols)
 proc genMoE(T: int): MoEG =
   (scaledRand(T, 2048, 0.3'f32), scaledRand(64, 2048, 0.125'f32),
    scaledRand(64 * 3072, 2048, 0.125'f32), scaledRand(64 * 2048, 1536, 0.125'f32),

--- a/workspace/positron/tests/manual_swa_attn_fp16.nim
+++ b/workspace/positron/tests/manual_swa_attn_fp16.nim
@@ -1,0 +1,89 @@
+## Tattletale
+## Copyright (c) 2026 Mamy André-Ratsimbazafy
+## Licensed and distributed under either of
+##   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+##   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+## at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+##
+## Run: nim cpp -r --hints:off --warnings:off \
+##   --outdir:build/wip \
+##   --nimcache:nimcache/wip \
+##   workspace/positron/tests/manual_swa_attn_fp16.nim
+
+import std/[strformat, math, options]
+import workspace/crucible
+import workspace/libtorch
+import workspace/libtorch as F
+import workspace/libtorch_testutils
+from workspace/libtorch/src/raw_libtorch import manual_seed
+import ../src/kernels/ceramic/swa_attn
+import ./attn_test_utils
+
+const swaMsl = metal:
+  proc swaD64(
+      o, q, k, v: ptr UncheckedArray[float16],
+      num_qo, num_kv, q_offset, H, Nkv, window: int32) {.global.} =
+    swa_attn_fwd(o, q, k, v, num_qo, num_kv, q_offset, H, Nkv, window, 64)
+  proc swaD128(
+      o, q, k, v: ptr UncheckedArray[float16],
+      num_qo, num_kv, q_offset, H, Nkv, window: int32) {.global.} =
+    swa_attn_fwd(o, q, k, v, num_qo, num_kv, q_offset, H, Nkv, window, 128)
+
+proc swaAttnKernel(qf, kf, vf: seq[float32], numQo, numKv, qOffset, H, Nkv, window, D: int): F.Tensor =
+  ## Runs the D-specialized wrapper on the fp16-rounded inputs, returns the fp16 output widened to fp32.
+  var engine = bkMetal.init()
+  engine.ingest(swaMsl)
+  let args = (fp32sToFp16(qf), fp32sToFp16(kf), fp32sToFp16(vf),
+              int32(numQo), int32(numKv), int32(qOffset), int32(H), int32(Nkv), int32(window))
+  var outO = newSeq[uint16](numQo * H * D)
+  engine.run << (grid: ((numQo + 7) div 8, H, 1), blk: (32, 1)) >> ("swaD" & $D, outO, args)
+  result = toTensor(fp16sToF32(outO)).reshape(numQo, H, D)
+
+proc swaAttnReference(qf, kf, vf: seq[float32], numQo, numKv, qOffset, H, Nkv, window, D: int): F.Tensor =
+  ## torch SDPA over the same fp16-rounded values: q (1, H, num_qo, D),
+  ## k/v (1, Nkv, num_kv, D), scale 1.0, the banded window mask as an
+  ## additive bias, GQA on when H > Nkv.
+  let qT = toTensor(qf).reshape(numQo, H, D).to(kFloat16).to(kFloat32)
+  let kT = toTensor(kf).reshape(numKv, Nkv, D).to(kFloat16).to(kFloat32)
+  let vT = toTensor(vf).reshape(numKv, Nkv, D).to(kFloat16).to(kFloat32)
+  let q4 = qT.reshape(1, numQo, H, D).transpose(1, 2)
+  let k4 = kT.reshape(1, numKv, Nkv, D).transpose(1, 2)
+  let v4 = vT.reshape(1, numKv, Nkv, D).transpose(1, 2)
+  var maskF = newSeq[float32](numQo * numKv)
+  for i in 0 ..< numQo:
+    for j in 0 ..< numKv:
+      maskF[i * numKv + j] = if j <= qOffset + i and j >= qOffset + i - window + 1: 0.0'f32 else: float32(NegInf)
+  let mt = toTensor(maskF).reshape(1, numQo, numKv)
+  let o4 = scaled_dot_product_attention(q4, k4, v4, attn_mask = some(mt),
+             scale = some(1.0'f64), enable_gqa = H > Nkv)
+  result = o4.transpose(1, 2).reshape(numQo, H, D)
+
+proc checkSwaAttn(): bool =
+  ## Five cases vs torch SDPA: window 512 (causal only), window 16
+  ## (band binds), GQA with D = 64, a decode query at the tail, and a
+  ## short decode window at the causal edge. The 5e-3 bound sits ~7x
+  ## above the observed 7e-4 accumulation-order noise between the
+  ## torch matmuls and the Metal mma, so a wrong band edge, scale or
+  ## GQA mapping shows up as O(1) errors.
+  Torch.manual_seed(0x5EED'u64)
+  let cases = [(8, 1, 128, 64, 64, 0, 512), (8, 1, 128, 128, 128, 0, 16),
+               (4, 2, 64, 40, 40, 0, 12), (8, 1, 128, 1, 33, 32, 8),
+               (4, 2, 64, 4, 28, 24, 8)]
+  var worstAll = 0.0'f32
+  for d in 0 ..< cases.len:
+    let (H, Nkv, D, numQo, numKv, qOffset, window) = cases[d]
+    let qf = scaledRand(numQo, H * D, 2.0'f32)
+    let kf = scaledRand(numKv, Nkv * D, 2.0'f32)
+    let vf = scaledRand(numKv, Nkv * D, 2.0'f32)
+    let actual = swaAttnKernel(qf, kf, vf, numQo, numKv, qOffset, H, Nkv, window, D)
+    let expected = swaAttnReference(qf, kf, vf, numQo, numKv, qOffset, H, Nkv, window, D)
+    let w = worstAbsDiff(actual, expected)
+    if w > worstAll: worstAll = w
+    echo &"  H={H} Nkv={Nkv} D={D} num_qo={numQo} num_kv={numKv} q_offset={qOffset} window={window}: worst |Δ| = {w}"
+    assertAllClose(actual, expected, rtol = 0.0'f64, abstol = 5e-3'f64)
+  echo &"  worst |Δ| across {cases.len} cases = {worstAll} (tolerance 5e-3)"
+  result = true
+
+when isMainModule:
+  runCppTest("swa_attn_fwd vs torch SDPA (window mask)", checkSwaAttn)

--- a/workspace/positron/tests/manual_swa_attn_fp16.nim
+++ b/workspace/positron/tests/manual_swa_attn_fp16.nim
@@ -26,11 +26,22 @@ const swaMsl = metal:
       num_qo, num_kv, q_offset, H, Nkv, window: int32) {.global.} =
     swa_attn_fwd(o, q, k, v, num_qo, num_kv, q_offset, H, Nkv, window, 128)
 
+proc padRows8(fs: seq[float32], rows, rowStride: int): seq[float32] =
+  ## Appends zero rows until the row count is a multiple of 8.
+  ## The kernel's tile loads fetch full 8-row blocks, so a partial
+  ## trailing block must exist in the buffer. The zero rows are inert:
+  ## the band mask excludes them from the softmax and the zero v rows
+  ## add nothing to the P·V mma.
+  let padRows = (rows + 7) div 8 * 8 - rows
+  result = fs & newSeq[float32](padRows * rowStride)
+
 proc swaAttnKernel(qf, kf, vf: seq[float32], numQo, numKv, qOffset, H, Nkv, window, D: int): F.Tensor =
   ## Runs the D-specialized wrapper on the fp16-rounded inputs, returns the fp16 output widened to fp32.
   var engine = bkMetal.init()
   engine.ingest(swaMsl)
-  let args = (fp32sToFp16(qf), fp32sToFp16(kf), fp32sToFp16(vf),
+  let args = (fp32sToFp16(padRows8(qf, numQo, H * D)),
+              fp32sToFp16(padRows8(kf, numKv, Nkv * D)),
+              fp32sToFp16(padRows8(vf, numKv, Nkv * D)),
               int32(numQo), int32(numKv), int32(qOffset), int32(H), int32(Nkv), int32(window))
   var outO = newSeq[uint16](numQo * H * D)
   engine.run << (grid: ((numQo + 7) div 8, H, 1), blk: (32, 1)) >> ("swaD" & $D, outO, args)
@@ -69,7 +80,8 @@ proc checkSwaAttn(): bool =
     let actual = swaAttnKernel(qf, kf, vf, numQo, numKv, qOffset, H, Nkv, window, D)
     let expected = swaAttnReference(qf, kf, vf, numQo, numKv, qOffset, H, Nkv, window, D)
     let w = worstAbsDiff(actual, expected)
-    if w > worstAll: worstAll = w
+    if w > worstAll:
+      worstAll = w
     echo &"  H={H} Nkv={Nkv} D={D} num_qo={numQo} num_kv={numKv} q_offset={qOffset} window={window}: worst |Δ| = {w}"
     assertAllClose(actual, expected, rtol = 0.0'f64, abstol = 5e-3'f64)
   echo &"  worst |Δ| across {cases.len} cases = {worstAll} (tolerance 5e-3)"

--- a/workspace/positron/tests/manual_swa_attn_fp16.nim
+++ b/workspace/positron/tests/manual_swa_attn_fp16.nim
@@ -6,9 +6,7 @@
 ## at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 ##
-## Run: nim cpp -r --hints:off --warnings:off \
-##   --outdir:build/wip \
-##   --nimcache:nimcache/wip \
+## Run: nim cpp -r --hints:off --warnings:off --outdir:build/wip --nimcache:nimcache/wip \
 ##   workspace/positron/tests/manual_swa_attn_fp16.nim
 
 import std/[strformat, math, options]
@@ -21,12 +19,10 @@ import ../src/kernels/ceramic/swa_attn
 import ./attn_test_utils
 
 const swaMsl = metal:
-  proc swaD64(
-      o, q, k, v: ptr UncheckedArray[float16],
+  proc swaD64(o, q, k, v: ptr UncheckedArray[float16],
       num_qo, num_kv, q_offset, H, Nkv, window: int32) {.global.} =
     swa_attn_fwd(o, q, k, v, num_qo, num_kv, q_offset, H, Nkv, window, 64)
-  proc swaD128(
-      o, q, k, v: ptr UncheckedArray[float16],
+  proc swaD128(o, q, k, v: ptr UncheckedArray[float16],
       num_qo, num_kv, q_offset, H, Nkv, window: int32) {.global.} =
     swa_attn_fwd(o, q, k, v, num_qo, num_kv, q_offset, H, Nkv, window, 128)
 
@@ -41,9 +37,7 @@ proc swaAttnKernel(qf, kf, vf: seq[float32], numQo, numKv, qOffset, H, Nkv, wind
   result = toTensor(fp16sToF32(outO)).reshape(numQo, H, D)
 
 proc swaAttnReference(qf, kf, vf: seq[float32], numQo, numKv, qOffset, H, Nkv, window, D: int): F.Tensor =
-  ## torch SDPA over the same fp16-rounded values: q (1, H, num_qo, D),
-  ## k/v (1, Nkv, num_kv, D), scale 1.0, the banded window mask as an
-  ## additive bias, GQA on when H > Nkv.
+  ## torch SDPA over the same fp16-rounded values: scale 1.0, the banded window mask as an additive bias, GQA on when H > Nkv.
   let qT = toTensor(qf).reshape(numQo, H, D).to(kFloat16).to(kFloat32)
   let kT = toTensor(kf).reshape(numKv, Nkv, D).to(kFloat16).to(kFloat32)
   let vT = toTensor(vf).reshape(numKv, Nkv, D).to(kFloat16).to(kFloat32)
@@ -60,16 +54,12 @@ proc swaAttnReference(qf, kf, vf: seq[float32], numQo, numKv, qOffset, H, Nkv, w
   result = o4.transpose(1, 2).reshape(numQo, H, D)
 
 proc checkSwaAttn(): bool =
-  ## Five cases vs torch SDPA: window 512 (causal only), window 16
-  ## (band binds), GQA with D = 64, a decode query at the tail, and a
-  ## short decode window at the causal edge. The 5e-3 bound sits ~7x
-  ## above the observed 7e-4 accumulation-order noise between the
-  ## torch matmuls and the Metal mma, so a wrong band edge, scale or
-  ## GQA mapping shows up as O(1) errors.
+  ## Five cases vs torch SDPA: causal-only, banded, GQA, tail decode,
+  ## and a short edge window. The 5e-3 bound is ~7x the observed noise
+  ## (~7e-4), so wrong band edges, scale or GQA mapping fail by O(1).
   Torch.manual_seed(0x5EED'u64)
   let cases = [(8, 1, 128, 64, 64, 0, 512), (8, 1, 128, 128, 128, 0, 16),
-               (4, 2, 64, 40, 40, 0, 12), (8, 1, 128, 1, 33, 32, 8),
-               (4, 2, 64, 4, 28, 24, 8)]
+               (4, 2, 64, 40, 40, 0, 12), (8, 1, 128, 1, 33, 32, 8), (4, 2, 64, 4, 28, 24, 8)]
   var worstAll = 0.0'f32
   for d in 0 ..< cases.len:
     let (H, Nkv, D, numQo, numKv, qOffset, window) = cases[d]


### PR DESCRIPTION
This adds:
- Multi-Head Latent Attention
- Sliding-Window Attention
- Mixtures of Experts

Those are prerequisites to prepare for supporting state-of-the-art models.

For now, hardcoding GLM-4.7-Flash and Gemma-4-E2B as the smallest models that uses those features.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added experimental accelerated kernels for MLA latent projection, mixture-of-experts processing, and sliding-window attention.
  - Added support for rotary embeddings, routed expert selection, grouped-query attention, causal masking, and fp16 output processing.

- **Tests**
  - Added manual validation tests comparing all three kernels with PyTorch reference implementations.
  - Added shared utilities for tensor generation, fp16 conversion, RoPE tables, and numerical error checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->