### PR TITLE
[Kernel] Paged EXL3-quantized KV cache support for PagedAttention

### DIFF
--- a/workspace/ceramic/experiments/manual_tile_ragged_gemm_fp16.nim
+++ b/workspace/ceramic/experiments/manual_tile_ragged_gemm_fp16.nim
@@ -167,7 +167,7 @@ proc checkIdentical(name: string; A, B: seq[float32]; M, N, Np: int) =
     quit 1
 
 proc runTests() =   # engines are RAII, so keep them function-local
-  checkDrawPins()          # the hash draws must not drift
+  checkCasePins()          # the hash cases must not drift
   var zfEngine = bkMetal.init()
   var brEngine = bkMetal.init()
   zfEngine.ingest(raggedZfMsl)
@@ -187,21 +187,21 @@ proc runTests() =   # engines are RAII, so keep them function-local
   let br0 = checkRagged(brEngine, "ragBr", M0, N0, K0, k40)
   checkIdentical("ragZf ≡ ragBr", zf0, br0, M0, N0, Np0)
 
-  var draws = initShapeDraws("ragged")
-  for draw in 0 ..< 2:
-    let b0 = draws.nextBytes()
-    let M = drawInRange(b0, 0, 1, 96)
-    let N = drawInRange(b0, 1, 1, 96)
-    let K = drawInRange(b0, 2, 1, 96)
+  var cases = initShapeCases("ragged")
+  for caseIdx in 0 ..< 2:
+    let b0 = cases.nextBytes()
+    let M = caseInRange(b0, 0, 1, 96)
+    let N = caseInRange(b0, 1, 1, 96)
+    let K = caseInRange(b0, 2, 1, 96)
     let Np = ((N + 31) div 32) * 32
-    # per-row K_eff from the following digest bytes (20 rows per draw)
+    # per-row K_eff from the following digest bytes (20 rows per case)
     var kEffs = newSeq[int](M)
     var i = 0
-    var b = draws.nextBytes()
+    var b = cases.nextBytes()
     for m in 0 ..< M:
       if i >= 20:
         i = 0
-        b = draws.nextBytes()
+        b = cases.nextBytes()
       kEffs[m] = int(b[i]) mod (K + 1)
       inc i
     echo &"ragged GEMM {M}×{N}×{K} (K_eff ∈ [{kEffs.min},{kEffs.max}], both strategies):"

--- a/workspace/ceramic/tests/kernels_tiles/manual_tile_attn_fp16.nim
+++ b/workspace/ceramic/tests/kernels_tiles/manual_tile_attn_fp16.nim
@@ -118,17 +118,17 @@ proc checkAttn(engine: var auto; kernel: string; B, H, N, D: int;
     quit 1
 
 proc runTests() =   # engines are RAII, so keep them function-local
-  checkDrawPins()          # the hash draws must not drift
+  checkCasePins()          # the hash cases must not drift
   var engine = bkMetal.init()
   engine.ingest(attnMsl)
   echo attnMsl            # keep the generated MSL inspectable
 
-  var draws = initShapeDraws("attn")
-  for draw in 0 ..< 3:
-    let b = draws.nextBytes()
-    let B = drawInRange(b, 0, 1, 2)
-    let H = drawInRange(b, 1, 1, 2)
-    let N = 8 * drawInRange(b, 4, 1, 12)   # N ∈ {8..96}, multiples of 8
+  var cases = initShapeCases("attn")
+  for caseIdx in 0 ..< 3:
+    let b = cases.nextBytes()
+    let B = caseInRange(b, 0, 1, 2)
+    let H = caseInRange(b, 1, 1, 2)
+    let N = 8 * caseInRange(b, 4, 1, 12)   # N ∈ {8..96}, multiples of 8
     let g = torchSdpa(B, H, N, D = 64, seedQ = 1, seedK = 4, seedV = 8)
     checkAttn(engine, "attnD64", B, H, N, 64, g)
     let g128 = torchSdpa(B, H, N, D = 128, seedQ = 11, seedK = 14, seedV = 18)

--- a/workspace/ceramic/tests/kernels_tiles/manual_tile_gemm_fp16.nim
+++ b/workspace/ceramic/tests/kernels_tiles/manual_tile_gemm_fp16.nim
@@ -103,7 +103,7 @@ proc checkGemm(engine: var auto; kernel: string; M, N, K: int) =
     quit 1
 
 proc runTests() =   # engines are RAII, so keep them function-local
-  checkDrawPins()          # the hash draws must not drift
+  checkCasePins()          # the hash cases must not drift
   var engine = bkMetal.init()
   engine.ingest(gemmMsl)
   echo gemmMsl          # keep the generated MSL inspectable
@@ -113,12 +113,12 @@ proc runTests() =   # engines are RAII, so keep them function-local
   # (bit-exact vs the empty reference).
   checkGemm(engine, "fusedGemm", 32, 64, 0)
 
-  var draws = initShapeDraws("gemm")
-  for draw in 0 ..< 2:
-    let b = draws.nextBytes()
-    let M = drawInRange(b, 0, 1, 96)
-    let N = drawInRange(b, 1, 1, 96)
-    let K = drawInRange(b, 2, 1, 96)
+  var cases = initShapeCases("gemm")
+  for caseIdx in 0 ..< 2:
+    let b = cases.nextBytes()
+    let M = caseInRange(b, 0, 1, 96)
+    let N = caseInRange(b, 1, 1, 96)
+    let K = caseInRange(b, 2, 1, 96)
     checkGemm(engine, "fusedGemm", M, N, K)
 
 when isMainModule:

--- a/workspace/ceramic/tests/kernels_tiles/manual_tile_rmsnorm_fp16.nim
+++ b/workspace/ceramic/tests/kernels_tiles/manual_tile_rmsnorm_fp16.nim
@@ -98,25 +98,25 @@ proc checkRmsnorm(engine: var auto; kernel: string; M, C: int; eps: float32) =
     quit 1
 
 proc runTests() =   # engines are RAII, so keep them function-local
-  checkDrawPins()          # the hash draws must not drift
+  checkCasePins()          # the hash cases must not drift
   var engine = bkMetal.init()
   engine.ingest(rmsnormMsl)
   echo rmsnormMsl           # keep the generated MSL inspectable
 
-  var draws = initShapeDraws("rmsnormKernel")
-  for draw in 0 ..< 2:
-    let b = draws.nextBytes()
-    let M = drawInRange(b, 0, 1, 64)
-    let C = drawInRange(b, 1, 1, 128)
+  var cases = initShapeCases("rmsnormKernel")
+  for caseIdx in 0 ..< 2:
+    let b = cases.nextBytes()
+    let M = caseInRange(b, 0, 1, 64)
+    let C = caseInRange(b, 1, 1, 128)
     doAssert C <= Ct, "C must fit the static tile width (Ct)"
-    # ε varies across the draws: at ε = 1e-2 a kernel that drops the ε shift
+    # ε varies across the cases: at ε = 1e-2 a kernel that drops the ε shift
     # (rstd without the add) errs orders above the 1e-5 tolerance.
-    let eps = if draw == 0: 1e-5'f32 else: 1e-2'f32
+    let eps = if caseIdx == 0: 1e-5'f32 else: 1e-2'f32
     checkRmsnorm(engine, "rmsnormKernel", M, C, eps)
-  # The C == 128 draw exercises the unpadded path: every source column
+  # The C == 128 case exercises the unpadded path: every source column
   # carries real data, so the zero-padding never contributes.
-  let b = draws.nextBytes()
-  let M = drawInRange(b, 0, 1, 64)
+  let b = cases.nextBytes()
+  let M = caseInRange(b, 0, 1, 64)
   checkRmsnorm(engine, "rmsnormKernel", M, Ct, eps = 1e-2'f32)
 
 when isMainModule:

--- a/workspace/ceramic/tests/tile_test_utils.nim
+++ b/workspace/ceramic/tests/tile_test_utils.nim
@@ -6,7 +6,7 @@
 ## at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 ## Host-side test support for the tile layer: the fp16↔fp32 bit-pattern converters
-## (round-to-nearest-even) and the deterministic shape draws for the on-device tests.
+## (round-to-nearest-even) and the deterministic shape cases for the on-device tests.
 ## Not a test module (no `test_` prefix): `nim test_ceramic` does not run it.
 
 import std/sha1
@@ -73,100 +73,100 @@ func fp32ToFp16*(x: float32): uint16 =
   return sign or uint16(bexp shl 10) or uint16(r)
 
 # ═════════════════════════════════════════════════════════════════════════
-#  Deterministic shape draws (SHA-1 of a fixed seed and a per-draw counter)
+#  Deterministic shape cases (SHA-1 of a fixed seed and a per-case counter)
 # ═════════════════════════════════════════════════════════════════════════
 #
 # The on-device tests must be impossible to pass by hardcoding dimensions:
-# each test draws its shapes from the SHA-1 digest of a fixed seed and a per-draw counter
+# each test takes its shapes from the SHA-1 digest of a fixed seed and a per-case counter
 # (preimage-resistant), so the dimensions cannot be baked into a kernel.
 # The digest bytes are the only source of shape parameters.
 
 type
-  ShapeDraws* = object
-    ## A deterministic hash-draw stream. `seed` is fixed at construction.
-    ## `counter` increments per draw. `nextBytes` returns the 20-byte SHA-1 digest
+  ShapeCases* = object
+    ## A deterministic hash-case stream. `seed` is fixed at construction.
+    ## `counter` increments per case. `nextBytes` returns the 20-byte SHA-1 digest
     ## of `seed & ":" & counter`.
     seed*: string
     counter*: int
 
-func initShapeDraws*(seed: string): ShapeDraws =
-  ## Starts a draw stream for `seed`. All draws are deterministic: the same seed
+func initShapeCases*(seed: string): ShapeCases =
+  ## Starts a case stream for `seed`. All cases are deterministic: the same seed
   ## always yields the same shapes.
-  ShapeDraws(seed: seed, counter: 0)
+  ShapeCases(seed: seed, counter: 0)
 
-func nextBytes*(draws: var ShapeDraws): array[20, uint8] =
+func nextBytes*(cases: var ShapeCases): array[20, uint8] =
   ## Returns the 20 digest bytes of `sha1(seed & ":" & counter)`.
-  let digest = secureHash(draws.seed & ":" & $draws.counter)
-  inc draws.counter
+  let digest = secureHash(cases.seed & ":" & $cases.counter)
+  inc cases.counter
   Sha1Digest(digest)
 
-func drawInRange*(b: array[20, uint8]; i: int; lo, hi: int): int =
+func caseInRange*(b: array[20, uint8]; i: int; lo, hi: int): int =
   ## Returns a deterministic value in `[lo, hi]` from digest byte `i`.
   ## Callers keep `i` distinct per parameter so the parameters stay
   ## independent.
   doAssert i >= 0 and i < 20
   lo + int(b[i]) mod (hi - lo + 1)
 
-proc checkDrawPins*() =
-  ## Verifies the fixed digest bytes and derived shapes for the first draws
+proc checkCasePins*() =
+  ## Verifies the fixed digest bytes and derived shapes for the first cases
   ## of each test seed. A silent hash regression must fail loudly
   ## here, not silently shrink every shape.
   block gemmPins:
-    var d = initShapeDraws("gemm")
+    var d = initShapeCases("gemm")
     let b0 = d.nextBytes()
     doAssert b0[0] == 0x85'u8 and b0[1] == 0xf3'u8 and b0[2] == 0x8f'u8,
       "gemm:0 digest bytes changed"
-    doAssert drawInRange(b0, 0, 1, 96) == 38
-    doAssert drawInRange(b0, 1, 1, 96) == 52
-    doAssert drawInRange(b0, 2, 1, 96) == 48
+    doAssert caseInRange(b0, 0, 1, 96) == 38
+    doAssert caseInRange(b0, 1, 1, 96) == 52
+    doAssert caseInRange(b0, 2, 1, 96) == 48
     let b1 = d.nextBytes()
-    doAssert b1 != b0, "gemm draws must differ"
-    doAssert drawInRange(b1, 0, 1, 96) == 53
-    doAssert drawInRange(b1, 1, 1, 96) == 35
-    doAssert drawInRange(b1, 2, 1, 96) == 77
+    doAssert b1 != b0, "gemm cases must differ"
+    doAssert caseInRange(b1, 0, 1, 96) == 53
+    doAssert caseInRange(b1, 1, 1, 96) == 35
+    doAssert caseInRange(b1, 2, 1, 96) == 77
   block rmsnormPins:
-    var d = initShapeDraws("rmsnorm")
+    var d = initShapeCases("rmsnorm")
     let b0 = d.nextBytes()
     doAssert b0[0] == 0x4a'u8 and b0[1] == 0x8f'u8,
       "rmsnorm:0 digest bytes changed"
-    doAssert drawInRange(b0, 0, 1, 64) == 11
-    doAssert drawInRange(b0, 1, 1, 128) == 16
+    doAssert caseInRange(b0, 0, 1, 64) == 11
+    doAssert caseInRange(b0, 1, 1, 128) == 16
     let b1 = d.nextBytes()
-    doAssert drawInRange(b1, 0, 1, 64) == 48
-    doAssert drawInRange(b1, 1, 1, 128) == 44
+    doAssert caseInRange(b1, 0, 1, 64) == 48
+    doAssert caseInRange(b1, 1, 1, 128) == 44
   block raggedPins:
-    var d = initShapeDraws("ragged")
+    var d = initShapeCases("ragged")
     let b0 = d.nextBytes()
     doAssert b0[0] == 0xa8'u8 and b0[1] == 0x4a'u8 and b0[2] == 0x5b'u8,
       "ragged:0 digest bytes changed"
-    doAssert drawInRange(b0, 0, 1, 96) == 73
-    doAssert drawInRange(b0, 1, 1, 96) == 75
-    doAssert drawInRange(b0, 2, 1, 96) == 92
+    doAssert caseInRange(b0, 0, 1, 96) == 73
+    doAssert caseInRange(b0, 1, 1, 96) == 75
+    doAssert caseInRange(b0, 2, 1, 96) == 92
     # The ragged test's per-row K_eff stream consumes one digest per 20 rows
-    # after the shape draw, so the second shape draw is the 6th digest
-    # (b0 + 4 kEff digests for the 73-row draw + the draw itself).
+    # after the shape case, so the second shape case is the 6th digest
+    # (b0 + 4 kEff digests for the 73-row case + the case itself).
     var b1: array[20, uint8]
     for i in 0 ..< 5:
       b1 = d.nextBytes()
-    doAssert drawInRange(b1, 0, 1, 96) == 47,
-      "ragged second shape draw changed"
-    doAssert drawInRange(b1, 1, 1, 96) == 9
-    doAssert drawInRange(b1, 2, 1, 96) == 48
+    doAssert caseInRange(b1, 0, 1, 96) == 47,
+      "ragged second shape case changed"
+    doAssert caseInRange(b1, 1, 1, 96) == 9
+    doAssert caseInRange(b1, 2, 1, 96) == 48
   block attnPins:
-    var d = initShapeDraws("attn")
+    var d = initShapeCases("attn")
     let b0 = d.nextBytes()
     doAssert b0[0] == 0x28'u8 and b0[1] == 0x56'u8 and b0[4] == 0x5e'u8,
       "attn:0 digest bytes changed"
-    doAssert drawInRange(b0, 0, 1, 2) == 1
-    doAssert drawInRange(b0, 1, 1, 2) == 1
-    doAssert 8 * drawInRange(b0, 4, 1, 12) == 88
+    doAssert caseInRange(b0, 0, 1, 2) == 1
+    doAssert caseInRange(b0, 1, 1, 2) == 1
+    doAssert 8 * caseInRange(b0, 4, 1, 12) == 88
     let b1 = d.nextBytes()
-    doAssert 8 * drawInRange(b1, 4, 1, 12) == 24,
+    doAssert 8 * caseInRange(b1, 4, 1, 12) == 24,
       "attn:1 KV dimension changed"
     let b2 = d.nextBytes()
-    doAssert 8 * drawInRange(b2, 4, 1, 12) == 16,
+    doAssert 8 * caseInRange(b2, 4, 1, 12) == 16,
       "attn:2 KV dimension changed"
-    doAssert drawInRange(b2, 0, 1, 2) == 1 and drawInRange(b2, 1, 1, 2) == 2,
-      "attn:2 batch/head draws changed"
+    doAssert caseInRange(b2, 0, 1, 2) == 1 and caseInRange(b2, 1, 1, 2) == 2,
+      "attn:2 batch/head cases changed"
 when isMainModule:
-  checkDrawPins()
+  checkCasePins()

--- a/workspace/positron/src/kernels/ceramic/exl3_kvquant.nim
+++ b/workspace/positron/src/kernels/ceramic/exl3_kvquant.nim
@@ -1,0 +1,496 @@
+## Tattletale
+## Copyright (c) 2026 Mamy André-Ratsimbazafy
+## Licensed and distributed under either of
+##   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+##   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+## at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+# ############################################################
+#
+#     Paged KV-cache quant/dequant (exl3_kvquant): Tile API port
+#
+# ############################################################
+
+## The paged KV-cache quant/dequant kernels on the ceramic Tile API,
+## the tile-program form of the old ThunderMittens `tm_exl3_kvquant_fp16.nim`
+## + `common/tm_exl3_kvquant.nim` (the frozen kernel contract): the exllamav3 `cache/q_cache_kernels.cuh`
+## mechanism for bits {2, 4, 8} × {linear, LMCubic}: quant
+## (fp16 K/V rows → packed planes + fp16 absmax scales) and dequant
+## (planes → fp16 rows). The kernels are opt-in (the production cache stays plain fp16, covered by `paged_attn_fwd`).
+## This module proves the mechanism bit-exact, not that production uses it.
+##
+## Numeric contract (fixed formula-by-formula from q_cache_kernels.cuh): a token's row is quantized in groups of 32
+## CONSECUTIVE values, each group rotated by the H32 Hadamard
+## (the in-register H4 over the lane's 4 consecutive values, then the H8
+## over the 8-lane subgroup with shuffle stages at lane xor 1/2/4 and the exact ±1 sign multiply),
+## scaled by 1/sqrt(32), normalized by the group's absmax + 1e-10
+## (stored as one fp16 per group, RNE), and quantized to `bits` with either
+## the linear midpoint grid or the LMCubic compander. The packed representation is the CUDA
+## bit-plane layout: value j of a group occupies bits
+## [j·bits, (j+1)·bits) of the group's `bits` uint32 words (one plane for bits {2,4,8}).
+## The dequant is the mirror (unpack, dequantize, rotate back, fp16 RNE store).
+## The quant is LOSSY by design: the round-trip error is reported per bits,
+## never asserted ≤ 1 ulp.
+##
+## The transcendental behavior (measured): MSL `sqrt`/`floor`/`fma`
+## are bit-exact vs host libm on the finite-normal domain. MSL has NO
+## `cbrt`, so the LMCubic encode uses `cbrtDefined`, a defined fp32
+## cube root (exponent ladder + degree-4 Chebyshev seed + 2 Newton iterations)
+## computed identically by the kernel and the host test's reference.
+## The group scale reduce is exact fp32 max (order-independent),
+## and the fp16 scale is written by the subgroup's lane-0.
+##
+## Paged layout (matching `paged_attn_fwd`): the K/V slabs are the layer-major pool
+## (num_pages, num_layers, PAGE_SIZE, token_dim) fp16 with row stride
+## `token_dim = kv_heads·head_dim` (head-dim contiguous). The block table
+## is the dense (num_seqs, max_pages) int32 table with the -1 padding
+## convention, and `cache_seqlens` (num_seqs) marks the cached prefix per seq.
+## PAGE_SIZE is the static 256
+## (the exllamav3 CQ_PAGE_SIZE and the paged slab contract), so the page math is shift/mask:
+## zero div/mod in the kernel body.
+## A token's physical position in the layer-major pool:
+## `pageId·(num_layers·PAGE_SIZE) + layer·PAGE_SIZE + (tokenIdx and 255)`.
+## The packed planes/scales buffers follow the same layer-major physical addressing:
+## `q_words_total = num_pages·num_layers·PAGE_SIZE·groups·bits`
+## spans the whole pool. A token's quantized row is groups_per_token·bits uint32 words
+## (groups of 32 consecutive values along the full token row, the exllamav3 token_dim grouping)
+## plus groups_per_token fp16 scales.
+##
+## Grid and modes. Both kernels run one group-block (4 groups = 128 values = one warp's span) per threadgroup, on the grid
+## (groups_per_token div 4, tokens, num_seqs): x = group-block,
+## y = token, z = seq.
+## The quant kernel follows the exllamav3 update semantics: the quantized token
+## is at logical position `y + cache_seqlens[z]` (the rows appended beyond the cached prefix).
+## The dequant kernel covers the cached rows [0, cache_seqlens[z]) at logical position y
+## and writes the fp16 rows back to the physical positions, the round-trip path.
+##
+## Binding 0 (the engine reads back only binding 0). The quant kernel
+## packs ALL four outputs into the uint32 output buffer: [K words | V words | K scales | V scales].
+## The scale slots carry the f16 bit pattern in bits [0, 16). The test slices the regions, and the K-word total
+## `q_words_total` and the derived scale total `q_words_total shr log2(bits)` locate them.
+## The dequant kernel packs the two fp16 row streams into the uint16
+## output buffer: [K rows | V rows], the V half at `out_total` elements.
+## The kernel signatures carry the buffer bindings in the established
+## order: outBuf FIRST, then the inputs, then the runtime scalars.
+## `bits`/`compander` are STATIC (the per-bits/per-compander instantiations),
+## `pageSize` and `D` static with D fixed to 128 (the head dim).
+##
+## Tile-program note. The group-block is a per-lane 4-value chunk
+## (lane l owns values 4·l..4·l+3 of the 128-span), NOT an mma
+## fragment layout, so the loads/stores are the per-lane global accesses
+## of the paged slab contract (the `dequantTrellis` precedent in `exl3_ops`):
+## the ops own the lane machinery (H4/H8 shuffles, the subgroup scale reduce, the in-register plane combine),
+## and the kernel body sees no lane bit, no shuffle, no packing word. There is no shared memory
+## (the CUDA sh_pack staging has no MSL equivalent in `{.device.}` procs).
+##
+## Known production gaps (documented, not fixed):
+## - token_dim must be a 128-multiple with groups_per_token a 4-multiple
+##   (grid.x covers whole group-blocks, so partial spans are out of contract).
+##   The test's kv_heads sets divide evenly.
+## - Compander `a` is runtime (0.65 production). The derived LMCubic
+##   constants are recomputed per block in fp32 (the CUDA constructor order).
+
+import workspace/crucible
+import workspace/ceramic
+
+# ═════════════════════════════════════════════════════════════════════
+#  Device math builtins (module-local forwards to the MSL natives)
+#  ═════════════════════════════════════════════════════════════════════
+
+proc fma(x, y, z: float32): float32 {.builtin.} = discard
+  ## The IEEE fused multiply-add `x·y + z` with one rounding:
+  ## the `{.builtin.}` pragma forwards the plain name to the backend, and MSL
+  ## has `fma` natively (bit-exact vs host fmaf on the finite-normal domain).
+
+proc floor(x: float32): float32 {.builtin.} = discard
+  ## Device-side `floor`, forwarded to MSL's native `floor`
+  ## (bit-identical to host `floorf`).
+
+proc sqrt(x: float32): float32 {.builtin.} = discard
+  ## Device-side `sqrt`, forwarded to MSL's native `sqrt`
+  ## (correctly rounded, bit-identical to host `sqrtf` on the finite-normal domain).
+
+proc fabs(x: float32): float32 {.builtin.} = discard
+  ## Device-side `abs`, forwarded to MSL's native `fabs`. The
+  ## distinct name avoids the stdlib float `abs` overload (whose
+  ## generic body carries a `when nimvm` that crucible cannot lower).
+
+proc fmax(a, b: float32): float32 {.builtin.} = discard
+  ## Device-side `max`, forwarded to MSL's native `fmax`. Same
+  ## rationale as `fabs`. The values here are never NaN, so the MSL
+  ## fmax is bit-identical to the CUDA fmaxf the old kernel used.
+
+# ═════════════════════════════════════════════════════════════════════
+#  The H32 rotation: the frozen had_4_inreg / had_8_subgroup pair
+#  ═════════════════════════════════════════════════════════════════════
+
+proc had4InReg(v: var array[4, float32]) {.device.} =
+  ## The H4 butterfly over the lane's 4 consecutive values, in place:
+  ## the two pairwise stages (s0 = v0+v1, d0 = v0−v1, s1 = v2+v3,
+  ## d1 = v2−v3, then the two sums), the q_cache_kernels.cuh
+  ## `had_4_inreg` arithmetic in fp32.
+  let s0 = v[0] + v[1]
+  let d0 = v[0] - v[1]
+  let s1 = v[2] + v[3]
+  let d1 = v[2] - v[3]
+  v[0] = s0 + s1
+  v[1] = d0 + d1
+  v[2] = s0 - s1
+  v[3] = d0 - d1
+
+proc had8Subgroup(v: var array[4, float32]; lane: uint32) {.device.} =
+  ## The H8 butterfly over the 8-lane subgroup, in place on the lane's
+  ## 4 values: three shuffle stages at deltas 1/2/4 (lane xor delta,
+  ## which stays inside the subgroup). The lane with the stage bit set
+  ## negates its own value by an exact ±1 multiply (the CUDA sign-mask
+  ## trick in arithmetic) before adding the partner's, the pairwise
+  ## (a+b, a−b) with one rounding each, the q_cache_kernels.cuh
+  ## `had_8_subgroup` sequence. The shuffle reads the partner's
+  ## PRE-stage value (SIMT lockstep: the shuffle instruction runs
+  ## before any lane's write).
+  let sgn1 = 1.0'f32 - 2.0'f32 * float32(lane and 1'u32)
+  for s in 0'i32 ..< 4:
+    v[s] = v[s] * sgn1 + simdShuffle(v[s], lane xor 1'u32)
+  let sgn2 = 1.0'f32 - 2.0'f32 * float32((lane and 2'u32) shr 1)
+  for s in 0'i32 ..< 4:
+    v[s] = v[s] * sgn2 + simdShuffle(v[s], lane xor 2'u32)
+  let sgn4 = 1.0'f32 - 2.0'f32 * float32((lane and 4'u32) shr 2)
+  for s in 0'i32 ..< 4:
+    v[s] = v[s] * sgn4 + simdShuffle(v[s], lane xor 4'u32)
+
+# ═════════════════════════════════════════════════════════════════════
+#  The defined cbrt: the LMCubic encode's cube root (MSL has no cbrt)
+#  ═════════════════════════════════════════════════════════════════════
+
+const
+  CbC0 = 1.1374176813308194'f32
+  CbC1 = 0.1292479927845696'f32
+  CbC2 = -0.0073754847563900945'f32
+  CbC3 = 0.000702055045675154'f32
+  CbC4 = -7.892353387775054e-05'f32
+  CbCbrt2 = 1.2599210498948732'f32
+  CbCbrt4 = 1.5874010519681994'f32
+  CbThird = 0.3333333432674408'f32
+  CbInv3 = 0.3333333432674408'f32
+
+proc cbrtSeed(m: float32): float32 {.device.} =
+  ## The degree-4 Chebyshev seed for cbrt(m), m in [1, 2): Clenshaw on u = 2m − 3,
+  ## max relative error ~1.3e-5 (measured): the Newton iterations square it away.
+  let u = 2.0'f32 * m - 3.0'f32
+  var b1 = 0.0'f32
+  var b2 = 0.0'f32
+  var b = 2.0'f32 * u * b1 - b2 + CbC4
+  b2 = b1
+  b1 = b
+  b = 2.0'f32 * u * b1 - b2 + CbC3
+  b2 = b1
+  b1 = b
+  b = 2.0'f32 * u * b1 - b2 + CbC2
+  b2 = b1
+  b1 = b
+  b = 2.0'f32 * u * b1 - b2 + CbC1
+  b2 = b1
+  b1 = b
+  u * b1 - b2 + CbC0
+
+proc cbrtDefined(x: float32): float32 {.device.} =
+  ## Defined fp32 cube root, the shared stand-in for the CUDA `cbrtf`
+  ## (MSL has no cbrt): exponent split x = m·2^e with m in [1, 2) via an exact
+  ## power-of-two ladder, the seed cbrt(m)·2^(r/3) with r = e mod 3 folded
+  ## through the cbrt(2)/cbrt(4) constants, two Newton iterations
+  ## `(2y + x/y²)/3` on the full value. ~2 fp32 ulp vs the correctly rounded
+  ## cbrtf (measured). The host reference runs the same fp32 sequence
+  ## (importc floorf/exp2f mirrors), so the bit-exact test is host-replicable.
+  ## The ascending ladder is a while loop (≤ 1 iteration in the LMCubic domain, |input| in [0.49, 2.94], ≤ 126 in general).
+  ## Subnormal inputs behave as the device's flush-to-zero, never hit
+  ## by the quantizer (the delta operand is always ≥ p3_cub ≈ 0.237).
+  let sgn = (if x < 0.0'f32: -1.0'f32 else: 1.0'f32)
+  let ax = (if x < 0.0'f32: -x else: x)
+  var e = 0'i32
+  var m = ax
+  if m >= 1.8446744073709552e19'f32:
+    m = m * 5.421010862427522e-20'f32
+    e += 64
+  if m >= 4294967296.0'f32:
+    m = m * 2.3283064365386963e-10'f32
+    e += 32
+  if m >= 65536.0'f32:
+    m = m * 1.52587890625e-05'f32
+    e += 16
+  if m >= 256.0'f32:
+    m = m * 0.00390625'f32
+    e += 8
+  if m >= 16.0'f32:
+    m = m * 0.0625'f32
+    e += 4
+  if m >= 4.0'f32:
+    m = m * 0.25'f32
+    e += 2
+  if m >= 2.0'f32:
+    m = m * 0.5'f32
+    e += 1
+  while m < 1.0'f32:
+    m = m * 2.0'f32
+    e -= 1
+  let q = int32(floor(float32(e) * CbInv3))
+  let r = e - 3 * q
+  var y = cbrtSeed(m)
+  if r == 1:
+    y = y * CbCbrt2
+  else:
+    if r == 2:
+      y = y * CbCbrt4
+  y = y * exp2(float32(q))
+  y = (2.0'f32 * y + ax / (y * y)) * CbThird
+  y = (2.0'f32 * y + ax / (y * y)) * CbThird
+  (if x == 0.0'f32: x else: sgn * y)
+
+# ═════════════════════════════════════════════════════════════════════
+#  The LMCubic compander: the lmq.cuh forward + inverse (a = 0.65)
+#  ═════════════════════════════════════════════════════════════════════
+
+proc lmCubicEncode(x: float32; compandA: float32; bits: static int): uint32 {.device.} =
+  ## The LMCubic forward (lmq.cuh `lm_cubic_encode` / the LMCubic
+  ## template `encode`): Cardano's formula for the depressed cubic
+  ## b·t³ + a·t = x: q_half = x·inv_b·0.5, delta = fma(q_half, q_half,
+  ## p3_cub), t = cbrt(q_half + s) + cbrt(q_half − s) with s = sqrt(delta),
+  ## idx = floor(fma(t, half_n, half_n)) clamped to [0, 2^bits − 1].
+  ## `compandA` is the runtime `a` (0.65). The derived constants b = 1−a,
+  ## inv_b, p3 = a·inv_b/3, p3_cub are computed in fp32 exactly as the CUDA
+  ## constructor does.
+  let b = 1.0'f32 - compandA
+  let invB = 1.0'f32 / b
+  let p3 = compandA * invB * (1.0'f32 / 3.0'f32)
+  let p3cub = p3 * p3 * p3
+  let qHalf = x * invB * 0.5'f32
+  let delta = fma(qHalf, qHalf, p3cub)
+  let sq = sqrt(delta)
+  let t = cbrtDefined(qHalf + sq) + cbrtDefined(qHalf - sq)
+  let idx = int32(floor(fma(t, float32(1 shl (bits - 1)), float32(1 shl (bits - 1)))))
+  let qmax = (1 shl bits) - 1
+  uint32(if idx < 0: 0 else: (if idx > qmax: qmax else: idx))
+
+proc lmCubicDecode(idx: uint32; compandA: float32; bits: static int): float32 {.device.} =
+  ## The LMCubic inverse (lmq.cuh `lm_cubic_decode` / `decode`):
+  ## t = fma(2·idx + 1, 1/N, −1), t2 = t·t, returns
+  ## t·fma(t2, b, a), the fp32 sequence in the CUDA order.
+  let b = 1.0'f32 - compandA
+  let invN = 1.0'f32 / float32(1 shl bits)
+  let t = fma(2.0'f32 * float32(idx) + 1.0'f32, invN, -1.0'f32)
+  let t2 = t * t
+  t * fma(t2, b, compandA)
+
+# ═════════════════════════════════════════════════════════════════════
+#  kvQuantBlock: one group-block (4 groups = 128 values) quantized
+#  ═════════════════════════════════════════════════════════════════════
+
+proc kvQuantBlock(
+    outBuf: ptr UncheckedArray[uint32],   # packed words + fp16 scale bits (low 16)
+    inBuf: ptr UncheckedArray[uint16],    # the fp16 rows
+    inBase, wordBase, scaleBase: int32,   # per-token bases
+    bits: static int, compander: static int, compandA: float32) {.device.} =
+  ## Quantizes the 128-value span at `inBase` (4 groups of 32, the token's values [32·g0, 32·g0 + 128))
+  ## into the group-block's packed words at `wordBase` (groups·bits uint32 per token)
+  ## and the fp16 group scales at `scaleBase` (one u32 slot per group, the f16 bits in [0, 16), the binding-0 packing).
+  ## Per lane: the 4 consecutive values at 4·lane (the warp lane mapping),
+  ## H4+H8, 1/sqrt(32), group absmax + 1e-10 reduced over the 8-lane subgroup,
+  ## the linear midpoint-grid or LMCubic quantize, and the in-register plane combine
+  ## with the per-bits word write.
+  ## `bits` ∈ {2, 4, 8} (one plane each), `compander` 0 = linear / 1 = LMCubic.
+  static: doAssert bits in {2, 4, 8}
+  static: doAssert compander in {0, 1}
+  let lane = uint32(thread_index_in_threadgroup)
+  let l = int32(lane)
+  let sg = l shr 3
+  let sl = l and 7
+  var v: array[4, float32]
+  for r in 0'i32 ..< 4:
+    v[r] = inBuf[inBase + 4 * l + r].asFp16().to(float32)
+  had4InReg(v)
+  had8Subgroup(v, lane)
+  for r in 0'i32 ..< 4:
+    v[r] = v[r] * 0.17677669529663688110'f32
+  var s = fabs(v[0])
+  for r in 1'i32 ..< 4:
+    s = fmax(s, fabs(v[r]))
+  s = s + 1e-10'f32
+  s = fmax(s, simdShuffle(s, lane xor 1'u32))
+  s = fmax(s, simdShuffle(s, lane xor 2'u32))
+  s = fmax(s, simdShuffle(s, lane xor 4'u32))
+  let invS = 1.0'f32 / s
+  var q: array[4, uint32]
+  when compander == 0:
+    let mf = float32(1 shl (bits - 1))
+    let qmax = (1 shl bits) - 1
+    for r in 0'i32 ..< 4:
+      let t = fma(v[r] * invS, mf, mf)
+      let qi = int32(floor(t))
+      q[r] = uint32(if qi < 0: 0 else: (if qi > qmax: qmax else: qi))
+  else:
+    for r in 0'i32 ..< 4:
+      q[r] = lmCubicEncode(v[r] * invS, compandA, bits)
+  when bits == 8:
+    let field = q[0] or (q[1] shl 8) or (q[2] shl 16) or (q[3] shl 24)
+    outBuf[wordBase + sg * 8 + sl] = field
+  elif bits == 4:
+    let field = q[0] or (q[1] shl 4) or (q[2] shl 8) or (q[3] shl 12)
+    var f = field
+    let pv = simdShuffle(f, lane xor 1'u32)
+    if (sl and 1) == 0:
+      f = f or (pv shl 16)
+      outBuf[wordBase + sg * 4 + (sl shr 1)] = f
+  else:
+    let field = q[0] or (q[1] shl 2) or (q[2] shl 4) or (q[3] shl 6)
+    var f = field
+    let pv1 = simdShuffle(f, lane xor 1'u32)
+    if (sl and 1) == 0:
+      f = f or (pv1 shl 8)
+    let pv2 = simdShuffle(f, lane xor 2'u32)
+    if (sl and 2) == 0:
+      f = f or (pv2 shl 16)
+    if (sl and 3) == 0:
+      outBuf[wordBase + sg * 2 + (sl shr 2)] = f
+  if sl == 0:
+    outBuf[scaleBase + sg] = uint32(s.to(float16).asU16())
+
+# ═════════════════════════════════════════════════════════════════════
+#  kvDequantBlock: one group-block (4 groups = 128 values) dequantized
+#  ═════════════════════════════════════════════════════════════════════
+
+proc kvDequantBlock(
+    outBuf: ptr UncheckedArray[uint16],   # the fp16 rows
+    inWords: ptr UncheckedArray[uint32],  # the packed words
+    inScales: ptr UncheckedArray[uint16], # the fp16 group scales
+    wordBase, scaleBase, outBase: int32,
+    bits: static int, compander: static int, compandA: float32) {.device.} =
+  ## Dequantizes one group-block back to fp16 rows: the lane's 4 codes
+  ## unpacked from the group's words (single global reads, the CUDA
+  ## two-word funnel window, no cross-lane traffic for the payload),
+  ## the fp16 scale × 1/sqrt(32), the linear / LMCubic inverse, the H4+H8 rotate back (same order as the quant),
+  ## and the fp16 RNE store at `outBase` + 4·lane. `bits` ∈ {2, 4, 8},
+  ## `compander` 0 = linear / 1 = LMCubic.
+  static: doAssert bits in {2, 4, 8}
+  static: doAssert compander in {0, 1}
+  let lane = uint32(thread_index_in_threadgroup)
+  let l = int32(lane)
+  let sg = l shr 3
+  let sl = l and 7
+  var q: array[4, uint32]
+  when bits == 8:
+    let w = inWords[wordBase + sg * 8 + sl]
+    q[0] = w and 0xFF'u32
+    q[1] = (w shr 8) and 0xFF'u32
+    q[2] = (w shr 16) and 0xFF'u32
+    q[3] = (w shr 24) and 0xFF'u32
+  elif bits == 4:
+    let w = inWords[wordBase + sg * 4 + (sl shr 1)] shr (16 * (sl and 1))
+    q[0] = w and 0xF'u32
+    q[1] = (w shr 4) and 0xF'u32
+    q[2] = (w shr 8) and 0xF'u32
+    q[3] = (w shr 12) and 0xF'u32
+  else:
+    let w = inWords[wordBase + sg * 2 + (sl shr 2)] shr (8 * (sl and 3))
+    q[0] = w and 0x3'u32
+    q[1] = (w shr 2) and 0x3'u32
+    q[2] = (w shr 4) and 0x3'u32
+    q[3] = (w shr 6) and 0x3'u32
+  let s = inScales[scaleBase + sg].asFp16().to(float32) *
+          0.17677669529663688110'f32
+  var v: array[4, float32]
+  when compander == 0:
+    let mh = float32(1 shl (bits - 1)) - 0.5'f32
+    let sm = s * (1.0'f32 / float32(1 shl (bits - 1)))
+    for r in 0'i32 ..< 4:
+      v[r] = (float32(q[r]) - mh) * sm
+  else:
+    for r in 0'i32 ..< 4:
+      v[r] = lmCubicDecode(q[r], compandA, bits) * s
+  had4InReg(v)
+  had8Subgroup(v, lane)
+  for r in 0'i32 ..< 4:
+    outBuf[outBase + 4 * l + r] = v[r].to(float16).asU16()
+
+# ═════════════════════════════════════════════════════════════════════
+#  The kernels
+#  ═════════════════════════════════════════════════════════════════════
+
+proc kv_quant_fwd*(
+    outBuf: ptr UncheckedArray[uint32],   # binding 0: [K words | V words | K scales | V scales]
+    kIn, vIn: ptr UncheckedArray[uint16], # (num_pages, num_layers, PAGE_SIZE, token_dim) fp16 rows
+    block_table: ptr UncheckedArray[int32],   # (num_seqs, max_pages) dense, -1 padding
+    cache_seqlens: ptr UncheckedArray[int32], # (num_seqs)
+    num_seqs, max_pages, token_dim, groups_per_token, q_words_total,
+    num_layers, layer: int32,
+    compand_a: float32,
+    bits: static int, compander: static int,
+    pageSize: static int, D: static int) {.device.} =
+  ## Quantizes the appended K/V rows (one group-block per threadgroup)
+  ## into the packed planes + fp16 scales, the exllamav3 paged quant
+  ## semantics on the layer-major slab layout. The logical token
+  ## `y + cache_seqlens[z]` maps through the block table and the `layer`
+  ## scalar to the physical layer-major position. The group-block's
+  ## 128-value span is quantized by `kvQuantBlock` into the binding-0 regions
+  ## (see the module doc). `bits` ∈ {2, 4, 8}, `compander` 0 = linear / 1 = LMCubic, `pageSize` = 256, D = 128.
+  static: doAssert bits in {2, 4, 8}
+  static: doAssert compander in {0, 1}
+  static: doAssert pageSize == 256
+  static: doAssert D == 128
+  let batch = int32(threadgroup_position_in_grid.z)
+  let token = int32(threadgroup_position_in_grid.y)
+  let gBlock = int32(threadgroup_position_in_grid.x)
+  let tokenIdx = token + cache_seqlens[batch]
+  let pageIdx = tokenIdx shr 8
+  let pageId = block_table[batch * max_pages + pageIdx]
+  let tokenPos = pageId * num_layers * 256 + layer * 256 + (tokenIdx and 255)
+  let inBase = tokenPos * token_dim + gBlock * 128
+  let wordBase = tokenPos * (groups_per_token * bits) + gBlock * (4 * bits)
+  let scaleBase = tokenPos * groups_per_token + gBlock * 4
+  when bits == 2:
+    let sTotal = q_words_total shr 1
+  elif bits == 4:
+    let sTotal = q_words_total shr 2
+  else:
+    let sTotal = q_words_total shr 3
+  kvQuantBlock(outBuf, kIn, inBase, wordBase, scaleBase + 2 * q_words_total,
+               bits, compander, compand_a)
+  kvQuantBlock(outBuf, vIn, inBase, wordBase + q_words_total,
+               scaleBase + 2 * q_words_total + sTotal,
+               bits, compander, compand_a)
+
+proc kv_dequant_fwd*(
+    outBuf: ptr UncheckedArray[uint16],   # binding 0: [K rows | V rows] fp16
+    qK, qV: ptr UncheckedArray[uint32],   # the packed planes (num_pages, num_layers, PAGE_SIZE, groups·bits)
+    sK, sV: ptr UncheckedArray[uint16],   # the fp16 scales (num_pages, num_layers, PAGE_SIZE, groups)
+    block_table: ptr UncheckedArray[int32],   # (num_seqs, max_pages) dense, -1 padding
+    cache_seqlens: ptr UncheckedArray[int32], # (num_seqs)
+    num_seqs, max_pages, token_dim, groups_per_token, out_total,
+    num_layers, layer: int32,
+    compand_a: float32,
+    bits: static int, compander: static int,
+    pageSize: static int, D: static int) {.device.} =
+  ## Dequantizes the cached K/V rows (one group-block per threadgroup)
+  ## from the packed planes + fp16 scales back to fp16 rows, the round-trip mirror
+  ## of `kv_quant_fwd`. The logical token `y` (the seq's cached rows [0, cache_seqlens[z]))
+  ## maps through the block table and the `layer` scalar to the physical
+  ## layer-major position. `kvDequantBlock` writes the K row stream to [0, out_total)
+  ## and the V stream to [out_total, 2·out_total) of the binding-0 buffer.
+  static: doAssert bits in {2, 4, 8}
+  static: doAssert compander in {0, 1}
+  static: doAssert pageSize == 256
+  static: doAssert D == 128
+  let batch = int32(threadgroup_position_in_grid.z)
+  let token = int32(threadgroup_position_in_grid.y)
+  let gBlock = int32(threadgroup_position_in_grid.x)
+  if token >= cache_seqlens[batch]:
+    return
+  let tokenIdx = token
+  let pageIdx = tokenIdx shr 8
+  let pageId = block_table[batch * max_pages + pageIdx]
+  let tokenPos = pageId * num_layers * 256 + layer * 256 + (tokenIdx and 255)
+  let outBase = tokenPos * token_dim + gBlock * 128
+  let wordBase = tokenPos * (groups_per_token * bits) + gBlock * (4 * bits)
+  let scaleBase = tokenPos * groups_per_token + gBlock * 4
+  kvDequantBlock(outBuf, qK, sK, wordBase, scaleBase, outBase,
+                 bits, compander, compand_a)
+  kvDequantBlock(outBuf, qV, sV, wordBase, scaleBase, outBase + out_total,
+                 bits, compander, compand_a)

--- a/workspace/positron/src/kernels/ceramic/exl3_kvquant.nim
+++ b/workspace/positron/src/kernels/ceramic/exl3_kvquant.nim
@@ -11,96 +11,97 @@
 #
 # ############################################################
 
-## The paged KV-cache quant/dequant kernels on the ceramic Tile API,
-## the tile-program form of the old ThunderMittens `tm_exl3_kvquant_fp16.nim`
-## + `common/tm_exl3_kvquant.nim` (the frozen kernel contract): the exllamav3 `cache/q_cache_kernels.cuh`
-## mechanism for bits {2, 4, 8} × {linear, LMCubic}: quant
-## (fp16 K/V rows → packed planes + fp16 absmax scales) and dequant
-## (planes → fp16 rows). The kernels are opt-in (the production cache stays plain fp16, covered by `paged_attn_fwd`).
-## This module proves the mechanism bit-exact, not that production uses it.
+## Paged KV-cache quant/dequant kernels on the ceramic Tile API,
+## a port of the exllamav3 `cache/q_cache_kernels.cuh` mechanism:
+## quant (fp16 K/V rows → packed planes + fp16 absmax scales)
+## and dequant (planes → fp16 rows), bits {2, 4, 8} × {linear, LMCubic}.
+## The kernels are opt-in (the production cache stays plain fp16).
 ##
-## Numeric contract (fixed formula-by-formula from q_cache_kernels.cuh): a token's row is quantized in groups of 32
-## CONSECUTIVE values, each group rotated by the H32 Hadamard
-## (the in-register H4 over the lane's 4 consecutive values, then the H8
-## over the 8-lane subgroup with shuffle stages at lane xor 1/2/4 and the exact ±1 sign multiply),
-## scaled by 1/sqrt(32), normalized by the group's absmax + 1e-10
-## (stored as one fp16 per group, RNE), and quantized to `bits` with either
-## the linear midpoint grid or the LMCubic compander. The packed representation is the CUDA
-## bit-plane layout: value j of a group occupies bits
-## [j·bits, (j+1)·bits) of the group's `bits` uint32 words (one plane for bits {2,4,8}).
-## The dequant is the mirror (unpack, dequantize, rotate back, fp16 RNE store).
-## The quant is LOSSY by design: the round-trip error is reported per bits,
-## never asserted ≤ 1 ulp.
+## Quant chain (one group-block = 128 values, 4 groups of 32):
 ##
-## The transcendental behavior (measured): MSL `sqrt`/`floor`/`fma`
-## are bit-exact vs host libm on the finite-normal domain. MSL has NO
-## `cbrt`, so the LMCubic encode uses `cbrtDefined`, a defined fp32
-## cube root (exponent ladder + degree-4 Chebyshev seed + 2 Newton iterations)
-## computed identically by the kernel and the host test's reference.
-## The group scale reduce is exact fp32 max (order-independent),
-## and the fp16 scale is written by the subgroup's lane-0.
+##   fp16 rows --> per-lane 4 values --> H4 in-reg --> H8 subgroup
+##     --> × 1/sqrt(32) --> ÷ (absmax + 1e-10)  (fp32 subgroup max)
+##     --> quantize: linear midpoint grid | LMCubic compander
+##     --> bit-plane combine
+##   out: packed uint32 words + fp16 group scales (RNE, lane-0)
 ##
-## Paged layout (matching `paged_attn_fwd`): the K/V slabs are the layer-major pool
-## (num_pages, num_layers, PAGE_SIZE, token_dim) fp16 with row stride
+## Dequant chain (the mirror):
+##
+##   packed words + fp16 scales --> unpack codes --> × 1/sqrt(32)
+##     --> linear grid | LMCubic inverse --> H4 in-reg --> H8 subgroup
+##     --> fp16 rows (RNE store)
+##
+## Frozen contract (from q_cache_kernels.cuh):
+##   - a token row is quantized in groups of 32 consecutive values
+##   - the H32 rotation is the H4 in-register over the lane's 4 values
+##     plus the H8 over the 8-lane subgroup (shuffle stages at lane
+##     xor 1/2/4, exact ±1 sign multiply)
+##   - the group scale is absmax + 1e-10 over the 32 values, one fp16
+##     per group (round-to-nearest-even), the fp32 reduce
+##     order-independent, written by the subgroup's lane-0
+##   - the quantizer is the linear midpoint grid or the LMCubic
+##     compander, both clamped to [0, 2^bits − 1]
+##   - the packed representation is the CUDA bit-plane layout: value j
+##     of a group occupies bits [j·bits, (j+1)·bits) of the group's
+##     uint32 words, one plane per bits {2, 4, 8}
+##   - the quant is LOSSY by design: round-trip error is reported per
+##     bits, never asserted ≤ 1 ulp
+##
+## Paged layout: the K/V slabs are the layer-major pool (num_pages,
+## num_layers, PAGE_SIZE, token_dim) fp16 with row stride
 ## `token_dim = kv_heads·head_dim` (head-dim contiguous). The block table
-## is the dense (num_seqs, max_pages) int32 table with the -1 padding
-## convention, and `cache_seqlens` (num_seqs) marks the cached prefix per seq.
-## PAGE_SIZE is the static 256
-## (the exllamav3 CQ_PAGE_SIZE and the paged slab contract), so the page math is shift/mask:
-## zero div/mod in the kernel body.
+## is the dense (num_seqs, max_pages) int32 table with -1 padding,
+## and `cache_seqlens` (num_seqs) marks the cached prefix per seq.
+## PAGE_SIZE is the static 256 (the exllamav3 CQ_PAGE_SIZE),
+## so the page math is shift/mask (zero div/mod in the kernel body).
 ## A token's physical position in the layer-major pool:
 ## `pageId·(num_layers·PAGE_SIZE) + layer·PAGE_SIZE + (tokenIdx and 255)`.
-## The packed planes/scales buffers follow the same layer-major physical addressing:
-## `q_words_total = num_pages·num_layers·PAGE_SIZE·groups·bits`
-## spans the whole pool. A token's quantized row is groups_per_token·bits uint32 words
-## (groups of 32 consecutive values along the full token row, the exllamav3 token_dim grouping)
-## plus groups_per_token fp16 scales.
-##
-## Grid and modes. Both kernels run one group-block (4 groups = 128 values = one warp's span) per threadgroup, on the grid
-## (groups_per_token div 4, tokens, num_seqs): x = group-block,
-## y = token, z = seq.
-## The quant kernel follows the exllamav3 update semantics: the quantized token
-## is at logical position `y + cache_seqlens[z]` (the rows appended beyond the cached prefix).
-## The dequant kernel covers the cached rows [0, cache_seqlens[z]) at logical position y
-## and writes the fp16 rows back to the physical positions, the round-trip path.
+## The packed planes/scales buffers follow the same layer-major
+## addressing: `q_words_total = num_pages·num_layers·PAGE_SIZE·groups·bits`
+## spans the whole pool. A token's quantized row:
+## groups_per_token·bits uint32 words (groups of 32 consecutive
+## values along the full token row) plus groups_per_token fp16 scales.
 ##
 ## Binding 0 (the engine reads back only binding 0). The quant kernel
-## packs ALL four outputs into the uint32 output buffer: [K words | V words | K scales | V scales].
-## The scale slots carry the f16 bit pattern in bits [0, 16). The test slices the regions, and the K-word total
-## `q_words_total` and the derived scale total `q_words_total shr log2(bits)` locate them.
-## The dequant kernel packs the two fp16 row streams into the uint16
-## output buffer: [K rows | V rows], the V half at `out_total` elements.
-## The kernel signatures carry the buffer bindings in the established
-## order: outBuf FIRST, then the inputs, then the runtime scalars.
-## `bits`/`compander` are STATIC (the per-bits/per-compander instantiations),
-## `pageSize` and `D` static with D fixed to 128 (the head dim).
+## packs all four outputs into the uint32 buffer:
+## [K words | V words | K scales | V scales], the scale slots carrying
+## the f16 bit pattern in bits [0, 16). The K-word total
+## `q_words_total` and the derived scale total
+## `q_words_total shr log2(bits)` locate the regions. The dequant
+## kernel packs the two fp16 row streams into the uint16 buffer:
+## [K rows | V rows], the V half at `out_total` elements. The kernel
+## signatures carry the buffer bindings in order: outBuf first,
+## then the inputs, then the runtime scalars.
+## `bits`/`compander` are STATIC (the per-bits/per-compander
+## instantiations). `pageSize` = 256 and `D` = 128, both static.
 ##
 ## Tile-program note. The group-block is a per-lane 4-value chunk
-## (lane l owns values 4·l..4·l+3 of the 128-span), NOT an mma
-## fragment layout, so the loads/stores are the per-lane global accesses
-## of the paged slab contract (the `dequantTrellis` precedent in `exl3_ops`):
-## the ops own the lane machinery (H4/H8 shuffles, the subgroup scale reduce, the in-register plane combine),
-## and the kernel body sees no lane bit, no shuffle, no packing word. There is no shared memory
-## (the CUDA sh_pack staging has no MSL equivalent in `{.device.}` procs).
+## (lane l owns values 4·l..4·l+3 of the 128-span), not an mma
+## fragment layout, so the loads/stores are per-lane global accesses.
+## The ops own the lane machinery (H4/H8 shuffles, the subgroup scale
+## reduce, the in-register plane combine), and the kernel body sees no
+## lane bit, no shuffle, no packing word. There is no shared memory
+## (the CUDA sh_pack staging has no `{.device.}` equivalent).
 ##
 ## Known production gaps (documented, not fixed):
-## - token_dim must be a 128-multiple with groups_per_token a 4-multiple
-##   (grid.x covers whole group-blocks, so partial spans are out of contract).
-##   The test's kv_heads sets divide evenly.
+## - token_dim: 128-multiple, groups_per_token: 4-multiple.
+##   Grid.x covers whole group-blocks only. Partial spans fall
+##   outside the contract.
 ## - Compander `a` is runtime (0.65 production). The derived LMCubic
-##   constants are recomputed per block in fp32 (the CUDA constructor order).
+##   constants are recomputed per block in fp32 (the CUDA constructor
+##   order).
 
 import workspace/crucible
 import workspace/ceramic
 
-# ═════════════════════════════════════════════════════════════════════
+# ════════════════════════════════════════
 #  Device math builtins (module-local forwards to the MSL natives)
-#  ═════════════════════════════════════════════════════════════════════
+# ════════════════════════════════════════
 
 proc fma(x, y, z: float32): float32 {.builtin.} = discard
-  ## The IEEE fused multiply-add `x·y + z` with one rounding:
-  ## the `{.builtin.}` pragma forwards the plain name to the backend, and MSL
-  ## has `fma` natively (bit-exact vs host fmaf on the finite-normal domain).
+  ## The IEEE fused multiply-add `x·y + z` with one rounding,
+  ## forwarded to the MSL (Metal Shading Language) native `fma`
+  ## (bit-exact vs host `fmaf` on the finite-normal domain).
 
 proc floor(x: float32): float32 {.builtin.} = discard
   ## Device-side `floor`, forwarded to MSL's native `floor`
@@ -118,17 +119,15 @@ proc fabs(x: float32): float32 {.builtin.} = discard
 proc fmax(a, b: float32): float32 {.builtin.} = discard
   ## Device-side `max`, forwarded to MSL's native `fmax`. Same
   ## rationale as `fabs`. The values here are never NaN, so the MSL
-  ## fmax is bit-identical to the CUDA fmaxf the old kernel used.
+  ## fmax is bit-identical to the CUDA fmaxf.
 
-# ═════════════════════════════════════════════════════════════════════
-#  The H32 rotation: the frozen had_4_inreg / had_8_subgroup pair
-#  ═════════════════════════════════════════════════════════════════════
+# ════════════════════════════════════════
+#  The H32 rotation: the had_4_inreg / had_8_subgroup pair (q_cache_kernels.cuh)
+# ════════════════════════════════════════
 
 proc had4InReg(v: var array[4, float32]) {.device.} =
   ## The H4 butterfly over the lane's 4 consecutive values, in place:
-  ## the two pairwise stages (s0 = v0+v1, d0 = v0−v1, s1 = v2+v3,
-  ## d1 = v2−v3, then the two sums), the q_cache_kernels.cuh
-  ## `had_4_inreg` arithmetic in fp32.
+  ## the q_cache_kernels.cuh `had_4_inreg` arithmetic in fp32.
   let s0 = v[0] + v[1]
   let d0 = v[0] - v[1]
   let s1 = v[2] + v[3]
@@ -143,8 +142,7 @@ proc had8Subgroup(v: var array[4, float32]; lane: uint32) {.device.} =
   ## 4 values: three shuffle stages at deltas 1/2/4 (lane xor delta,
   ## which stays inside the subgroup). The lane with the stage bit set
   ## negates its own value by an exact ±1 multiply (the CUDA sign-mask
-  ## trick in arithmetic) before adding the partner's, the pairwise
-  ## (a+b, a−b) with one rounding each, the q_cache_kernels.cuh
+  ## trick) before adding the partner's, the q_cache_kernels.cuh
   ## `had_8_subgroup` sequence. The shuffle reads the partner's
   ## PRE-stage value (SIMT lockstep: the shuffle instruction runs
   ## before any lane's write).
@@ -158,9 +156,9 @@ proc had8Subgroup(v: var array[4, float32]; lane: uint32) {.device.} =
   for s in 0'i32 ..< 4:
     v[s] = v[s] * sgn4 + simdShuffle(v[s], lane xor 4'u32)
 
-# ═════════════════════════════════════════════════════════════════════
+# ════════════════════════════════════════
 #  The defined cbrt: the LMCubic encode's cube root (MSL has no cbrt)
-#  ═════════════════════════════════════════════════════════════════════
+# ════════════════════════════════════════
 
 const
   CbC0 = 1.1374176813308194'f32
@@ -174,8 +172,9 @@ const
   CbInv3 = 0.3333333432674408'f32
 
 proc cbrtSeed(m: float32): float32 {.device.} =
-  ## The degree-4 Chebyshev seed for cbrt(m), m in [1, 2): Clenshaw on u = 2m − 3,
-  ## max relative error ~1.3e-5 (measured): the Newton iterations square it away.
+  ## The degree-4 Chebyshev seed for cbrt(m), m in [1, 2): Clenshaw
+  ## on u = 2m − 3, max relative error ~1.3e-5 (measured), which the
+  ## two Newton iterations reduce to the final accuracy.
   let u = 2.0'f32 * m - 3.0'f32
   var b1 = 0.0'f32
   var b2 = 0.0'f32
@@ -199,11 +198,11 @@ proc cbrtDefined(x: float32): float32 {.device.} =
   ## power-of-two ladder, the seed cbrt(m)·2^(r/3) with r = e mod 3 folded
   ## through the cbrt(2)/cbrt(4) constants, two Newton iterations
   ## `(2y + x/y²)/3` on the full value. ~2 fp32 ulp vs the correctly rounded
-  ## cbrtf (measured). The host reference runs the same fp32 sequence
-  ## (importc floorf/exp2f mirrors), so the bit-exact test is host-replicable.
-  ## The ascending ladder is a while loop (≤ 1 iteration in the LMCubic domain, |input| in [0.49, 2.94], ≤ 126 in general).
-  ## Subnormal inputs behave as the device's flush-to-zero, never hit
-  ## by the quantizer (the delta operand is always ≥ p3_cub ≈ 0.237).
+  ## cbrtf (measured).
+  ## The ascending ladder is a while loop (≤ 4 iterations in the
+  ## LMCubic domain, |input| ≥ ~0.08, ≤ 126 in general). Subnormal
+  ## inputs never reach the ladder (the LMCubic inputs are
+  ## qHalf ± sqrt(qHalf² + p3_cub), |input| ≥ ~0.08).
   let sgn = (if x < 0.0'f32: -1.0'f32 else: 1.0'f32)
   let ax = (if x < 0.0'f32: -x else: x)
   var e = 0'i32
@@ -245,19 +244,17 @@ proc cbrtDefined(x: float32): float32 {.device.} =
   y = (2.0'f32 * y + ax / (y * y)) * CbThird
   (if x == 0.0'f32: x else: sgn * y)
 
-# ═════════════════════════════════════════════════════════════════════
+# ════════════════════════════════════════
 #  The LMCubic compander: the lmq.cuh forward + inverse (a = 0.65)
-#  ═════════════════════════════════════════════════════════════════════
+# ════════════════════════════════════════
 
 proc lmCubicEncode(x: float32; compandA: float32; bits: static int): uint32 {.device.} =
-  ## The LMCubic forward (lmq.cuh `lm_cubic_encode` / the LMCubic
-  ## template `encode`): Cardano's formula for the depressed cubic
-  ## b·t³ + a·t = x: q_half = x·inv_b·0.5, delta = fma(q_half, q_half,
-  ## p3_cub), t = cbrt(q_half + s) + cbrt(q_half − s) with s = sqrt(delta),
-  ## idx = floor(fma(t, half_n, half_n)) clamped to [0, 2^bits − 1].
-  ## `compandA` is the runtime `a` (0.65). The derived constants b = 1−a,
-  ## inv_b, p3 = a·inv_b/3, p3_cub are computed in fp32 exactly as the CUDA
-  ## constructor does.
+  ## The LMCubic forward (lmq.cuh `lm_cubic_encode`): Cardano's
+  ## formula for the depressed cubic `b·t³ + a·t = x` (the cbrt pair
+  ## on qHalf ± sqrt(qHalf² + p3_cub)), the index clamped to
+  ## [0, 2^bits − 1]. `compandA` is the runtime `a` (0.65 production).
+  ## The derived constants b = 1−a, inv_b, p3 = a·inv_b/3, p3_cub are
+  ## computed in fp32 exactly as the CUDA constructor does.
   let b = 1.0'f32 - compandA
   let invB = 1.0'f32 / b
   let p3 = compandA * invB * (1.0'f32 / 3.0'f32)
@@ -271,32 +268,30 @@ proc lmCubicEncode(x: float32; compandA: float32; bits: static int): uint32 {.de
   uint32(if idx < 0: 0 else: (if idx > qmax: qmax else: idx))
 
 proc lmCubicDecode(idx: uint32; compandA: float32; bits: static int): float32 {.device.} =
-  ## The LMCubic inverse (lmq.cuh `lm_cubic_decode` / `decode`):
-  ## t = fma(2·idx + 1, 1/N, −1), t2 = t·t, returns
-  ## t·fma(t2, b, a), the fp32 sequence in the CUDA order.
+  ## The LMCubic inverse (lmq.cuh `lm_cubic_decode`), the fp32
+  ## sequence in the CUDA order.
   let b = 1.0'f32 - compandA
   let invN = 1.0'f32 / float32(1 shl bits)
   let t = fma(2.0'f32 * float32(idx) + 1.0'f32, invN, -1.0'f32)
   let t2 = t * t
   t * fma(t2, b, compandA)
 
-# ═════════════════════════════════════════════════════════════════════
+# ════════════════════════════════════════
 #  kvQuantBlock: one group-block (4 groups = 128 values) quantized
-#  ═════════════════════════════════════════════════════════════════════
+# ════════════════════════════════════════
 
 proc kvQuantBlock(
     outBuf: ptr UncheckedArray[uint32],   # packed words + fp16 scale bits (low 16)
     inBuf: ptr UncheckedArray[uint16],    # the fp16 rows
     inBase, wordBase, scaleBase: int32,   # per-token bases
     bits: static int, compander: static int, compandA: float32) {.device.} =
-  ## Quantizes the 128-value span at `inBase` (4 groups of 32, the token's values [32·g0, 32·g0 + 128))
-  ## into the group-block's packed words at `wordBase` (groups·bits uint32 per token)
-  ## and the fp16 group scales at `scaleBase` (one u32 slot per group, the f16 bits in [0, 16), the binding-0 packing).
-  ## Per lane: the 4 consecutive values at 4·lane (the warp lane mapping),
-  ## H4+H8, 1/sqrt(32), group absmax + 1e-10 reduced over the 8-lane subgroup,
-  ## the linear midpoint-grid or LMCubic quantize, and the in-register plane combine
-  ## with the per-bits word write.
-  ## `bits` ∈ {2, 4, 8} (one plane each), `compander` 0 = linear / 1 = LMCubic.
+  ## Quantizes the 128-value span at `inBase` (4 groups of 32
+  ## consecutive values) into the group-block's packed words at
+  ## `wordBase` (groups·bits uint32 per token) and the fp16 group
+  ## scales at `scaleBase` (one u32 slot per group, the f16 bits in
+  ## [0, 16), the binding-0 packing). Lane `l` owns the 4 consecutive
+  ## values at 4·l. `bits` ∈ {2, 4, 8} (one plane each), `compander`
+  ## 0 = linear / 1 = LMCubic.
   static: doAssert bits in {2, 4, 8}
   static: doAssert compander in {0, 1}
   let lane = uint32(thread_index_in_threadgroup)
@@ -353,9 +348,9 @@ proc kvQuantBlock(
   if sl == 0:
     outBuf[scaleBase + sg] = uint32(s.to(float16).asU16())
 
-# ═════════════════════════════════════════════════════════════════════
+# ════════════════════════════════════════
 #  kvDequantBlock: one group-block (4 groups = 128 values) dequantized
-#  ═════════════════════════════════════════════════════════════════════
+# ════════════════════════════════════════
 
 proc kvDequantBlock(
     outBuf: ptr UncheckedArray[uint16],   # the fp16 rows
@@ -366,9 +361,10 @@ proc kvDequantBlock(
   ## Dequantizes one group-block back to fp16 rows: the lane's 4 codes
   ## unpacked from the group's words (single global reads, the CUDA
   ## two-word funnel window, no cross-lane traffic for the payload),
-  ## the fp16 scale × 1/sqrt(32), the linear / LMCubic inverse, the H4+H8 rotate back (same order as the quant),
-  ## and the fp16 RNE store at `outBase` + 4·lane. `bits` ∈ {2, 4, 8},
-  ## `compander` 0 = linear / 1 = LMCubic.
+  ## the fp16 scale × 1/sqrt(32), the linear / LMCubic inverse, the
+  ## H4+H8 rotate back (same order as the quant), and the fp16 RNE
+  ## store at `outBase` + 4·lane. `bits` ∈ {2, 4, 8}, `compander`
+  ## 0 = linear / 1 = LMCubic.
   static: doAssert bits in {2, 4, 8}
   static: doAssert compander in {0, 1}
   let lane = uint32(thread_index_in_threadgroup)
@@ -410,9 +406,9 @@ proc kvDequantBlock(
   for r in 0'i32 ..< 4:
     outBuf[outBase + 4 * l + r] = v[r].to(float16).asU16()
 
-# ═════════════════════════════════════════════════════════════════════
+# ════════════════════════════════════════
 #  The kernels
-#  ═════════════════════════════════════════════════════════════════════
+# ════════════════════════════════════════
 
 proc kv_quant_fwd*(
     outBuf: ptr UncheckedArray[uint32],   # binding 0: [K words | V words | K scales | V scales]
@@ -427,10 +423,12 @@ proc kv_quant_fwd*(
   ## Quantizes the appended K/V rows (one group-block per threadgroup)
   ## into the packed planes + fp16 scales, the exllamav3 paged quant
   ## semantics on the layer-major slab layout. The logical token
-  ## `y + cache_seqlens[z]` maps through the block table and the `layer`
-  ## scalar to the physical layer-major position. The group-block's
-  ## 128-value span is quantized by `kvQuantBlock` into the binding-0 regions
-  ## (see the module doc). `bits` ∈ {2, 4, 8}, `compander` 0 = linear / 1 = LMCubic, `pageSize` = 256, D = 128.
+  ## `y + cache_seqlens[z]` maps through the block table and the
+  ## `layer` scalar to the physical layer-major position. The
+  ## group-block's 128-value span is quantized by `kvQuantBlock` into
+  ## the binding-0 regions (see the module doc).
+  ## Grid: (groups_per_token div 4, tokens, num_seqs), 32 lanes.
+  ## x = group-block, y = token, z = seq.
   static: doAssert bits in {2, 4, 8}
   static: doAssert compander in {0, 1}
   static: doAssert pageSize == 256
@@ -469,11 +467,15 @@ proc kv_dequant_fwd*(
     bits: static int, compander: static int,
     pageSize: static int, D: static int) {.device.} =
   ## Dequantizes the cached K/V rows (one group-block per threadgroup)
-  ## from the packed planes + fp16 scales back to fp16 rows, the round-trip mirror
-  ## of `kv_quant_fwd`. The logical token `y` (the seq's cached rows [0, cache_seqlens[z]))
-  ## maps through the block table and the `layer` scalar to the physical
-  ## layer-major position. `kvDequantBlock` writes the K row stream to [0, out_total)
-  ## and the V stream to [out_total, 2·out_total) of the binding-0 buffer.
+  ## from the packed planes + fp16 scales back to fp16 rows, the
+  ## round-trip mirror of `kv_quant_fwd`. The logical token `y` (the
+  ## seq's cached rows [0, cache_seqlens[z])) maps through the block
+  ## table and the `layer` scalar to the physical layer-major
+  ## position. `kvDequantBlock` writes the K row stream to [0,
+  ## out_total) and the V stream to [out_total, 2·out_total) of the
+  ## binding-0 buffer.
+  ## Grid: (groups_per_token div 4, tokens, num_seqs), 32 lanes.
+  ## x = group-block, y = token, z = seq.
   static: doAssert bits in {2, 4, 8}
   static: doAssert compander in {0, 1}
   static: doAssert pageSize == 256

--- a/workspace/positron/src/kernels/ceramic/exl3_kvquant.nim
+++ b/workspace/positron/src/kernels/ceramic/exl3_kvquant.nim
@@ -228,6 +228,8 @@ proc cbrtDefined(x: float32): float32 {.device.} =
   if m >= 2.0'f32:
     m = m * 0.5'f32
     e += 1
+  if ax == 0.0'f32:
+    return x
   while m < 1.0'f32:
     m = m * 2.0'f32
     e -= 1

--- a/workspace/positron/src/kernels/ceramic/gguf_attn.nim
+++ b/workspace/positron/src/kernels/ceramic/gguf_attn.nim
@@ -63,7 +63,8 @@ const ggufAttnMsl* = metal:
       block_table, cache_seqlens, cu_seqlens_q: ptr UncheckedArray[int32],
       num_seqs, H, Nkv, max_pages, page_size: int32) {.global.} =
     paged_attn_fwd(o, q, k_cache, v_cache, block_table, cache_seqlens,
-                   cu_seqlens_q, num_seqs, H, Nkv, max_pages, page_size, 128)
+                   cu_seqlens_q, num_seqs, H, Nkv, max_pages,
+                   num_layers = 1, layer = 0, page_size = 16, D = 128)
 
 # ═════════════════════════════════════════════════════════════════════
 #  The attention-forward parameters and result

--- a/workspace/positron/src/kernels/ceramic/paged_attn.nim
+++ b/workspace/positron/src/kernels/ceramic/paged_attn.nim
@@ -12,84 +12,94 @@
 # ############################################################
 
 ## Paged multi-head attention forward on the ceramic Tile API: decode
-## and prefill in one kernel, K/V fetched per 8-row block through a
-## dense `block_table` + `cache_seqlens` (no page→contiguous gather).
-## Experimental: not a production kernel, known gaps below, not fixed.
+## and prefill in one kernel, K/V fetched per 8-row block through
+## a dense `block_table` + `cache_seqlens`
+## (no page-to-contiguous gather). The K/V come from the layer-major
+## PagePool slab (num_pages, num_layers, page_size, Nkv, D), one layer
+## per kernel dispatch via the `layer` scalar.
+##
+## Dataflow per threadgroup:
+##
+##   q tile (8×D) --× q_mul--> Q·Kᵀ --> S tile (8×8)
+##   k tile: 8-row block <- block_table[seq, t div page_size] <- k_cache slab
+##   S tile --banded causal mask--> exp2 --> P (8×8) fp16
+##   v tile: 8-row block <- block_table[seq, t div page_size] <- v_cache slab
+##   P --P·V mma--> O (8×D) fp32 --÷ row norm--> fp16 store
+##
+## The softmax is online: each kv block rescales the running O
+## and row sum by exp2(m_prev − m_cur).
+##
+## Modes:
+##   - decode (q_len == 1): causal off, each query attends the cached
+##     rows [0, cache_seqlen)
+##   - prefill (q_len ≥ 2): causal on over [0, cache_seqlen + q_len),
+##     query row j attends keys [0, cache_seqlen + j]
+##     (flash-attn varlen semantics)
+##   - GQA: kv_head = q_head div (H div Nkv)
 ##
 ## Buffers, fp16 first then int32 tables then scalars:
 ##   - o, q: (num_qo_tokens, H, D)
-##   - k_cache, v_cache: (num_pages, page_size, Nkv, D), seq-first
-##     slab (row stride Nkv·D, head-dim contiguous)
-##   - block_table: (num_seqs, max_pages) dense, -1 padding, never read
+##   - k_cache, v_cache: (num_pages, num_layers, page_size, Nkv, D)
+##     layer-major pool (page stride num_layers·page_size·Nkv·D,
+##     per-layer row stride Nkv·D, head-dim contiguous)
+##   - block_table: (num_seqs, max_pages) dense, -1 padding
 ##   - cache_seqlens: (num_seqs)
 ##   - cu_seqlens_q: (num_seqs+1), the prefill query ranges
-##   - num_seqs, H, Nkv, max_pages, page_size: int32
+##   - num_seqs, H, Nkv, max_pages, num_layers, layer: int32
+##   - page_size: static int, multiple of 8 (tile geometry)
 ##   - D: static int, 64 or 128 (tile geometry). No generic brackets,
 ##     no stride or scratch parameters.
 ##
 ## The 16-bit element type is the DSL's `float16` (distinct uint16,
 ## bit-identical on the host).
 ##
-## Grid and modes:
-##   - grid (q token blocks, H, num_seqs): z = seq, y = head, x = the
-##     seq's 8-row q block
-##   - decode (q_len == 1): causal OFF, each query attends the cached
-##     rows [0, cache_seqlen)
-##   - prefill (q_len ≥ 2): causal ON over [0, cache_seqlen + q_len),
-##     query row j attends keys [0, cache_seqlen + j] (flash-attn
-##     varlen semantics)
-##   - GQA: kv_head = q_head div (H div Nkv)
-##
 ## Block fetch, page_size a multiple of 8 so each 8-row KV block lies
 ## inside one page. For block t0:
 ##   - page_idx = t0 div page_size, in_page = t0 mod page_size,
 ##     page_id = block_table[seq·max_pages + page_idx]
-##   - slab base = page_id·(page_size·Nkv·D) + in_page·(Nkv·D) +
-##     kv_head·D, passed as the origin's batch component, the block
-##     rows local to it
-##   - the K view carries stride (1, 1, Nkv·D, 1). The V view
-##     carries the transposed stride (1, 1, 1, Nkv·D), so the P·V mma
-##     consumes Vᵀ from the natural slab view, matching the plain attn kernel's V view
+##   - slab base = page_id·(num_layers·page_size·Nkv·D) +
+##     layer·(page_size·Nkv·D) + in_page·(Nkv·D) + kv_head·D
+##     (the layer-major pool position), passed as the origin's batch
+##     component, the block rows local to it
+##   - the K view carries stride (1, 1, Nkv·D, 1). The V view carries
+##     the transposed stride (1, 1, 1, Nkv·D), so the P·V mma consumes
+##     Vᵀ from the natural slab view
 ##
 ## Partial last page:
-##   - K/V rows are bounded by cache_seqlens[seq] (decode) or
-##     cache_seqlen + q_len (prefill), never by page multiples. The
-##     tail page may hold garbage beyond the covered length
+##   - K/V rows are bounded by cache_seqlens[seq] (decode)
+##     or cache_seqlen + q_len (prefill), never by page multiples.
+##     The tail page may hold garbage beyond the covered length
 ##     (bound, don't filter)
 ##   - the KV loop stays inside the seq's table pages
-##     (pageBlocks = ceil(totalK/page_size)·(page_size div 8), a block
-##     beyond the last table page would read a -1 padding slot). It
-##     also stays inside the last block's attended range
-##     (lastKey = min(cachedLen + q0Local + 7, totalK − 1))
-##   - garbage rows load as valid slab memory and are excluded by the
-##     banded mask: masked S columns are set to the most-negative
+##     (pageBlocks = ceil(totalK/page_size)·(page_size div 8))
+##     and inside the last block's attended range
+##     (lastKey = min(cachedLen + q0Local + 7, totalK − 1)). A block
+##     beyond the last table page would read a -1 padding slot
+##   - garbage rows load as valid slab memory and are excluded
+##     by the banded mask. Masked S columns become the most-negative
 ##     finite fp32 (−3.402823466e38), so the running row max ignores
-##     them and exp2(S − m) underflows to exact +0.0. The P, l and O
-##     accumulations never see them
+##     them and exp2(S − m) underflows to exact +0.0. The P, l
+##     and O accumulations never see them
 ##
 ## Numerics:
-##   - online softmax in TM's exp2 shape, q_mul = scale·log2(e) folded
+##   - online softmax in the exp2 shape, q_mul = scale·log2(e) folded
 ##     into Q (exp2(S·q_mul − m) is the exp(S·scale) convention,
 ##     scale = 1/sqrt(D))
 ##   - P downcast to fp16 (`convert`) before the P·V mma. The output
 ##     store quantizes the fp32 O tile to fp16 (RNE) through the `to`
 ##     chokepoint
 ##
-## Local device procs: the shared tile_algebra lacks the banded causal mask, so the module carries maskCausal locally.
-## The row-bounded load/store come from tile_io_rows (positron local extension).
+## Local device procs: the shared tile algebra has no banded causal
+## mask, so the module carries `maskCausal` locally. The row-bounded
+## loads/stores come from `tile_io_rows`.
 ##
-## Known production gaps (documented, not fixed):
-##   - Layer-major PagePool stride: production slabs are
-##     [num_pages, num_layers, page_size, kv_heads, head_dim]. This
-##     kernel consumes a per-layer slab view contiguous per layer (row
-##     stride Nkv·D), so the per-layer view needs a layer offset and a
-##     batch stride of num_layers·page_size·Nkv·D.
-##   - Runtime page_size: production should specialize page_size as a
-##     constexpr (the fetch math derives pageBlocks and the page
-##     stride from it).
-##   - Single-path gate: the new API has no `useCeramicLayout` toggle
-##     (the old API's addressing-layer switch). The kernel is the one
-##     path.
+## Production contract:
+##   - single addressing path, no toggle: the kernel is the one
+##     addressing path, and the Tile API has no `useCeramicLayout`
+##     switch
+##   - batch metadata (block_table, cache_seqlens, cu_seqlens_q)
+##     arrives as raw pointers. A future AttentionBatchInfo struct
+##     passes the same raw pointers, so the signature stays unchanged
 
 import workspace/crucible
 import workspace/ceramic
@@ -98,9 +108,9 @@ import ./tile_io_rows
 export int_tuples, layouts, layout_constructors, layout_indexing, tensors,
        ptr_arithmetic, tile_algebra
 
-# ═════════════════════════════════════════════════════════════════════
+# ════════════════════════════════════════
 #  Local device extensions: the tile API gaps the paged fetch needs
-#  ═════════════════════════════════════════════════════════════════════
+# ════════════════════════════════════════
 
 proc maskCausal[A: static MmaAtom](
     tile: var RtLeft[float32, 8, 8, A],
@@ -130,24 +140,27 @@ proc maskCausal[A: static MmaAtom](
         if int32(col + m * N + v) > band:
           tile.frags[n][m].frag[v] = -3.402823466e38'f32
 
-# ═════════════════════════════════════════════════════════════════════
+# ════════════════════════════════════════
 #  The kernel
-#  ═════════════════════════════════════════════════════════════════════
+# ════════════════════════════════════════
 
 proc paged_attn_fwd*(
     o: ptr UncheckedArray[float16],            # (num_qo_tokens, H, D)
     q: ptr UncheckedArray[float16],            # (num_qo_tokens, H, D)
-    k_cache, v_cache: ptr UncheckedArray[float16],  # (num_pages, page_size, Nkv, D)
+    k_cache, v_cache: ptr UncheckedArray[float16],  # (num_pages, num_layers, page_size, Nkv, D) layer-major pool
     block_table: ptr UncheckedArray[int32],    # (num_seqs, max_pages) dense
     cache_seqlens: ptr UncheckedArray[int32],  # (num_seqs)
     cu_seqlens_q: ptr UncheckedArray[int32],   # (num_seqs+1) prefill q ranges
-    num_seqs, H, Nkv, max_pages, page_size: int32,
-    D: static int) {.device.} =
+    num_seqs, H, Nkv, max_pages, num_layers, layer: int32,
+    page_size: static int, D: static int) {.device.} =
   ## One grid point = (seq, head, 8-row q block), following the module
   ## doc's contract: the q tile loads row-bounded, the KV loop is
   ## bounded by the seq's table pages and the banded causal mask, and
   ## the fp16 store writes only the seq's q rows.
+  ## Grid: (q token blocks, H, num_seqs), 32 lanes. x = the seq's
+  ## 8-row q block, y = head, z = seq.
   static: doAssert D == 64 or D == 128
+  static: doAssert page_size mod 8 == 0
 
   let seqId = int32(threadgroup_position_in_grid.z)
   let head = int32(threadgroup_position_in_grid.y)
@@ -173,7 +186,7 @@ proc paged_attn_fwd*(
   let decodeAdj = (if qLen == 1: 1'i32 else: 0'i32)
   let totalK = cachedLen + qLen - decodeAdj
   let q0Local = qBlock * 8
-  let pageStride = page_size * Nkv * int32(D)
+  let pageStride = num_layers * page_size * Nkv * int32(D)
   let rowStride = Nkv * int32(D)
   # The KV loop stays inside the seq's table pages and the last
   # attended block.
@@ -206,7 +219,8 @@ proc paged_attn_fwd*(
     let pageIdx = (kv_idx * 8) div page_size
     let inPage = kv_idx * 8 - pageIdx * page_size
     let pageId = block_table[seqId * max_pages + pageIdx]
-    let base = pageId * pageStride + inPage * rowStride + kvHead * int32(D)
+    let base = pageId * pageStride + layer * page_size * Nkv * int32(D) +
+               inPage * rowStride + kvHead * int32(D)
     # The block's rows are local to the base: the origin's row-tile
     # component stays 0.
     k_reg.loadTile(gd_k, (base, 0, 0, 0))

--- a/workspace/positron/tests/exl3_kvquant_test_utils.nim
+++ b/workspace/positron/tests/exl3_kvquant_test_utils.nim
@@ -1,0 +1,1107 @@
+## Tattletale
+## Copyright (c) 2026 Mamy André-Ratsimbazafy
+## Licensed and distributed under either of
+##   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+##   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+## at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+## Shared paged-KV quant/dequant test support: the deterministic paged
+## geometries, the host reference implementation of the
+## quant_block_x4 / dequant_block_x4 arithmetic (q_cache_kernels.cuh),
+## and the per-combo engine runs the exl3 kvquant tests share.
+
+import std/[strformat, strutils, math, random, sequtils]
+import workspace/crucible
+import ../../ceramic/tests/tile_test_utils
+import ../src/kernels/ceramic/exl3_kvquant
+
+# ════════════════════════════════════════
+#  The metal block. One launcher per kernel dispatches over runtime
+#  bits/compander int32 args to the 6 static instantiations (nested
+#  if/else: the crucible codegen drops elif branches). First param =
+#  the output buffer: engine.run binds the separate outBuf argument to
+#  it and the args tuple to the rest. pageSize = 256 and D = 128 baked
+#  into every call.
+# ════════════════════════════════════════
+
+const kvquantMsl* = metal:
+  proc kvQuantD128(
+      outBuf: ptr UncheckedArray[uint32],
+      kIn, vIn: ptr UncheckedArray[uint16],
+      block_table, cache_seqlens: ptr UncheckedArray[int32],
+      num_seqs, max_pages, token_dim, groups_per_token, q_words_total,
+      num_layers, layer: int32,
+      compand_a: float32, bits: int32, compander: int32) {.global.} =
+    if bits == 2:
+      if compander == 0:
+        kv_quant_fwd(outBuf, kIn, vIn, block_table, cache_seqlens,
+                     num_seqs, max_pages, token_dim, groups_per_token,
+                     q_words_total, num_layers, layer, compand_a, 2, 0, 256, 128)
+      else:
+        kv_quant_fwd(outBuf, kIn, vIn, block_table, cache_seqlens,
+                     num_seqs, max_pages, token_dim, groups_per_token,
+                     q_words_total, num_layers, layer, compand_a, 2, 1, 256, 128)
+    else:
+      if bits == 4:
+        if compander == 0:
+          kv_quant_fwd(outBuf, kIn, vIn, block_table, cache_seqlens,
+                       num_seqs, max_pages, token_dim, groups_per_token,
+                       q_words_total, num_layers, layer, compand_a, 4, 0, 256, 128)
+        else:
+          kv_quant_fwd(outBuf, kIn, vIn, block_table, cache_seqlens,
+                       num_seqs, max_pages, token_dim, groups_per_token,
+                       q_words_total, num_layers, layer, compand_a, 4, 1, 256, 128)
+      else:
+        if bits == 8:
+          if compander == 0:
+            kv_quant_fwd(outBuf, kIn, vIn, block_table, cache_seqlens,
+                         num_seqs, max_pages, token_dim, groups_per_token,
+                         q_words_total, num_layers, layer, compand_a, 8, 0, 256, 128)
+          else:
+            kv_quant_fwd(outBuf, kIn, vIn, block_table, cache_seqlens,
+                         num_seqs, max_pages, token_dim, groups_per_token,
+                         q_words_total, num_layers, layer, compand_a, 8, 1, 256, 128)
+
+  proc kvDequantD128(
+      outBuf: ptr UncheckedArray[uint16],
+      qK, qV: ptr UncheckedArray[uint32],
+      sK, sV: ptr UncheckedArray[uint16],
+      block_table, cache_seqlens: ptr UncheckedArray[int32],
+      num_seqs, max_pages, token_dim, groups_per_token, out_total,
+      num_layers, layer: int32,
+      compand_a: float32, bits: int32, compander: int32) {.global.} =
+    if bits == 2:
+      if compander == 0:
+        kv_dequant_fwd(outBuf, qK, qV, sK, sV, block_table, cache_seqlens,
+                       num_seqs, max_pages, token_dim, groups_per_token,
+                       out_total, num_layers, layer, compand_a, 2, 0, 256, 128)
+      else:
+        kv_dequant_fwd(outBuf, qK, qV, sK, sV, block_table, cache_seqlens,
+                       num_seqs, max_pages, token_dim, groups_per_token,
+                       out_total, num_layers, layer, compand_a, 2, 1, 256, 128)
+    else:
+      if bits == 4:
+        if compander == 0:
+          kv_dequant_fwd(outBuf, qK, qV, sK, sV, block_table, cache_seqlens,
+                         num_seqs, max_pages, token_dim, groups_per_token,
+                         out_total, num_layers, layer, compand_a, 4, 0, 256, 128)
+        else:
+          kv_dequant_fwd(outBuf, qK, qV, sK, sV, block_table, cache_seqlens,
+                         num_seqs, max_pages, token_dim, groups_per_token,
+                         out_total, num_layers, layer, compand_a, 4, 1, 256, 128)
+      else:
+        if bits == 8:
+          if compander == 0:
+            kv_dequant_fwd(outBuf, qK, qV, sK, sV, block_table, cache_seqlens,
+                           num_seqs, max_pages, token_dim, groups_per_token,
+                           out_total, num_layers, layer, compand_a, 8, 0, 256, 128)
+          else:
+            kv_dequant_fwd(outBuf, qK, qV, sK, sV, block_table, cache_seqlens,
+                         num_seqs, max_pages, token_dim, groups_per_token,
+                         out_total, num_layers, layer, compand_a, 8, 1, 256, 128)
+
+# ════════════════════════════════════════
+#  Case data (deterministic, hash-seeded: the shared ShapeCases
+#  stream)
+# ════════════════════════════════════════
+
+type XorShift = object
+  s: uint32
+
+func seedRng*(shapes: var ShapeCases): XorShift =
+  ## Seeds the value PRNG from the shape stream's seed bytes.
+  let b = shapes.nextBytes()
+  var s = uint32(b[0]) or (uint32(b[1]) shl 8) or
+          (uint32(b[2]) shl 16) or (uint32(b[3]) shl 24)
+  if s == 0: s = 0x9E3779B9'u32
+  result = XorShift(s: s)
+
+func nextU16(r: var XorShift): uint16 =
+  ## xorshift32, the test's deterministic value source.
+  r.s = r.s xor (r.s shl 13)
+  r.s = r.s xor (r.s shr 17)
+  r.s = r.s xor (r.s shl 5)
+  result = uint16(r.s shr 16)
+
+func f16GridVal(r: var XorShift): float32 =
+  ## Deterministic f16-exact value in [-2, 2): a 32-point grid, one
+  ## stream position per element, so the pattern never aliases the
+  ## 32-value group width or the 128-value group-block span.
+  float32(nextU16(r) mod 32) / 8.0'f32 - 2.0'f32
+
+type KvCase* = object
+  numSeqs*: int
+  kvHeads*: int                 # kv_heads (token_dim = kv_heads·128)
+  tokenDim*: int
+  groupsPerToken*: int          # kv_heads·128 div 32
+  rows*: int                    # the rectangular batch append / cached rows
+  maxPages*, numPages*: int
+  blockTable*: seq[int32]       # (num_seqs, max_pages) dense, -1 padding
+  kSlab*, vSlab*: seq[uint16]   # (num_pages, 256, token_dim) fp16
+
+proc buildKvCase*(shapes: var ShapeCases): KvCase =
+  ## One paged geometry: 1..3 seqs with a rectangular append of
+  ## `rows` tokens each (the exllamav3 batch-append semantics), the
+  ## row count taken from a partial/full-page mix at the production
+  ## PAGE_SIZE 256, gapped physical page ids, kv_heads 1..4 (→ 4..16
+  ## groups per token). The slabs are filled with f16-exact grid
+  ## values at the physical page rows.
+  let b = shapes.nextBytes()
+  result.numSeqs = caseInRange(b, 0, 1, 3)
+  result.kvHeads = [1, 2, 4][caseInRange(b, 1, 0, 2)]
+  result.tokenDim = result.kvHeads * 128
+  result.groupsPerToken = result.tokenDim div 32
+  let rowChoices = [100, 256, 300, 512, 600, 257]
+  result.rows = rowChoices[caseInRange(b, 2, 0, rowChoices.len - 1)]
+  let usedPages = (result.rows + 255) div 256
+  var tables = newSeq[seq[int32]](result.numSeqs)
+  var idCounter = 0
+  for s in 0 ..< result.numSeqs:
+    var row = newSeq[int32](usedPages)
+    for j in 0 ..< usedPages:
+      row[j] = int32(idCounter)
+      let gap = (if j == usedPages - 1: 0 else: caseInRange(shapes.nextBytes(), 3 + s, 0, 1))
+      idCounter += 1 + gap
+    tables[s] = row
+  result.numPages = idCounter
+  result.maxPages = usedPages
+  result.blockTable = newSeq[int32](result.numSeqs * result.maxPages)
+  for i in 0 ..< result.blockTable.len:
+    result.blockTable[i] = -1'i32
+  for s in 0 ..< result.numSeqs:
+    for j in 0 ..< usedPages:
+      result.blockTable[s * result.maxPages + j] = tables[s][j]
+  var r = seedRng(shapes)
+  let slabLen = result.numPages * 256 * result.tokenDim
+  result.kSlab = newSeq[uint16](slabLen)
+  result.vSlab = newSeq[uint16](slabLen)
+  for i in 0 ..< slabLen:
+    result.kSlab[i] = fp32ToFp16(f16GridVal(r) * 2.0'f32)
+    result.vSlab[i] = fp32ToFp16(f16GridVal(r) * 2.0'f32)
+
+func tokenPos(d: KvCase; batch, tokenIdx: int): int =
+  ## The physical position of the logical token: the block-table page
+  ## mapping (the kernel's addressing, mirrored host-side).
+  let pageIdx = tokenIdx shr 8
+  let pageId = d.blockTable[batch * d.maxPages + pageIdx].int
+  pageId * 256 + (tokenIdx and 255)
+
+# ════════════════════════════════════════
+#  The host reference implementation: the quant_block_x4 /
+#  dequant_block_x4 arithmetic (q_cache_kernels.cuh), formula by formula
+# ════════════════════════════════════════
+
+# host libm mirrors (the device builtins have empty bodies on the host)
+proc floorf(x: float32): float32 {.importc: "floorf", header: "<math.h>".}
+proc exp2f(x: float32): float32 {.importc: "exp2f", header: "<math.h>".}
+proc sqrtf(x: float32): float32 {.importc: "sqrtf", header: "<math.h>".}
+proc fmaf(x, y, z: float32): float32 {.importc: "fmaf", header: "<math.h>".}
+
+const R32 = 0.17677669529663688110'f32   # 1/sqrt(32), q_cache_kernels.cuh
+
+func refCbrt(x: float32): float32 =
+  ## The host mirror of the op's `cbrtDefined` (same fp32 sequence,
+  ## importc floorf/exp2f): the defined cube root the LMCubic encode
+  ## uses in place of the CUDA cbrtf (MSL has no cbrt).
+  if x == 0.0'f32:
+    return x
+  let sgn = (if x < 0.0'f32: -1.0'f32 else: 1.0'f32)
+  let ax = (if x < 0.0'f32: -x else: x)
+  var e = 0'i32
+  var m = ax
+  if m >= 1.8446744073709552e19'f32:
+    m = m * 5.421010862427522e-20'f32
+    e += 64
+  if m >= 4294967296.0'f32:
+    m = m * 2.3283064365386963e-10'f32
+    e += 32
+  if m >= 65536.0'f32:
+    m = m * 1.52587890625e-05'f32
+    e += 16
+  if m >= 256.0'f32:
+    m = m * 0.00390625'f32
+    e += 8
+  if m >= 16.0'f32:
+    m = m * 0.0625'f32
+    e += 4
+  if m >= 4.0'f32:
+    m = m * 0.25'f32
+    e += 2
+  if m >= 2.0'f32:
+    m = m * 0.5'f32
+    e += 1
+  while m < 1.0'f32:
+    m = m * 2.0'f32
+    e -= 1
+  let q = int32(floorf(float32(e) * 0.3333333432674408'f32))
+  let r = e - 3 * q
+  var y: float32
+  block seed:
+    let u = 2.0'f32 * m - 3.0'f32
+    var b1 = 0.0'f32
+    var b2 = 0.0'f32
+    var bb = 2.0'f32 * u * b1 - b2 - 7.892353387775054e-05'f32
+    b2 = b1
+    b1 = bb
+    bb = 2.0'f32 * u * b1 - b2 + 0.000702055045675154'f32
+    b2 = b1
+    b1 = bb
+    bb = 2.0'f32 * u * b1 - b2 - 0.0073754847563900945'f32
+    b2 = b1
+    b1 = bb
+    bb = 2.0'f32 * u * b1 - b2 + 0.1292479927845696'f32
+    b2 = b1
+    b1 = bb
+    y = u * b1 - b2 + 1.1374176813308194'f32
+  if r == 1:
+    y = y * 1.2599210498948732'f32
+  else:
+    if r == 2:
+      y = y * 1.5874010519681994'f32
+  y = y * exp2f(float32(q))
+  y = (2.0'f32 * y + ax / (y * y)) * 0.3333333432674408'f32
+  y = (2.0'f32 * y + ax / (y * y)) * 0.3333333432674408'f32
+  sgn * y
+
+func hadamard32(v: var array[32, float32]) =
+  ## The H32 rotation, in place: the H4 butterfly per 4-block
+  ## (had_4_inreg) followed by the H8 butterfly over the 8 blocks
+  ## (had_8_subgroup, 3 stages pairing block k with k^i, the exact
+  ## pairwise (a+b, a−b) with one rounding each, q_cache_kernels.cuh
+  ## had_4_inreg / had_8_subgroup).
+  for k in 0 ..< 8:
+    let s0 = v[4 * k + 0] + v[4 * k + 1]
+    let d0 = v[4 * k + 0] - v[4 * k + 1]
+    let s1 = v[4 * k + 2] + v[4 * k + 3]
+    let d1 = v[4 * k + 2] - v[4 * k + 3]
+    v[4 * k + 0] = s0 + s1
+    v[4 * k + 1] = d0 + d1
+    v[4 * k + 2] = s0 - s1
+    v[4 * k + 3] = d0 - d1
+  for i in [1, 2, 4]:
+    var nv = v
+    for k in 0 ..< 8:
+      let p = k xor i
+      if (k and i) == 0:
+        for rr in 0 ..< 4:
+          nv[4 * k + rr] = v[4 * k + rr] + v[4 * p + rr]
+          nv[4 * p + rr] = v[4 * k + rr] - v[4 * p + rr]
+    v = nv
+
+func lmCubicEncodeHost(x, compandA: float32; bits: int): uint32 =
+  ## The LMCubic forward (lmq.cuh encode): Cardano's formula:
+  ## q_half = x·inv_b·0.5, delta = fma(q_half, q_half, p3_cub),
+  ## s = sqrt(delta), t = cbrt(q_half + s) + cbrt(q_half − s),
+  ## idx = floor(fma(t, half_n, half_n)) clamped to [0, 2^bits − 1].
+  ## The derived constants follow the CUDA constructor's fp32 order.
+  let b = 1.0'f32 - compandA
+  let invB = 1.0'f32 / b
+  let p3 = compandA * invB * (1.0'f32 / 3.0'f32)
+  let p3cub = p3 * p3 * p3
+  let qHalf = x * invB * 0.5'f32
+  let delta = fmaf(qHalf, qHalf, p3cub)
+  let sq = sqrtf(delta)
+  let t = refCbrt(qHalf + sq) + refCbrt(qHalf - sq)
+  let idx = int(floorf(fmaf(t, float32(1 shl (bits - 1)), float32(1 shl (bits - 1)))))
+  let qmax = (1 shl bits) - 1
+  uint32(max(min(idx, qmax), 0))
+
+func lmCubicDecodeHost(idx: uint32; compandA: float32; bits: int): float32 =
+  ## The LMCubic inverse (lmq.cuh decode): t = fma(2·idx + 1, 1/N,
+  ## −1), t2 = t·t, returns t·fma(t2, b, a).
+  let b = 1.0'f32 - compandA
+  let invN = 1.0'f32 / float32(1 shl bits)
+  let t = fmaf(2.0'f32 * float32(idx) + 1.0'f32, invN, -1.0'f32)
+  let t2 = t * t
+  t * fmaf(t2, b, compandA)
+
+func refQuantGroup(x: array[32, uint16]; bits, compander: int;
+                      compandA: float32): tuple[words: array[8, uint32],
+                                                 scale: uint16] =
+  ## One group of 32 consecutive values quantized, the
+  ## quant_block_x4 arithmetic (q_cache_kernels.cuh): load in the CUDA
+  ## lane order (value j = 4·sl + r), H4+H8, the 1/sqrt(32) scale, the
+  ## absmax + 1e-10 group scale (fp16 round-to-nearest-even (RNE)),
+  ## the linear midpoint grid
+  ## (`fmaf(v·inv_s, mf, mf)` floor-clamped to [0, 2^bits − 1]) or
+  ## LMCubic encode, and the bit-plane pack (value j occupies bits
+  ## [j·bits, (j+1)·bits) of the group's `bits` uint32 words, the
+  ## single plane for bits {2,4,8}).
+  var v: array[32, float32]
+  for j in 0 ..< 32:
+    v[j] = fp16ToFp32(x[j])
+  hadamard32(v)
+  for j in 0 ..< 32:
+    v[j] = v[j] * R32
+  var s = max(max(abs(v[0]), abs(v[1])), max(abs(v[2]), abs(v[3])))
+  for j in 4 ..< 32:
+    s = max(s, abs(v[j]))
+  s = s + 1e-10'f32
+  let invS = 1.0'f32 / s
+  var q: array[32, uint32]
+  if compander == 0:
+    let mf = float32(1 shl (bits - 1))
+    let qmax = (1 shl bits) - 1
+    for j in 0 ..< 32:
+      let t = fmaf(v[j] * invS, mf, mf)
+      let qi = int(floorf(t))
+      q[j] = uint32(max(min(qi, qmax), 0))
+  else:
+    for j in 0 ..< 32:
+      q[j] = lmCubicEncodeHost(v[j] * invS, compandA, bits)
+  let mask = (1'u32 shl bits) - 1
+  for w in 0 ..< bits:
+    var word = 0'u32
+    for j in 0 ..< 32:
+      if (j * bits) div 32 == w:
+        word = word or ((q[j] and mask) shl ((j * bits) mod 32))
+    result.words[w] = word
+  result.scale = fp32ToFp16(s)
+
+func refDequantGroup(words: array[8, uint32]; scale: uint16;
+                        bits, compander: int; compandA: float32): array[32, uint16] =
+  ## One group of 32 values dequantized, the dequant_block_x4
+  ## arithmetic (q_cache_kernels.cuh): the bit-plane unpack, the fp16
+  ## scale × 1/sqrt(32), the linear ((q − mh)·(s·inv_mf)) or LMCubic
+  ## inverse, the H4+H8 rotate back (same order as the quant), and the
+  ## fp16 RNE store.
+  var q: array[32, uint32]
+  let mask = (1'u32 shl bits) - 1
+  for w in 0 ..< bits:
+    let word = words[w]
+    for j in 0 ..< 32:
+      if (j * bits) div 32 == w:
+        q[j] = (word shr ((j * bits) mod 32)) and mask
+  let s = fp16ToFp32(scale) * R32
+  var v: array[32, float32]
+  if compander == 0:
+    let mh = float32(1 shl (bits - 1)) - 0.5'f32
+    let sm = s * (1.0'f32 / float32(1 shl (bits - 1)))
+    for j in 0 ..< 32:
+      v[j] = (float32(q[j]) - mh) * sm
+  else:
+    for j in 0 ..< 32:
+      v[j] = lmCubicDecodeHost(q[j], compandA, bits) * s
+  hadamard32(v)
+  for j in 0 ..< 32:
+    result[j] = fp32ToFp16(v[j])
+
+# ════════════════════════════════════════
+#  The per-combo check: quant bit-exact, dequant bit-exact, round trip
+# ════════════════════════════════════════
+
+func fnv1a(acc: var uint32; data: seq[uint32]) =
+  ## FNV-1a over a uint32 stream (the quant output), byte-wise.
+  for i in 0 ..< data.len:
+    let b0 = uint32(data[i] and 0xFF'u32)
+    let b1 = uint32((data[i] shr 8) and 0xFF'u32)
+    let b2 = uint32((data[i] shr 16) and 0xFF'u32)
+    let b3 = uint32((data[i] shr 24) and 0xFF'u32)
+    acc = (acc xor b0) * 0x01000193'u32
+    acc = (acc xor b1) * 0x01000193'u32
+    acc = (acc xor b2) * 0x01000193'u32
+    acc = (acc xor b3) * 0x01000193'u32
+
+func fnv1a(acc: var uint32; data: seq[uint16]) =
+  ## FNV-1a over a uint16 stream (the dequant output), byte-wise.
+  for i in 0 ..< data.len:
+    let b0 = uint32(data[i] and 0xFF'u16)
+    let b1 = uint32(data[i] shr 8)
+    acc = (acc xor b0) * 0x01000193'u32
+    acc = (acc xor b1) * 0x01000193'u32
+
+proc refQuant(d: KvCase; bits, compander: int; compandA: float32;
+                 prefix: seq[int32]): seq[uint32] =
+  ## The full reference quant over the case: for each seq and each
+  ## appended row `y` (logical token y + prefix[s]), the K and V
+  ## group quantizations written to the binding-0 layout
+  ## [K words | V words | K scales | V scales]. Returns the expected
+  ## quant buffer (the test sizes the regions by the PHYSICAL page
+  ## pool: the kernel indexes by physical token position, and the
+  ## gapped block tables leave unused holes that stay zero on both
+  ## sides).
+  let groups = d.groupsPerToken
+  let poolTokens = d.numPages * 256
+  let sTotal = poolTokens * groups
+  let qWordsTotal = poolTokens * groups * bits
+  let quantLen = 2 * qWordsTotal + 2 * sTotal
+  result = newSeq[uint32](quantLen)
+  for b in 0 ..< d.numSeqs:
+    for y in 0 ..< d.rows:
+      let tp = tokenPos(d, b, y + prefix[b])
+      for g in 0 ..< groups:
+        var xg: array[32, uint16]
+        for j in 0 ..< 32:
+          xg[j] = d.kSlab[tp * d.tokenDim + g * 32 + j]
+        let r = refQuantGroup(xg, bits, compander, compandA)
+        for w in 0 ..< bits:
+          result[(tp * groups + g) * bits + w] = r.words[w]
+        result[2 * qWordsTotal + tp * groups + g] = uint32(r.scale)
+    for y in 0 ..< d.rows:
+      let tp = tokenPos(d, b, y + prefix[b])
+      for g in 0 ..< groups:
+        var xg: array[32, uint16]
+        for j in 0 ..< 32:
+          xg[j] = d.vSlab[tp * d.tokenDim + g * 32 + j]
+        let r = refQuantGroup(xg, bits, compander, compandA)
+        for w in 0 ..< bits:
+          result[qWordsTotal + (tp * groups + g) * bits + w] = r.words[w]
+        result[2 * qWordsTotal + sTotal + tp * groups + g] = uint32(r.scale)
+
+proc refDequant(d: KvCase; expQ: seq[uint32]; bits, compander: int;
+                   compandA: float32; rows: int): seq[uint16] =
+  ## The full reference dequant over the case's first `rows` logical
+  ## tokens of each seq: K rows to [0, out_total), V rows to
+  ## [out_total, 2·out_total), reading the reference quant's binding-0
+  ## layout.
+  let groups = d.groupsPerToken
+  let poolTokens = d.numPages * 256
+  let sTotal = poolTokens * groups
+  let qWordsTotal = poolTokens * groups * bits
+  let outTotal = poolTokens * d.tokenDim
+  result = newSeq[uint16](2 * outTotal)
+  for b in 0 ..< d.numSeqs:
+    for y in 0 ..< rows:
+      let tp = tokenPos(d, b, y)
+      for g in 0 ..< groups:
+        var words: array[8, uint32]
+        for w in 0 ..< bits:
+          words[w] = expQ[(tp * groups + g) * bits + w]
+        let scale = uint16(expQ[2 * qWordsTotal + tp * groups + g] and 0xFFFF'u32)
+        let row = refDequantGroup(words, scale, bits, compander, compandA)
+        for j in 0 ..< 32:
+          result[tp * d.tokenDim + g * 32 + j] = row[j]
+    for y in 0 ..< rows:
+      let tp = tokenPos(d, b, y)
+      for g in 0 ..< groups:
+        var words: array[8, uint32]
+        for w in 0 ..< bits:
+          words[w] = expQ[qWordsTotal + (tp * groups + g) * bits + w]
+        let scale = uint16(expQ[2 * qWordsTotal + sTotal + tp * groups + g] and
+                           0xFFFF'u32)
+        let row = refDequantGroup(words, scale, bits, compander, compandA)
+        for j in 0 ..< 32:
+          result[outTotal + tp * d.tokenDim + g * 32 + j] = row[j]
+
+type KvStats* = object
+  nQuantWords*: int
+  nQuantScales*: int
+  nDequantRows*: int
+  worstRoundTrip*: float32
+
+proc runKvCombo*(engine: var auto; d: KvCase; bits, compander: int;
+                 compandA: float32; tag: string;
+                 st: var KvStats; hAll: var uint32;
+                 numLayers = 1, layer = 0): tuple[worstRt: float32, hash: uint32] =
+  ## One (bits, compander) round-trip run over the case: the reference
+  ## quant + the kernel quant (cache_seqlens = 0, binding-0 sliced:
+  ## [K words | V words | K scales | V scales]), then the reference
+  ## dequant of the reference quant + the kernel dequant of the kernel
+  ## quant (cache_seqlens = rows, binding-0 [K rows | V rows]). Runs
+  ## at layer `layer` of a `numLayers`-layer pool (defaults 1 and 0,
+  ## the plain pool). Checks: quant planes and scales and dequant
+  ## rows 100% bit-exact vs the reference implementation (NaN =
+  ## failure), the dequant |Δ| ≤ 1e-2 bound, and the round-trip worst
+  ## |Δ| ≤ 64 bound (a backstop against NaN/inf/wild out-of-slab
+  ## reads). Addressing/scale bugs are caught by the bit-exact
+  ## compares. Returns the round-trip worst |Δ| (the KERNEL path) and
+  ## the FNV hash of the combined quant + dequant outputs.
+  let groups = d.groupsPerToken
+  let poolTokens = d.numPages * 256
+  let sTotal = poolTokens * groups
+  let qWordsTotal = poolTokens * groups * bits
+  let quantLen = 2 * qWordsTotal + 2 * sTotal
+  let outTotal = poolTokens * d.tokenDim
+  var prefix = newSeq[int32](d.numSeqs)
+
+  # ── the reference quant ──
+  let expQ = refQuant(d, bits, compander, compandA, prefix)
+
+  # ── the kernel quant (cache_seqlens = 0: the appended rows) ──
+  var kq = newSeq[uint32](quantLen)
+  var rowsZero = newSeq[int32](d.numSeqs)
+  engine.run << (grid: (groups div 4, d.rows, d.numSeqs), blk: (32, 1)) >> (
+    "kvQuantD128", kq,
+    (d.kSlab, d.vSlab, d.blockTable, rowsZero,
+     int32(d.numSeqs), int32(d.maxPages), int32(d.tokenDim), int32(groups),
+     int32(qWordsTotal), int32(numLayers), int32(layer),
+     compandA, int32(bits), int32(compander)))
+
+  # ── bit-exact planes + scales ──
+  var nBitW = 0
+  var nBitS = 0
+  for i in 0 ..< 2 * qWordsTotal:
+    if kq[i] == expQ[i]: inc nBitW
+  for i in 0 ..< 2 * sTotal:
+    if (kq[2 * qWordsTotal + i] and 0xFFFF'u32) ==
+       (expQ[2 * qWordsTotal + i] and 0xFFFF'u32):
+      inc nBitS
+
+  # ── the reference dequant (of the reference quant) ──
+  let expD = refDequant(d, expQ, bits, compander, compandA, d.rows)
+
+  # ── the kernel dequant (of the kernel quant, the real path) ──
+  var qK = newSeq[uint32](qWordsTotal)
+  var qV = newSeq[uint32](qWordsTotal)
+  for i in 0 ..< qWordsTotal:
+    qK[i] = kq[i]
+    qV[i] = kq[qWordsTotal + i]
+  var sK = newSeq[uint16](sTotal)
+  var sV = newSeq[uint16](sTotal)
+  for i in 0 ..< sTotal:
+    sK[i] = uint16(kq[2 * qWordsTotal + i] and 0xFFFF'u32)
+    sV[i] = uint16(kq[2 * qWordsTotal + sTotal + i] and 0xFFFF'u32)
+  var rowsCached = newSeq[int32](d.numSeqs)
+  for i in 0 ..< d.numSeqs:
+    rowsCached[i] = int32(d.rows)
+  var kd = newSeq[uint16](2 * outTotal)
+  engine.run << (grid: (groups div 4, d.rows, d.numSeqs), blk: (32, 1)) >> (
+    "kvDequantD128", kd,
+    (qK, qV, sK, sV, d.blockTable, rowsCached,
+     int32(d.numSeqs), int32(d.maxPages), int32(d.tokenDim), int32(groups),
+     int32(outTotal), int32(numLayers), int32(layer),
+     compandA, int32(bits), int32(compander)))
+
+  # ── the dequant bit-exact check + the round-trip |Δ| (kernel path) ──
+  var nBitD = 0
+  var worst = 0.0'f32
+  var nBad = 0
+  for i in 0 ..< 2 * outTotal:
+    if kd[i] == expD[i]:
+      inc nBitD
+    else:
+      let dv = fp16ToFp32(kd[i])
+      let ov = fp16ToFp32(expD[i])
+      let dabs = abs(dv - ov)
+      if dabs != dabs or dabs > 1e-2'f32:      # NaN is a failure, not a pass
+        inc nBad
+      if dabs > worst: worst = dabs
+  var worstRt = 0.0'f32
+  var nGross = 0
+  for b in 0 ..< d.numSeqs:
+    for y in 0 ..< d.rows:
+      let tp = tokenPos(d, b, y)
+      for i in 0 ..< d.tokenDim:
+        let got = fp16ToFp32(kd[tp * d.tokenDim + i])
+        let orig = fp16ToFp32(d.kSlab[tp * d.tokenDim + i])
+        let dabs = abs(got - orig)
+        if dabs != dabs: inc nGross
+        if dabs > worstRt: worstRt = dabs
+        if dabs > 64.0'f32: inc nGross
+      for i in 0 ..< d.tokenDim:
+        let got = fp16ToFp32(kd[outTotal + tp * d.tokenDim + i])
+        let orig = fp16ToFp32(d.vSlab[tp * d.tokenDim + i])
+        let dabs = abs(got - orig)
+        if dabs != dabs: inc nGross
+        if dabs > worstRt: worstRt = dabs
+        if dabs > 64.0'f32: inc nGross
+
+  # ── the hash (quant + dequant outputs, FNV-1a) ──
+  var h = 0x811C9DC5'u32
+  fnv1a(h, kq)
+  fnv1a(h, kd)
+
+  st.nQuantWords += 2 * qWordsTotal
+  st.nQuantScales += 2 * sTotal
+  st.nDequantRows += 2 * outTotal
+  if worstRt > st.worstRoundTrip: st.worstRoundTrip = worstRt
+  fnv1a(hAll, kq)
+  fnv1a(hAll, kd)
+
+  let compName = (if compander == 0: "linear" else: "LMCubic")
+  echo &"  [{tag}] bits={bits} {compName}: quant planes {nBitW}/{2*qWordsTotal} " &
+       &"bit-exact, scales {nBitS}/{2*sTotal} bit-exact, dequant rows " &
+       &"{nBitD}/{2*outTotal} bit-exact, round-trip worst |Δ| = {worstRt:.3e} " &
+       &"(gross > 64: {nGross}), hash 0x{h:08X}"
+  if nBitW != 2 * qWordsTotal or nBitS != 2 * sTotal or nBitD != 2 * outTotal:
+    echo "  FAIL: quant planes/scales or dequant rows not bit-exact vs the " &
+         "reference implementation"
+    quit 1
+  if nBad != 0:
+    echo &"  FAIL: {nBad}/{2*outTotal} dequant elements beyond the 1e-2 bound " &
+         "or NaN"
+    quit 1
+  if nGross != 0:
+    echo "  FAIL: round-trip |Δ| > 64 (a backstop against NaN/inf/wild " &
+         "out-of-slab reads; addressing/scale bugs are caught by the " &
+         "bit-exact compares)"
+    quit 1
+  result = (worstRt, h)
+
+# ════════════════════════════════════════
+#  Fixed-value checks
+# ════════════════════════════════════════
+
+proc checkConvDrift*() =
+  ## Checks the shared fp16 conversion helpers this test's three sides
+  ## (buffer build, reference implementation, output readback) all
+  ## consume: a silent rounding-mode drift must fail loudly here, not
+  ## shift every case.
+  doAssert fp32ToFp16(1.0005'f32) == 0x3C01'u16      # RNE: 1.0005 -> 1.0009765625
+  doAssert fp32ToFp16(-1.0005'f32) == 0xBC01'u16
+  doAssert fp32ToFp16(0.1'f32) == 0x2E66'u16        # -> 0.0999755859375
+  doAssert fp32ToFp16(1.00048828125'f32) == 0x3C00'u16  # RNE tie -> even mantissa
+  doAssert fp16ToFp32(0x3C01'u16) == 1.0009765625'f32
+  doAssert fp16ToFp32(0x2E66'u16) == 0.0999755859375'f32
+
+proc checkKvDrift*() =
+  ## Checks the "exl3_kvquant" shape stream's first seed bytes and the
+  ## value generator's first outputs: a silent drift must fail loudly
+  ## here, not silently change every case's coverage.
+  var shapes = initShapeCases("exl3_kvquant")
+  let b0 = shapes.nextBytes()
+  doAssert b0[0] == 0xF6'u8 and b0[1] == 0x01'u8 and b0[2] == 0x5E'u8,
+    "exl3_kvquant:0 seed bytes changed"
+  doAssert caseInRange(b0, 0, 1, 3) == 1, "exl3_kvquant:0 num_seqs changed"
+  doAssert caseInRange(b0, 1, 0, 2) == 1, "exl3_kvquant:0 kv_heads changed"
+  var r = seedRng(shapes)
+  doAssert f16GridVal(r) == 1.625'f32, "kvquant value generator drifted"
+  doAssert f16GridVal(r) == -0.375'f32, "kvquant value generator drifted"
+
+# ════════════════════════════════════════
+#  The guard cases
+# ════════════════════════════════════════
+
+proc runAppendCase(engine: var auto; shapes: var ShapeCases;
+                   st: var KvStats; hAll: var uint32) =
+  ## The append-semantics case: the quant kernel runs with a per-seq
+  ## cached prefix (logical token y + cache_seqlens[s]), so the
+  ## appended rows' regions must match the reference implementation
+  ## and the prefix regions must stay untouched (marker 0xDEADBEEF).
+  ## Checks the addressing the round-trip cases (all prefixes 0)
+  ## cannot see.
+  echo "\n── the append-semantics case: quant with per-seq cached prefixes ──"
+  let b = shapes.nextBytes()
+  let numSeqs = caseInRange(b, 0, 1, 3)
+  let kvHeads = [1, 2, 4][caseInRange(b, 1, 0, 2)]
+  let tokenDim = kvHeads * 128
+  let groups = tokenDim div 32
+  let rows = 64 + 32 * caseInRange(b, 2, 0, 3)   # 64..160 appended rows
+  let prefix = 200 + caseInRange(b, 3, 0, 55)    # 200..255 cached rows
+  # the per-seq prefixes grow by s, so the table must cover the largest
+  # logical token: rows − 1 + prefix + num_seqs − 1. The prefix ≥ 200
+  # with rows ≥ 64 puts every appended span across the 256-token page
+  # boundary, so the composed y + cache_seqlens + page math is
+  # exercised on both pages
+  let totalRows = rows + prefix + numSeqs - 1
+  let usedPages = (totalRows + 255) div 256
+  var tables = newSeq[seq[int32]](numSeqs)
+  var idCounter = 0
+  for s in 0 ..< numSeqs:
+    var row = newSeq[int32](usedPages)
+    for j in 0 ..< usedPages:
+      row[j] = int32(idCounter)
+      let gap = (if j == usedPages - 1: 0 else: caseInRange(shapes.nextBytes(), 4 + s, 0, 1))
+      idCounter += 1 + gap
+    tables[s] = row
+  let numPages = idCounter
+  var blockTable = newSeq[int32](numSeqs * usedPages)
+  for i in 0 ..< blockTable.len:
+    blockTable[i] = -1'i32
+  for s in 0 ..< numSeqs:
+    for j in 0 ..< usedPages:
+      blockTable[s * usedPages + j] = tables[s][j]
+  var r = seedRng(shapes)
+  let slabLen = numPages * 256 * tokenDim
+  var kSlab = newSeq[uint16](slabLen)
+  var vSlab = newSeq[uint16](slabLen)
+  for i in 0 ..< slabLen:
+    kSlab[i] = fp32ToFp16(f16GridVal(r) * 2.0'f32)
+    vSlab[i] = fp32ToFp16(f16GridVal(r) * 2.0'f32)
+  let d = KvCase(numSeqs: numSeqs, kvHeads: kvHeads, tokenDim: tokenDim,
+                 groupsPerToken: groups, rows: rows, maxPages: usedPages,
+                 numPages: numPages, blockTable: blockTable,
+                 kSlab: kSlab, vSlab: vSlab)
+  var prefixSeq = newSeq[int32](numSeqs)
+  for s in 0 ..< numSeqs:
+    prefixSeq[s] = int32(prefix + s)
+  for bits in [2, 4, 8]:
+    for compander in [0, 1]:
+      let groupsL = d.groupsPerToken
+      let poolTokens = d.numPages * 256
+      let sTotal = poolTokens * groupsL
+      let qWordsTotal = poolTokens * groupsL * bits
+      let quantLen = 2 * qWordsTotal + 2 * sTotal
+      let expQ = refQuant(d, bits, compander, 0.65'f32, prefixSeq)
+      var kq = newSeq[uint32](quantLen)
+      for i in 0 ..< quantLen:
+        kq[i] = 0xDEADBEEF'u32
+      engine.run << (grid: (groupsL div 4, d.rows, d.numSeqs), blk: (32, 1)) >> (
+        "kvQuantD128", kq,
+        (d.kSlab, d.vSlab, d.blockTable, prefixSeq,
+         int32(d.numSeqs), int32(d.maxPages), int32(d.tokenDim), int32(groupsL),
+         int32(qWordsTotal), int32(1), int32(0),
+         0.65'f32, int32(bits), int32(compander)))
+      var nBitW = 0
+      var nBitS = 0
+      var nMarkW = 0
+      var nMarkS = 0
+      for i in 0 ..< 2 * qWordsTotal:
+        if kq[i] == expQ[i]:
+          inc nBitW
+        elif kq[i] == 0xDEADBEEF'u32:
+          inc nMarkW
+      for i in 0 ..< 2 * sTotal:
+        let idx = 2 * qWordsTotal + i
+        if (kq[idx] and 0xFFFF'u32) == (expQ[idx] and 0xFFFF'u32):
+          inc nBitS
+        elif kq[idx] == 0xDEADBEEF'u32:
+          inc nMarkS
+      let writtenW = 2 * qWordsTotal - nMarkW
+      let writtenS = 2 * sTotal - nMarkS
+      let compName = (if compander == 0: "linear" else: "LMCubic")
+      echo &"  bits={bits} {compName}: appended-region words {nBitW}/{writtenW} " &
+           &"and scales {nBitS}/{writtenS} bit-exact vs the reference " &
+           &"implementation, {nMarkW + nMarkS} untouched prefix slots"
+      if nBitW != writtenW or nBitS != writtenS:
+        echo "  FAIL: the appended rows' quant regions must match the reference implementation"
+        quit 1
+      if nMarkW + nMarkS == 0:
+        echo "  FAIL: the prefix regions must stay untouched (marker)"
+        quit 1
+      var h = 0x811C9DC5'u32
+      fnv1a(h, kq)
+      fnv1a(hAll, kq)
+      st.nQuantWords += nBitW
+      st.nQuantScales += nBitS
+      echo &"    append hash 0x{h:08X}"
+
+proc runBoundaryCase(engine: var auto; shapes: var ShapeCases;
+                     st: var KvStats; hAll: var uint32) =
+  ## The dequant boundary case: cache_seqlens < rows into a
+  ## 0x7C00-prefilled uint16 buffer. Rows ≥ cache_seqlens must stay
+  ## 0x7C00 and rows < cache_seqlens must match the reference dequant
+  ## of the reference quant. Checks the dequant kernel's row guard.
+  echo "\n── the dequant boundary case: cache_seqlens < rows, 0x7C00 prefill ──"
+  let b = shapes.nextBytes()
+  let numSeqs = caseInRange(b, 0, 1, 3)
+  let kvHeads = [1, 2, 4][caseInRange(b, 1, 0, 2)]
+  let tokenDim = kvHeads * 128
+  let groups = tokenDim div 32
+  let rows = 64 + 32 * caseInRange(b, 2, 0, 3)
+  let usedPages = (rows + 255) div 256
+  var tables = newSeq[seq[int32]](numSeqs)
+  var idCounter = 0
+  for s in 0 ..< numSeqs:
+    var row = newSeq[int32](usedPages)
+    for j in 0 ..< usedPages:
+      row[j] = int32(idCounter)
+      let gap = (if j == usedPages - 1: 0 else: caseInRange(shapes.nextBytes(), 3 + s, 0, 1))
+      idCounter += 1 + gap
+    tables[s] = row
+  let numPages = idCounter
+  var blockTable = newSeq[int32](numSeqs * usedPages)
+  for i in 0 ..< blockTable.len:
+    blockTable[i] = -1'i32
+  for s in 0 ..< numSeqs:
+    for j in 0 ..< usedPages:
+      blockTable[s * usedPages + j] = tables[s][j]
+  var r = seedRng(shapes)
+  let slabLen = numPages * 256 * tokenDim
+  var kSlab = newSeq[uint16](slabLen)
+  var vSlab = newSeq[uint16](slabLen)
+  for i in 0 ..< slabLen:
+    kSlab[i] = fp32ToFp16(f16GridVal(r) * 2.0'f32)
+    vSlab[i] = fp32ToFp16(f16GridVal(r) * 2.0'f32)
+  let d = KvCase(numSeqs: numSeqs, kvHeads: kvHeads, tokenDim: tokenDim,
+                 groupsPerToken: groups, rows: rows, maxPages: usedPages,
+                 numPages: numPages, blockTable: blockTable,
+                 kSlab: kSlab, vSlab: vSlab)
+  # the covered prefix per seq: rows − (1 + s) keeps the guard live
+  var cached = newSeq[int32](numSeqs)
+  for s in 0 ..< numSeqs:
+    cached[s] = int32(rows - 1 - s)
+  for bits in [2, 4, 8]:
+    for compander in [0, 1]:
+      let groupsL = d.groupsPerToken
+      let poolTokens = d.numPages * 256
+      let sTotal = poolTokens * groupsL
+      let qWordsTotal = poolTokens * groupsL * bits
+      let outTotal = poolTokens * d.tokenDim
+      let quantLen = 2 * qWordsTotal + 2 * sTotal
+      var prefix = newSeq[int32](d.numSeqs)
+      let expQ = refQuant(d, bits, compander, 0.65'f32, prefix)
+      let expD = refDequant(d, expQ, bits, compander, 0.65'f32, rows)
+      # the kernel quant covers all rows (cache_seqlens = 0)
+      var kq = newSeq[uint32](quantLen)
+      var rowsZero = newSeq[int32](d.numSeqs)
+      engine.run << (grid: (groupsL div 4, d.rows, d.numSeqs), blk: (32, 1)) >> (
+        "kvQuantD128", kq,
+        (d.kSlab, d.vSlab, d.blockTable, rowsZero,
+         int32(d.numSeqs), int32(d.maxPages), int32(d.tokenDim), int32(groupsL),
+         int32(qWordsTotal), int32(1), int32(0),
+         0.65'f32, int32(bits), int32(compander)))
+      var qK = newSeq[uint32](qWordsTotal)
+      var qV = newSeq[uint32](qWordsTotal)
+      for i in 0 ..< qWordsTotal:
+        qK[i] = kq[i]
+        qV[i] = kq[qWordsTotal + i]
+      var sK = newSeq[uint16](sTotal)
+      var sV = newSeq[uint16](sTotal)
+      for i in 0 ..< sTotal:
+        sK[i] = uint16(kq[2 * qWordsTotal + i] and 0xFFFF'u32)
+        sV[i] = uint16(kq[2 * qWordsTotal + sTotal + i] and 0xFFFF'u32)
+      var kd = newSeq[uint16](2 * outTotal)
+      for i in 0 ..< kd.len:
+        kd[i] = 0x7C00'u16
+      engine.run << (grid: (groupsL div 4, d.rows, d.numSeqs), blk: (32, 1)) >> (
+        "kvDequantD128", kd,
+        (qK, qV, sK, sV, d.blockTable, cached,
+         int32(d.numSeqs), int32(d.maxPages), int32(d.tokenDim), int32(groupsL),
+         int32(outTotal), int32(1), int32(0),
+         0.65'f32, int32(bits), int32(compander)))
+      # The covered rows must match the reference implementation. The guard rows must stay 0x7C00.
+      var nBit = 0
+      var nGuard = 0
+      var nGuardBad = 0
+      for s in 0 ..< d.numSeqs:
+        for y in 0 ..< int(cached[s]):
+          let tp = tokenPos(d, s, y)
+          for i in 0 ..< d.tokenDim:
+            if kd[tp * d.tokenDim + i] == expD[tp * d.tokenDim + i]:
+              inc nBit
+            else:
+              echo "  FAIL: a covered K row differs from the reference implementation"
+              quit 1
+            if kd[outTotal + tp * d.tokenDim + i] ==
+               expD[outTotal + tp * d.tokenDim + i]:
+              inc nBit
+            else:
+              echo "  FAIL: a covered V row differs from the reference implementation"
+              quit 1
+        for y in int(cached[s]) ..< d.rows:
+          let tp = tokenPos(d, s, y)
+          for i in 0 ..< d.tokenDim:
+            inc nGuard
+            if kd[tp * d.tokenDim + i] != 0x7C00'u16:
+              inc nGuardBad
+            if kd[outTotal + tp * d.tokenDim + i] != 0x7C00'u16:
+              inc nGuardBad
+      let compName = (if compander == 0: "linear" else: "LMCubic")
+      echo &"  bits={bits} {compName}: covered rows {nBit} bit-exact vs the " &
+           &"reference implementation, {nGuard} guard slots untouched " &
+           &"({nGuardBad} violations)"
+      if nGuardBad != 0:
+        echo "  FAIL: the dequant row guard wrote past cache_seqlens"
+        quit 1
+      st.nDequantRows += nBit
+      var h = 0x811C9DC5'u32
+      fnv1a(h, kd)
+      fnv1a(hAll, kd)
+      echo &"    boundary hash 0x{h:08X}"
+
+proc kvRoundTrip(
+    kf, vf: seq[float32], blockTable: seq[int32],
+    numPages, numLayers, layer, numSeqs, maxPages, rows, kvHeads, D,
+    bits, compander: int): tuple[rt, cross: float32] =
+  ## Quant then dequant round trip at one fixed (bits, compander) combo
+  ## on layer `layer` of a flat layer-major pool. Returns the worst
+  ## |Δ| of the dequant rows vs the fp16 slab they came from (`rt`)
+  ## and vs the same page/token of layer 0 (`cross`).
+  let tokenDim = kvHeads * D
+  let groups = tokenDim div 32
+  let poolTokens = numPages * numLayers * 256
+  let qWordsTotal = poolTokens * groups * bits
+  let sTotal = qWordsTotal shr int(log2(float(bits)))
+  let quantLen = 2 * qWordsTotal + 2 * sTotal
+  let outTotal = poolTokens * tokenDim
+  let compandA = (if compander == 0: 0.0'f32 else: 0.65'f32)
+  var kSlab = newSeq[uint16](poolTokens * tokenDim)
+  var vSlab = newSeq[uint16](poolTokens * tokenDim)
+  for i in 0 ..< poolTokens * tokenDim:
+    kSlab[i] = fp32ToFp16(kf[i])
+    vSlab[i] = fp32ToFp16(vf[i])
+  var engine = bkMetal.init()
+  engine.ingest(kvquantMsl)
+  var cacheZero = newSeq[int32](numSeqs)
+  var cacheRows = newSeq[int32](numSeqs)
+  for i in 0 ..< numSeqs:
+    cacheRows[i] = int32(rows)
+  var outBuf = newSeq[uint32](quantLen)
+  engine.run << (grid: (groups div 4, rows, numSeqs), blk: (32, 1)) >> (
+    "kvQuantD128", outBuf,
+    (kSlab, vSlab, blockTable, cacheZero,
+     int32(numSeqs), int32(maxPages), int32(tokenDim),
+     int32(groups), int32(qWordsTotal),
+     int32(numLayers), int32(layer), compandA,
+     int32(bits), int32(compander)))
+  var qK = newSeq[uint32](qWordsTotal)
+  var qV = newSeq[uint32](qWordsTotal)
+  var sK = newSeq[uint16](sTotal)
+  var sV = newSeq[uint16](sTotal)
+  for i in 0 ..< qWordsTotal:
+    qK[i] = outBuf[i]
+    qV[i] = outBuf[qWordsTotal + i]
+  for i in 0 ..< sTotal:
+    sK[i] = uint16(outBuf[2 * qWordsTotal + i])
+    sV[i] = uint16(outBuf[2 * qWordsTotal + sTotal + i])
+  var kd = newSeq[uint16](2 * outTotal)
+  engine.run << (grid: (groups div 4, rows, numSeqs), blk: (32, 1)) >> (
+    "kvDequantD128", kd,
+    (qK, qV, sK, sV, blockTable, cacheRows,
+     int32(numSeqs), int32(maxPages), int32(tokenDim),
+     int32(groups), int32(outTotal),
+     int32(numLayers), int32(layer), compandA,
+     int32(bits), int32(compander)))
+  var rt = 0.0'f32
+  var cross = 0.0'f32
+  for b in 0 ..< numSeqs:
+    for y in 0 ..< rows:
+      let pageIdx = y shr 8
+      let pageId = blockTable[b * maxPages + pageIdx].int
+      let tp = pageId * numLayers * 256 + layer * 256 + (y and 255)
+      let pos = tp * tokenDim
+      let posL0 = pos - layer * 256 * tokenDim
+      for i in 0 ..< tokenDim:
+        let a = fp16ToFp32(kd[pos + i])
+        let aV = fp16ToFp32(kd[outTotal + pos + i])
+        let s1 = fp16ToFp32(kSlab[pos + i])
+        let s1V = fp16ToFp32(vSlab[pos + i])
+        let s0 = fp16ToFp32(kSlab[posL0 + i])
+        let s0V = fp16ToFp32(vSlab[posL0 + i])
+        rt = max(rt, abs(a - s1))
+        rt = max(rt, abs(aV - s1V))
+        cross = max(cross, abs(a - s0))
+        cross = max(cross, abs(aV - s0V))
+  (rt, cross)
+
+proc checkKvQuant() =
+  ## Two fixed (bits, compander) combos on layer 1 of a layer-major
+  ## pool with a gapped block table: the dequant rows must reconstruct
+  ## layer 1's slab within the lossy bound and must NOT match layer
+  ## 0's content. Layer 1 holds 100× layer 0's values: a missing layer
+  ## term leaves layer 1's rows unwritten (zeros), which the rt ≤ 64
+  ## bound rejects (amplitude 100–200), and a wrong page stride reads
+  ## layer 0's rows, which the cross > 64 bound rejects.
+  randomize(0x5EED)
+  let numPages = 4
+  let numLayers = 2
+  let layer = 1
+  let numSeqs = 2
+  let maxPages = 2
+  let rows = 300
+  let kvHeads = 2
+  let D = 128
+  let tokenDim = kvHeads * D
+  let blockTable = [0'i32, 3, 1, 2].toSeq()
+  let poolTokens = numPages * numLayers * 256
+  var kf = newSeq[float32](poolTokens * tokenDim)
+  var vf = newSeq[float32](poolTokens * tokenDim)
+  for p in 0 ..< numPages:
+    for l in 0 ..< numLayers:
+      for t in 0 ..< 256:
+        for d in 0 ..< tokenDim:
+          let base = 1.0'f32 + rand(1.0'f32)
+          let idx = (p * numLayers + l) * 256 * tokenDim + t * tokenDim + d
+          kf[idx] = (if l == 1: 100.0'f32 * base else: base)
+          vf[idx] = (if l == 1: 100.0'f32 * base else: base)
+  for (bits, compander) in [(8, 0), (8, 1)]:
+    let (rt, cross) = kvRoundTrip(kf, vf, blockTable, numPages, numLayers,
+                                  layer, numSeqs, maxPages, rows, kvHeads,
+                                  D, bits, compander)
+    echo &"  bits={bits} compander={compander}: rt worst |Δ| = {rt} cross |Δ| = {cross}"
+    doAssert rt <= 64.0'f32, "round-trip error exceeds the lossy bound"
+    doAssert cross > 64.0'f32, "dequant output matches layer 0's content"
+
+proc runCompanderSpot(engine: var auto) =
+  ## The LMCubic compander's runtime `a` at a second operating point
+  ## (a = 0.5, bits 2): the quant planes/scales + dequant rows must stay
+  ## bit-exact vs the host reference implementation at a = 0.5. The
+  ## fixed kv_heads=1 geometry (4 groups, grid.x = 1, 2 pages crossing
+  ## 255/256, gapped page ids) also checks the group-count-1 launch
+  ## shape end-to-end. Its slab comes from a fixed seed so the shape
+  ## stream is untouched. Local accumulator, deliberately outside
+  ## `hAll` and `st`, so this check adds no re-verification burden.
+  echo "\n── the LMCubic compander at a = 0.5 (kv_heads 1, bits 2, LMCubic) ──"
+  let maxPagesA05 = 2
+  let numPagesA05 = 6
+  let blockTableA05 = @[0'i32, 2'i32, 3'i32, 5'i32]  # seq0: pages 0,2 · seq1: pages 3,5
+  var rA05 = XorShift(s: 0xA05A05'u32)
+  let slabLenA05 = numPagesA05 * 256 * 128
+  var kSlabA05 = newSeq[uint16](slabLenA05)
+  var vSlabA05 = newSeq[uint16](slabLenA05)
+  for i in 0 ..< slabLenA05:
+    kSlabA05[i] = fp32ToFp16(f16GridVal(rA05) * 2.0'f32)
+    vSlabA05[i] = fp32ToFp16(f16GridVal(rA05) * 2.0'f32)
+  let dA05 = KvCase(numSeqs: 2, kvHeads: 1, tokenDim: 128,
+                    groupsPerToken: 4, rows: 300, maxPages: maxPagesA05,
+                    numPages: numPagesA05, blockTable: blockTableA05,
+                    kSlab: kSlabA05, vSlab: vSlabA05)
+  var stA05: KvStats
+  var hA05 = 0x811C9DC5'u32
+  discard runKvCombo(engine, dA05, 2, 1, 0.5'f32, tag = "a05", stA05, hA05)
+
+# ════════════════════════════════════════
+#  runKvQuantSuite
+# ════════════════════════════════════════
+
+proc runKvQuantSuite*(engine: var auto; shapes: var ShapeCases): uint32 =
+  ## The full kvquant suite: the drift checks, the 3 round-trip paged
+  ## geometries × bits {2,4,8} × {linear, LMCubic} (quant planes,
+  ## scales and dequant rows bit-exact vs the host reference
+  ## implementation, round-trip |Δ| bounded), the append-semantics
+  ## and dequant-boundary guard cases, the layer-major separation
+  ## spot, and the LMCubic a = 0.5 spot. Prints per-combo
+  ## diagnostics, the round-trip error table and the aggregate.
+  ## Returns the combined FNV hash of the round-trip, append and
+  ## boundary outputs (the caller asserts it against the pinned
+  ## value). Each combo gates its own checks with a hard `quit 1`,
+  ## so the returned hash is only reached when every check passed.
+  checkConvDrift()
+  checkKvDrift()
+
+  echo "\n── paged KV quant/dequant vs the q_cache_kernels.cuh reference implementation ──"
+  var worstByBits: array[9, array[2, float32]]
+  var st: KvStats
+  var hAll = 0x811C9DC5'u32
+  for dIdx in 0 ..< 3:
+    var d = buildKvCase(shapes)
+    echo &"  case {dIdx}: num_seqs={d.numSeqs} kv_heads={d.kvHeads} " &
+         &"token_dim={d.tokenDim} groups_per_token={d.groupsPerToken} " &
+         &"rows={d.rows} pages_per_seq={(d.rows + 255) div 256} " &
+         &"num_pages={d.numPages} (gapped)"
+    for bits in [2, 4, 8]:
+      for compander in [0, 1]:
+        let res = runKvCombo(engine, d, bits, compander, 0.65'f32,
+                             tag = &"case{dIdx}", st, hAll)
+        worstByBits[bits][compander] = max(worstByBits[bits][compander], res.worstRt)
+        if dIdx == 0:
+          # hash checks: the first case's combos must never drift
+          let knownHashes: array[9, array[2, uint32]] = [
+            [0x00000000'u32, 0x00000000'u32],   # bits 0 (unused)
+            [0x00000000'u32, 0x00000000'u32],
+            [0x8FF6034F'u32, 0x8D0CE614'u32],   # bits 2: linear, LMCubic
+            [0x00000000'u32, 0x00000000'u32],
+            [0x9CB3D317'u32, 0xD54573C3'u32],   # bits 4: linear, LMCubic
+            [0x00000000'u32, 0x00000000'u32],
+            [0x00000000'u32, 0x00000000'u32],
+            [0x00000000'u32, 0x00000000'u32],
+            [0x1138BC67'u32, 0x3C05071A'u32]]   # bits 8: linear, LMCubic
+          doAssert res.hash == knownHashes[bits][compander],
+            &"case 0 bits={bits} compander={compander} hash drifted"
+  runAppendCase(engine, shapes, st, hAll)
+  runBoundaryCase(engine, shapes, st, hAll)
+  checkKvQuant()
+  runCompanderSpot(engine)
+
+  echo "\n── round-trip reconstruction error per bits (kernel path, worst |Δ| " &
+       "over all cases) ──"
+  echo "  bits |      linear |      LMCubic | LMCubic-vs-linear spread"
+  for bits in [2, 4, 8]:
+    let lin = worstByBits[bits][0]
+    let cub = worstByBits[bits][1]
+    echo &"  {bits:>4} | {lin:>10.3e} | {cub:>10.3e} | {cub - lin:+.3e}"
+  echo "\n── aggregate ──"
+  echo &"  quant words {st.nQuantWords} bit-exact, scales {st.nQuantScales} " &
+       &"bit-exact, dequant rows {st.nDequantRows} bit-exact, " &
+       &"round-trip worst |Δ| = " &
+       &"{st.worstRoundTrip:.3e}, combined hash 0x{hAll:08X}"
+  echo "\nkvquant check: quant planes + scales and dequant rows BIT-EXACT vs the " &
+       "q_cache_kernels.cuh reference implementation across bits {2,4,8} × " &
+       "{linear, LMCubic} at head_dim 128 on the 3 round-trip geometries " &
+       "(the kernel dequant consumes the kernel quant — the real path); the " &
+       "append-semantics case checks the y + cache_seqlens addressing with " &
+       "marker-guarded prefix regions; the dequant boundary case checks the " &
+       "row guard with a 0x7C00 prefill; the round-trip |Δ| table is the " &
+       "lossy quantizer's documented reconstruction error"
+  result = hAll

--- a/workspace/positron/tests/exl3_kvquant_test_utils.nim
+++ b/workspace/positron/tests/exl3_kvquant_test_utils.nim
@@ -491,15 +491,14 @@ type KvStats* = object
 
 proc runKvCombo*(engine: var auto; d: KvCase; bits, compander: int;
                  compandA: float32; tag: string;
-                 st: var KvStats; hAll: var uint32;
-                 numLayers = 1, layer = 0): tuple[worstRt: float32, hash: uint32] =
+                 st: var KvStats; hAll: var uint32): tuple[worstRt: float32, hash: uint32] =
   ## One (bits, compander) round-trip run over the case: the reference
   ## quant + the kernel quant (cache_seqlens = 0, binding-0 sliced:
   ## [K words | V words | K scales | V scales]), then the reference
   ## dequant of the reference quant + the kernel dequant of the kernel
-  ## quant (cache_seqlens = rows, binding-0 [K rows | V rows]). Runs
-  ## at layer `layer` of a `numLayers`-layer pool (defaults 1 and 0,
-  ## the plain pool). Checks: quant planes and scales and dequant
+  ## quant (cache_seqlens = rows, binding-0 [K rows | V rows]). Runs at
+  ## layer 0 of a 1-layer pool (the plain pool). Checks: quant planes
+  ## and scales and dequant
   ## rows 100% bit-exact vs the reference implementation (NaN =
   ## failure), the dequant |Δ| ≤ 1e-2 bound, and the round-trip worst
   ## |Δ| ≤ 64 bound (a backstop against NaN/inf/wild out-of-slab
@@ -524,7 +523,7 @@ proc runKvCombo*(engine: var auto; d: KvCase; bits, compander: int;
     "kvQuantD128", kq,
     (d.kSlab, d.vSlab, d.blockTable, rowsZero,
      int32(d.numSeqs), int32(d.maxPages), int32(d.tokenDim), int32(groups),
-     int32(qWordsTotal), int32(numLayers), int32(layer),
+     int32(qWordsTotal), int32(1), int32(0),
      compandA, int32(bits), int32(compander)))
 
   # ── bit-exact planes + scales ──
@@ -559,7 +558,7 @@ proc runKvCombo*(engine: var auto; d: KvCase; bits, compander: int;
     "kvDequantD128", kd,
     (qK, qV, sK, sV, d.blockTable, rowsCached,
      int32(d.numSeqs), int32(d.maxPages), int32(d.tokenDim), int32(groups),
-     int32(outTotal), int32(numLayers), int32(layer),
+     int32(outTotal), int32(1), int32(0),
      compandA, int32(bits), int32(compander)))
 
   # ── the dequant bit-exact check + the round-trip |Δ| (kernel path) ──

--- a/workspace/positron/tests/manual_exl3_kvquant_fp16.nim
+++ b/workspace/positron/tests/manual_exl3_kvquant_fp16.nim
@@ -6,189 +6,33 @@
 ## at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 ##
-## Round-trip test for the paged KV quant/dequant kernels on a layer-major pool:
-## `kv_quant_fwd` then `kv_dequant_fwd` at two fixed (bits, compander) combos,
-## comparing the dequant rows to the fp16 slab they came from (lossy bound)
-## and to the same page/token of layer 0 (the layer-major separation check).
-## Layer 1 holds 100× layer 0's values: a missing layer term leaves layer 1's
-## rows unwritten (zeros), which the rt ≤ 64 bound rejects (amplitude 100–200),
-## and a wrong page stride reads layer 0's rows, which the cross > 64 bound
-## rejects.
+## Paged KV quant/dequant vs the q_cache_kernels.cuh reference
+## implementation on a layer-major pool: 3 deterministic paged
+## geometries × bits {2,4,8} × {linear, LMCubic} round trips, the
+## append-semantics and dequant-boundary cases, and the layer-1 vs
+## layer-0 separation spot. Internals live in
+## exl3_kvquant_test_utils.
 ##
 ## Run: nim cpp -r --hints:off --warnings:off \
 ##   --outdir:build/wip \
 ##   --nimcache:nimcache/wip \
 ##   workspace/positron/tests/manual_exl3_kvquant_fp16.nim
 
-import std/[strformat, math, random, sequtils]
 import workspace/crucible
 import workspace/ceramic
 import workspace/libtorch_testutils
 import ../../ceramic/tests/tile_test_utils
-import ../src/kernels/ceramic/exl3_kvquant
+import ./exl3_kvquant_test_utils
 
-const kvquantMsl = metal:
-  proc kvQuantB8L0(
-      outBuf: ptr UncheckedArray[uint32],
-      kIn, vIn: ptr UncheckedArray[uint16],
-      block_table, cache_seqlens: ptr UncheckedArray[int32],
-      num_seqs, max_pages, token_dim, groups_per_token, q_words_total,
-      num_layers, layer: int32, compand_a: float32) {.global.} =
-    kv_quant_fwd(outBuf, kIn, vIn, block_table, cache_seqlens,
-                 num_seqs, max_pages, token_dim, groups_per_token,
-                 q_words_total, num_layers, layer, compand_a, 8, 0, 256, 128)
-
-  proc kvDequantB8L0(
-      outBuf: ptr UncheckedArray[uint16],
-      qK, qV: ptr UncheckedArray[uint32],
-      sK, sV: ptr UncheckedArray[uint16],
-      block_table, cache_seqlens: ptr UncheckedArray[int32],
-      num_seqs, max_pages, token_dim, groups_per_token, out_total,
-      num_layers, layer: int32, compand_a: float32) {.global.} =
-    kv_dequant_fwd(outBuf, qK, qV, sK, sV, block_table, cache_seqlens,
-                   num_seqs, max_pages, token_dim, groups_per_token,
-                   out_total, num_layers, layer, compand_a, 8, 0, 256, 128)
-
-  proc kvQuantB8L1(
-      outBuf: ptr UncheckedArray[uint32],
-      kIn, vIn: ptr UncheckedArray[uint16],
-      block_table, cache_seqlens: ptr UncheckedArray[int32],
-      num_seqs, max_pages, token_dim, groups_per_token, q_words_total,
-      num_layers, layer: int32, compand_a: float32) {.global.} =
-    kv_quant_fwd(outBuf, kIn, vIn, block_table, cache_seqlens,
-                 num_seqs, max_pages, token_dim, groups_per_token,
-                 q_words_total, num_layers, layer, compand_a, 8, 1, 256, 128)
-
-  proc kvDequantB8L1(
-      outBuf: ptr UncheckedArray[uint16],
-      qK, qV: ptr UncheckedArray[uint32],
-      sK, sV: ptr UncheckedArray[uint16],
-      block_table, cache_seqlens: ptr UncheckedArray[int32],
-      num_seqs, max_pages, token_dim, groups_per_token, out_total,
-      num_layers, layer: int32, compand_a: float32) {.global.} =
-    kv_dequant_fwd(outBuf, qK, qV, sK, sV, block_table, cache_seqlens,
-                   num_seqs, max_pages, token_dim, groups_per_token,
-                   out_total, num_layers, layer, compand_a, 8, 1, 256, 128)
-
-proc kvRoundTrip(
-    kf, vf: seq[float32], blockTable: seq[int32],
-    numPages, numLayers, layer, numSeqs, maxPages, rows, kvHeads, D,
-    bits, compander: int): tuple[rt, cross: float32] =
-  ## Quant then dequant round trip at one fixed (bits, compander) combo
-  ## on layer `layer` of a flat layer-major pool. Returns the worst
-  ## |Δ| of the dequant rows vs the fp16 slab they came from (`rt`)
-  ## and vs the same page/token of layer 0 (`cross`).
-  let tokenDim = kvHeads * D
-  let groups = tokenDim div 32
-  let poolTokens = numPages * numLayers * 256
-  let qWordsTotal = poolTokens * groups * bits
-  let sTotal = qWordsTotal shr int(log2(float(bits)))
-  let quantLen = 2 * qWordsTotal + 2 * sTotal
-  let outTotal = poolTokens * tokenDim
-  let compandA = (if compander == 0: 0.0'f32 else: 0.65'f32)
-  var kSlab = newSeq[uint16](poolTokens * tokenDim)
-  var vSlab = newSeq[uint16](poolTokens * tokenDim)
-  for i in 0 ..< poolTokens * tokenDim:
-    kSlab[i] = fp32ToFp16(kf[i])
-    vSlab[i] = fp32ToFp16(vf[i])
+proc runTest(): bool =
+  var shapes = initShapeCases("exl3_kvquant")
   var engine = bkMetal.init()
   engine.ingest(kvquantMsl)
-  var cacheZero = newSeq[int32](numSeqs)
-  var cacheRows = newSeq[int32](numSeqs)
-  for i in 0 ..< numSeqs:
-    cacheRows[i] = int32(rows)
-  var outBuf = newSeq[uint32](quantLen)
-  let qArgs = (kSlab, vSlab, blockTable, cacheZero,
-               int32(numSeqs), int32(maxPages), int32(tokenDim),
-               int32(groups), int32(qWordsTotal),
-               int32(numLayers), int32(layer), compandA)
-  if bits == 8 and compander == 0:
-    engine.run << (grid: (groups div 4, rows, numSeqs), blk: (32, 1)) >>
-      ("kvQuantB8L0", outBuf, qArgs)
-  else:
-    engine.run << (grid: (groups div 4, rows, numSeqs), blk: (32, 1)) >>
-      ("kvQuantB8L1", outBuf, qArgs)
-  var qK = newSeq[uint32](qWordsTotal)
-  var qV = newSeq[uint32](qWordsTotal)
-  var sK = newSeq[uint16](sTotal)
-  var sV = newSeq[uint16](sTotal)
-  for i in 0 ..< qWordsTotal:
-    qK[i] = outBuf[i]
-    qV[i] = outBuf[qWordsTotal + i]
-  for i in 0 ..< sTotal:
-    sK[i] = uint16(outBuf[2 * qWordsTotal + i])
-    sV[i] = uint16(outBuf[2 * qWordsTotal + sTotal + i])
-  var kd = newSeq[uint16](2 * outTotal)
-  let dArgs = (qK, qV, sK, sV, blockTable, cacheRows,
-               int32(numSeqs), int32(maxPages), int32(tokenDim),
-               int32(groups), int32(outTotal),
-               int32(numLayers), int32(layer), compandA)
-  if bits == 8 and compander == 0:
-    engine.run << (grid: (groups div 4, rows, numSeqs), blk: (32, 1)) >>
-      ("kvDequantB8L0", kd, dArgs)
-  else:
-    engine.run << (grid: (groups div 4, rows, numSeqs), blk: (32, 1)) >>
-      ("kvDequantB8L1", kd, dArgs)
-  var rt = 0.0'f32
-  var cross = 0.0'f32
-  for b in 0 ..< numSeqs:
-    for y in 0 ..< rows:
-      let pageIdx = y shr 8
-      let pageId = blockTable[b * maxPages + pageIdx].int
-      let tp = pageId * numLayers * 256 + layer * 256 + (y and 255)
-      let pos = tp * tokenDim
-      let posL0 = pos - layer * 256 * tokenDim
-      for i in 0 ..< tokenDim:
-        let a = fp16ToFp32(kd[pos + i])
-        let aV = fp16ToFp32(kd[outTotal + pos + i])
-        let s1 = fp16ToFp32(kSlab[pos + i])
-        let s1V = fp16ToFp32(vSlab[pos + i])
-        let s0 = fp16ToFp32(kSlab[posL0 + i])
-        let s0V = fp16ToFp32(vSlab[posL0 + i])
-        rt = max(rt, abs(a - s1))
-        rt = max(rt, abs(aV - s1V))
-        cross = max(cross, abs(a - s0))
-        cross = max(cross, abs(aV - s0V))
-  (rt, cross)
-
-proc checkKvQuant(): bool =
-  ## Two fixed (bits, compander) combos on layer 1 of a layer-major
-  ## pool with a gapped block table: the dequant rows must reconstruct
-  ## layer 1's slab within the lossy bound and must NOT match layer
-  ## 0's content. Layer 1 holds 100× layer 0's values: a missing layer
-  ## term leaves layer 1's rows unwritten (zeros), which the rt ≤ 64
-  ## bound rejects (amplitude 100–200), and a wrong page stride reads
-  ## layer 0's rows, which the cross > 64 bound rejects.
-  randomize(0x5EED)
-  let numPages = 4
-  let numLayers = 2
-  let layer = 1
-  let numSeqs = 2
-  let maxPages = 2
-  let rows = 300
-  let kvHeads = 2
-  let D = 128
-  let tokenDim = kvHeads * D
-  let blockTable = [0'i32, 3, 1, 2].toSeq()
-  let poolTokens = numPages * numLayers * 256
-  var kf = newSeq[float32](poolTokens * tokenDim)
-  var vf = newSeq[float32](poolTokens * tokenDim)
-  for p in 0 ..< numPages:
-    for l in 0 ..< numLayers:
-      for t in 0 ..< 256:
-        for d in 0 ..< tokenDim:
-          let base = 1.0'f32 + rand(1.0'f32)
-          let idx = (p * numLayers + l) * 256 * tokenDim + t * tokenDim + d
-          kf[idx] = (if l == 1: 100.0'f32 * base else: base)
-          vf[idx] = (if l == 1: 100.0'f32 * base else: base)
-  for (bits, compander) in [(8, 0), (8, 1)]:
-    let (rt, cross) = kvRoundTrip(kf, vf, blockTable, numPages, numLayers,
-                                  layer, numSeqs, maxPages, rows, kvHeads,
-                                  D, bits, compander)
-    echo &"  bits={bits} compander={compander}: rt worst |Δ| = {rt} cross |Δ| = {cross}"
-    doAssert rt <= 64.0'f32, "round-trip error exceeds the lossy bound"
-    doAssert cross > 64.0'f32, "dequant output matches layer 0's content"
+  echo kvquantMsl            # keep the generated MSL inspectable
+  let hAll = runKvQuantSuite(engine, shapes)
+  doAssert hAll == 0xEC3758D5'u32,
+    "the combined quant+dequant hash drifted"
   result = true
 
 when isMainModule:
-  runCppTest("kvquant round trip on a layer-major pool", checkKvQuant)
+  runCppTest("kvquant vs the q_cache_kernels.cuh reference + layer-major pool", runTest)

--- a/workspace/positron/tests/manual_exl3_kvquant_fp16.nim
+++ b/workspace/positron/tests/manual_exl3_kvquant_fp16.nim
@@ -1,0 +1,194 @@
+## Tattletale
+## Copyright (c) 2026 Mamy André-Ratsimbazafy
+## Licensed and distributed under either of
+##   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+##   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+## at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+##
+## Round-trip test for the paged KV quant/dequant kernels on a layer-major pool:
+## `kv_quant_fwd` then `kv_dequant_fwd` at two fixed (bits, compander) combos,
+## comparing the dequant rows to the fp16 slab they came from (lossy bound)
+## and to the same page/token of layer 0 (the layer-major separation check).
+## Layer 1 holds 100× layer 0's values: a missing layer term leaves layer 1's
+## rows unwritten (zeros), which the rt ≤ 64 bound rejects (amplitude 100–200),
+## and a wrong page stride reads layer 0's rows, which the cross > 64 bound
+## rejects.
+##
+## Run: nim cpp -r --hints:off --warnings:off \
+##   --outdir:build/wip \
+##   --nimcache:nimcache/wip \
+##   workspace/positron/tests/manual_exl3_kvquant_fp16.nim
+
+import std/[strformat, math, random, sequtils]
+import workspace/crucible
+import workspace/ceramic
+import workspace/libtorch_testutils
+import ../../ceramic/tests/tile_test_utils
+import ../src/kernels/ceramic/exl3_kvquant
+
+const kvquantMsl = metal:
+  proc kvQuantB8L0(
+      outBuf: ptr UncheckedArray[uint32],
+      kIn, vIn: ptr UncheckedArray[uint16],
+      block_table, cache_seqlens: ptr UncheckedArray[int32],
+      num_seqs, max_pages, token_dim, groups_per_token, q_words_total,
+      num_layers, layer: int32, compand_a: float32) {.global.} =
+    kv_quant_fwd(outBuf, kIn, vIn, block_table, cache_seqlens,
+                 num_seqs, max_pages, token_dim, groups_per_token,
+                 q_words_total, num_layers, layer, compand_a, 8, 0, 256, 128)
+
+  proc kvDequantB8L0(
+      outBuf: ptr UncheckedArray[uint16],
+      qK, qV: ptr UncheckedArray[uint32],
+      sK, sV: ptr UncheckedArray[uint16],
+      block_table, cache_seqlens: ptr UncheckedArray[int32],
+      num_seqs, max_pages, token_dim, groups_per_token, out_total,
+      num_layers, layer: int32, compand_a: float32) {.global.} =
+    kv_dequant_fwd(outBuf, qK, qV, sK, sV, block_table, cache_seqlens,
+                   num_seqs, max_pages, token_dim, groups_per_token,
+                   out_total, num_layers, layer, compand_a, 8, 0, 256, 128)
+
+  proc kvQuantB8L1(
+      outBuf: ptr UncheckedArray[uint32],
+      kIn, vIn: ptr UncheckedArray[uint16],
+      block_table, cache_seqlens: ptr UncheckedArray[int32],
+      num_seqs, max_pages, token_dim, groups_per_token, q_words_total,
+      num_layers, layer: int32, compand_a: float32) {.global.} =
+    kv_quant_fwd(outBuf, kIn, vIn, block_table, cache_seqlens,
+                 num_seqs, max_pages, token_dim, groups_per_token,
+                 q_words_total, num_layers, layer, compand_a, 8, 1, 256, 128)
+
+  proc kvDequantB8L1(
+      outBuf: ptr UncheckedArray[uint16],
+      qK, qV: ptr UncheckedArray[uint32],
+      sK, sV: ptr UncheckedArray[uint16],
+      block_table, cache_seqlens: ptr UncheckedArray[int32],
+      num_seqs, max_pages, token_dim, groups_per_token, out_total,
+      num_layers, layer: int32, compand_a: float32) {.global.} =
+    kv_dequant_fwd(outBuf, qK, qV, sK, sV, block_table, cache_seqlens,
+                   num_seqs, max_pages, token_dim, groups_per_token,
+                   out_total, num_layers, layer, compand_a, 8, 1, 256, 128)
+
+proc kvRoundTrip(
+    kf, vf: seq[float32], blockTable: seq[int32],
+    numPages, numLayers, layer, numSeqs, maxPages, rows, kvHeads, D,
+    bits, compander: int): tuple[rt, cross: float32] =
+  ## Quant then dequant round trip at one fixed (bits, compander) combo
+  ## on layer `layer` of a flat layer-major pool. Returns the worst
+  ## |Δ| of the dequant rows vs the fp16 slab they came from (`rt`)
+  ## and vs the same page/token of layer 0 (`cross`).
+  let tokenDim = kvHeads * D
+  let groups = tokenDim div 32
+  let poolTokens = numPages * numLayers * 256
+  let qWordsTotal = poolTokens * groups * bits
+  let sTotal = qWordsTotal shr int(log2(float(bits)))
+  let quantLen = 2 * qWordsTotal + 2 * sTotal
+  let outTotal = poolTokens * tokenDim
+  let compandA = (if compander == 0: 0.0'f32 else: 0.65'f32)
+  var kSlab = newSeq[uint16](poolTokens * tokenDim)
+  var vSlab = newSeq[uint16](poolTokens * tokenDim)
+  for i in 0 ..< poolTokens * tokenDim:
+    kSlab[i] = fp32ToFp16(kf[i])
+    vSlab[i] = fp32ToFp16(vf[i])
+  var engine = bkMetal.init()
+  engine.ingest(kvquantMsl)
+  var cacheZero = newSeq[int32](numSeqs)
+  var cacheRows = newSeq[int32](numSeqs)
+  for i in 0 ..< numSeqs:
+    cacheRows[i] = int32(rows)
+  var outBuf = newSeq[uint32](quantLen)
+  let qArgs = (kSlab, vSlab, blockTable, cacheZero,
+               int32(numSeqs), int32(maxPages), int32(tokenDim),
+               int32(groups), int32(qWordsTotal),
+               int32(numLayers), int32(layer), compandA)
+  if bits == 8 and compander == 0:
+    engine.run << (grid: (groups div 4, rows, numSeqs), blk: (32, 1)) >>
+      ("kvQuantB8L0", outBuf, qArgs)
+  else:
+    engine.run << (grid: (groups div 4, rows, numSeqs), blk: (32, 1)) >>
+      ("kvQuantB8L1", outBuf, qArgs)
+  var qK = newSeq[uint32](qWordsTotal)
+  var qV = newSeq[uint32](qWordsTotal)
+  var sK = newSeq[uint16](sTotal)
+  var sV = newSeq[uint16](sTotal)
+  for i in 0 ..< qWordsTotal:
+    qK[i] = outBuf[i]
+    qV[i] = outBuf[qWordsTotal + i]
+  for i in 0 ..< sTotal:
+    sK[i] = uint16(outBuf[2 * qWordsTotal + i])
+    sV[i] = uint16(outBuf[2 * qWordsTotal + sTotal + i])
+  var kd = newSeq[uint16](2 * outTotal)
+  let dArgs = (qK, qV, sK, sV, blockTable, cacheRows,
+               int32(numSeqs), int32(maxPages), int32(tokenDim),
+               int32(groups), int32(outTotal),
+               int32(numLayers), int32(layer), compandA)
+  if bits == 8 and compander == 0:
+    engine.run << (grid: (groups div 4, rows, numSeqs), blk: (32, 1)) >>
+      ("kvDequantB8L0", kd, dArgs)
+  else:
+    engine.run << (grid: (groups div 4, rows, numSeqs), blk: (32, 1)) >>
+      ("kvDequantB8L1", kd, dArgs)
+  var rt = 0.0'f32
+  var cross = 0.0'f32
+  for b in 0 ..< numSeqs:
+    for y in 0 ..< rows:
+      let pageIdx = y shr 8
+      let pageId = blockTable[b * maxPages + pageIdx].int
+      let tp = pageId * numLayers * 256 + layer * 256 + (y and 255)
+      let pos = tp * tokenDim
+      let posL0 = pos - layer * 256 * tokenDim
+      for i in 0 ..< tokenDim:
+        let a = fp16ToFp32(kd[pos + i])
+        let aV = fp16ToFp32(kd[outTotal + pos + i])
+        let s1 = fp16ToFp32(kSlab[pos + i])
+        let s1V = fp16ToFp32(vSlab[pos + i])
+        let s0 = fp16ToFp32(kSlab[posL0 + i])
+        let s0V = fp16ToFp32(vSlab[posL0 + i])
+        rt = max(rt, abs(a - s1))
+        rt = max(rt, abs(aV - s1V))
+        cross = max(cross, abs(a - s0))
+        cross = max(cross, abs(aV - s0V))
+  (rt, cross)
+
+proc checkKvQuant(): bool =
+  ## Two fixed (bits, compander) combos on layer 1 of a layer-major
+  ## pool with a gapped block table: the dequant rows must reconstruct
+  ## layer 1's slab within the lossy bound and must NOT match layer
+  ## 0's content. Layer 1 holds 100× layer 0's values: a missing layer
+  ## term leaves layer 1's rows unwritten (zeros), which the rt ≤ 64
+  ## bound rejects (amplitude 100–200), and a wrong page stride reads
+  ## layer 0's rows, which the cross > 64 bound rejects.
+  randomize(0x5EED)
+  let numPages = 4
+  let numLayers = 2
+  let layer = 1
+  let numSeqs = 2
+  let maxPages = 2
+  let rows = 300
+  let kvHeads = 2
+  let D = 128
+  let tokenDim = kvHeads * D
+  let blockTable = [0'i32, 3, 1, 2].toSeq()
+  let poolTokens = numPages * numLayers * 256
+  var kf = newSeq[float32](poolTokens * tokenDim)
+  var vf = newSeq[float32](poolTokens * tokenDim)
+  for p in 0 ..< numPages:
+    for l in 0 ..< numLayers:
+      for t in 0 ..< 256:
+        for d in 0 ..< tokenDim:
+          let base = 1.0'f32 + rand(1.0'f32)
+          let idx = (p * numLayers + l) * 256 * tokenDim + t * tokenDim + d
+          kf[idx] = (if l == 1: 100.0'f32 * base else: base)
+          vf[idx] = (if l == 1: 100.0'f32 * base else: base)
+  for (bits, compander) in [(8, 0), (8, 1)]:
+    let (rt, cross) = kvRoundTrip(kf, vf, blockTable, numPages, numLayers,
+                                  layer, numSeqs, maxPages, rows, kvHeads,
+                                  D, bits, compander)
+    echo &"  bits={bits} compander={compander}: rt worst |Δ| = {rt} cross |Δ| = {cross}"
+    doAssert rt <= 64.0'f32, "round-trip error exceeds the lossy bound"
+    doAssert cross > 64.0'f32, "dequant output matches layer 0's content"
+  result = true
+
+when isMainModule:
+  runCppTest("kvquant round trip on a layer-major pool", checkKvQuant)

--- a/workspace/positron/tests/manual_paged_attn_fp16.nim
+++ b/workspace/positron/tests/manual_paged_attn_fp16.nim
@@ -25,9 +25,10 @@ const pagedMsl = metal:
       o, q: ptr UncheckedArray[float16],
       k_cache, v_cache: ptr UncheckedArray[float16],
       block_table, cache_seqlens, cu_seqlens_q: ptr UncheckedArray[int32],
-      num_seqs, H, Nkv, max_pages, page_size: int32) {.global.} =
+      num_seqs, H, Nkv, max_pages, num_layers, layer: int32) {.global.} =
     paged_attn_fwd(o, q, k_cache, v_cache, block_table, cache_seqlens,
-                   cu_seqlens_q, num_seqs, H, Nkv, max_pages, page_size, 128)
+                   cu_seqlens_q, num_seqs, H, Nkv, max_pages, num_layers,
+                   layer, 16, 128)
 
 proc scaledRand(rows, cols: int, scaleF: float32): seq[float32] =
   ## rand(rows, cols) shifted host-side to [-scaleF, scaleF). The
@@ -46,6 +47,11 @@ proc worstAbsDiff(a, b: F.Tensor): float32 =
   for i in 0 ..< a.numel():
     let d = abs(ap[i] - bp[i])
     if d > result: result = d
+
+proc layerSelect(t: F.Tensor, layer: int): F.Tensor =
+  ## torch's select(1, layer) as a view: narrow the layer dim then
+  ## squeeze it. The result keeps the layer-major page stride.
+  t.narrow(1, layer, 1).squeeze(1)
 
 proc gatherKv(src: F.Tensor, blockTable: seq[int32], maxPages, pageSize, covered, s: int): F.Tensor =
   ## The seq's contiguous K or V: the flat (num_pages·page_size, Nkv, D)
@@ -81,9 +87,9 @@ proc sdpaPrefill(qt, kt, vt: F.Tensor, cacheSeqlen, qLen, H, Nkv: int): F.Tensor
 proc pagedAttnKernel(
     qf, kf, vf: seq[float32],
     blockTable, cacheSeqlens, cuSeqlensQ: seq[int32],
-    numSeqs, H, Nkv, maxPages, pageSize, nQo, D: int): F.Tensor =
-  ## Runs pagedD128 on the fp16-rounded inputs; returns the fp16
-  ## output converted to fp32.
+    numSeqs, H, Nkv, maxPages, numLayers, layer, nQo, D: int): F.Tensor =
+  ## Runs pagedD128 on the fp16-rounded layer-major slabs, returning the
+  ## fp16 output converted to fp32.
   var engine = bkMetal.init()
   engine.ingest(pagedMsl)
   var kSlab = newSeq[uint16](kf.len)
@@ -97,7 +103,7 @@ proc pagedAttnKernel(
   var outO = newSeq[uint16](nQo * H * D)
   let args = (q, kSlab, vSlab, blockTable, cacheSeqlens, cuSeqlensQ,
               int32(numSeqs), int32(H), int32(Nkv), int32(maxPages),
-              int32(pageSize))
+              int32(numLayers), int32(layer))
   engine.run << (grid: (1, H, numSeqs), blk: (32, 1)) >> ("pagedD128", outO, args)
   var outF = newSeq[float32](nQo * H * D)
   for i in 0 ..< nQo * H * D:
@@ -107,13 +113,21 @@ proc pagedAttnKernel(
 proc pagedAttnReference(
     qf, kf, vf: seq[float32],
     blockTable, cacheSeqlens, cuSeqlensQ, qLens: seq[int32],
-    numPages, maxPages, pageSize, numSeqs, H, Nkv, nQo, D: int): F.Tensor =
+    numPages, numLayers, layer, maxPages, pageSize, numSeqs, H, Nkv, nQo, D: int): F.Tensor =
   ## torch SDPA over the same fp16-rounded values, per seq: decode
   ## (q_len = 1) causal off, prefill (q_len >= 2) banded causal over
-  ## [0, cache_seqlen + q_len). SDPA wants (1, H, q_len, D), so the
+  ## [0, cache_seqlen + q_len). The K/V come from the layer-major pool
+  ## via torch's own per-layer addressing (select + contiguous, since
+  ## the select view is strided). SDPA wants (1, H, q_len, D), so the
   ## prefill q is transposed from the kernel's (q, H, D) order.
-  let kT = toTensor(kf).reshape(numPages * pageSize, Nkv, D).to(kFloat16).to(kFloat32)
-  let vT = toTensor(vf).reshape(numPages * pageSize, Nkv, D).to(kFloat16).to(kFloat32)
+  let kT = toTensor(kf).reshape(numPages, numLayers, pageSize, Nkv, D)
+            .layerSelect(layer).contiguous()
+            .reshape(numPages * pageSize, Nkv, D)
+            .to(kFloat16).to(kFloat32)
+  let vT = toTensor(vf).reshape(numPages, numLayers, pageSize, Nkv, D)
+            .layerSelect(layer).contiguous()
+            .reshape(numPages * pageSize, Nkv, D)
+            .to(kFloat16).to(kFloat32)
   let qT = toTensor(qf).reshape(nQo, H, D).to(kFloat16).to(kFloat32)
   var oRef = newSeq[float32](nQo * H * D)
   for s in 0 ..< numSeqs:
@@ -143,7 +157,9 @@ proc pagedAttnReference(
 
 proc checkPagedAttn(): bool =
   ## One mixed batch (decode and prefill seqs under one cu_seqlens_q):
-  ## kernel output vs torch SDPA per seq.
+  ## kernel output vs torch SDPA per seq, plus the cross-layer
+  ## invariant: the layer-1 kernel output must NOT match a layer-0
+  ## reference (a missing layer term or pageStride would make it match).
   Torch.manual_seed(0x5EED'u64)
   let numSeqs = 3
   let H = 4
@@ -152,23 +168,33 @@ proc checkPagedAttn(): bool =
   let pageSize = 16
   let maxPages = 3
   let numPages = 7
+  let numLayers = 2
+  let layer = 1
   let nQo = 5
   let cacheSeqlens = [20'i32, 5, 33].toSeq()
   let qLens = [1'i32, 3, 1].toSeq()
   let blockTable = [0'i32, 1, -1, 2, 3, -1, 4, 5, 6].toSeq()
   let cuSeqlensQ = [0'i32, 1, 4, 5].toSeq()
-  let kf = scaledRand(numPages * pageSize, Nkv * D, 2.0'f32)
-  let vf = scaledRand(numPages * pageSize, Nkv * D, 2.0'f32)
+  let kf = scaledRand(numPages * numLayers * pageSize, Nkv * D, 2.0'f32)
+  let vf = scaledRand(numPages * numLayers * pageSize, Nkv * D, 2.0'f32)
   let qf = scaledRand(nQo, H * D, 2.0'f32)
   let actual = pagedAttnKernel(qf, kf, vf, blockTable, cacheSeqlens,
                                cuSeqlensQ, numSeqs, H, Nkv, maxPages,
-                               pageSize, nQo, D)
+                               numLayers, layer, nQo, D)
   let expected = pagedAttnReference(qf, kf, vf, blockTable, cacheSeqlens,
-                                    cuSeqlensQ, qLens, numPages, maxPages,
-                                    pageSize, numSeqs, H, Nkv, nQo, D)
-  echo &"  worst |Δ| = {worstAbsDiff(actual, expected)} (tolerance 5e-3)"
+                                    cuSeqlensQ, qLens, numPages, numLayers,
+                                    layer, maxPages, pageSize, numSeqs, H,
+                                    Nkv, nQo, D)
+  echo &"  layer {layer}: worst |Δ| = {worstAbsDiff(actual, expected)} (tolerance 5e-3)"
   assertAllClose(actual, expected, rtol = 0.0'f64, abstol = 5e-3'f64)
+  let wrongLayer = pagedAttnReference(qf, kf, vf, blockTable, cacheSeqlens,
+                                      cuSeqlensQ, qLens, numPages, numLayers,
+                                      0, maxPages, pageSize, numSeqs, H,
+                                      Nkv, nQo, D)
+  let cross = worstAbsDiff(actual, wrongLayer)
+  echo &"  cross-layer |Δ| vs layer 0 = {cross} (must exceed 1e-2)"
+  doAssert cross > 1e-2'f32, "kernel output matches the other layer's data"
   result = true
 
 when isMainModule:
-  runCppTest("paged_attn vs torch SDPA (decode + prefill)", checkPagedAttn)
+  runCppTest("paged_attn vs torch SDPA on a layer-major pool", checkPagedAttn)

--- a/workspace/transformers/src/stateful/page_pool.nim
+++ b/workspace/transformers/src/stateful/page_pool.nim
@@ -79,5 +79,6 @@ func layerView*(pool: PagePool, layer: int): tuple[kView, vView: Tensor] =
   ## head_dim) of the layer-major pool, the slice the paged kernels
   ## consume per dispatch. data_ptr at the layer base, page stride
   ## num_layers·PAGE_SIZE·kv_heads·head_dim.
+  ## The kernel's `layer` arg must be 0 when a layerView view is passed (the offset is already applied).
   (pool.k_buffer.narrow(1, layer, 1).squeeze(1),
    pool.v_buffer.narrow(1, layer, 1).squeeze(1))

--- a/workspace/transformers/src/stateful/page_pool.nim
+++ b/workspace/transformers/src/stateful/page_pool.nim
@@ -22,19 +22,19 @@ type
     index: int32 = -1i32
     pool {.cursor.}: PagePool # Back-pointer: the orchestrator keeps the pool
     # alive, and we only have integers to return, so don't refcount
-    k_view*: Tensor           # (num_layers, PAGE_SIZE, kv_heads, head_dim) — view into pool
+    k_view*: Tensor           # (num_layers, PAGE_SIZE, kv_heads, head_dim) slab view
     v_view*: Tensor           # same
 
-# No custom =destroy, =copy, =sink hooks — ORC default field-by-field
-# destruction handles Tensor/TorchTensor lifecycle correctly for PagePool
+# No custom =destroy, =copy, =sink hooks. ORC default field-by-field
+# destruction handles Tensor/TorchTensor lifecycle correctly for PagePool.
 #
-# For the Page, if the PagePool is not destroyed return the index to it so it can be borrowed again
-# We need to nil the Tensor fields so their destructors run, the TorchTensor
-# refcount is decremented, and they are collected
+# A Page returns its slot to the pool's free stack while the pool
+# is still alive, then clears the tensor fields so their destructors
+# run and release the TorchTensor refcounts.
 
 proc `=destroy`(p: var PageObj) =
-  ## Auto-recycle slot index to the pool's free stack.
-  ## Called by ORC when the last Page ref is dropped.
+  ## Returns the slot index to the pool's free stack when the last
+  ## Page ref is dropped.
   ## SAFETY: PagePool outlives all Pages (orchestrator lifetime).
   if p.pool != nil and p.index >= 0:
     p.pool.free_indices.add(p.index)
@@ -76,8 +76,8 @@ func pageIndex*(p: Page): int32 =
 
 func layerView*(pool: PagePool, layer: int): tuple[kView, vView: Tensor] =
   ## Returns the per-layer slab views (num_pages, PAGE_SIZE, kv_heads,
-  ## head_dim) of the layer-major pool, the slice that the paged
-  ## kernels consume per dispatch: data_ptr at the layer base, page
-  ## stride num_layers·PAGE_SIZE·kv_heads·head_dim.
+  ## head_dim) of the layer-major pool, the slice the paged kernels
+  ## consume per dispatch. data_ptr at the layer base, page stride
+  ## num_layers·PAGE_SIZE·kv_heads·head_dim.
   (pool.k_buffer.narrow(1, layer, 1).squeeze(1),
    pool.v_buffer.narrow(1, layer, 1).squeeze(1))

--- a/workspace/transformers/src/stateful/page_pool.nim
+++ b/workspace/transformers/src/stateful/page_pool.nim
@@ -20,7 +20,8 @@ type
   PageObj = object
     ## Underlying data for Page ref objects.
     index: int32 = -1i32
-    pool {.cursor.}: PagePool # Back-pointer (orchestrator keeps pool alive, and we only have integers to return so don't refcount)
+    pool {.cursor.}: PagePool # Back-pointer: the orchestrator keeps the pool
+    # alive, and we only have integers to return, so don't refcount
     k_view*: Tensor           # (num_layers, PAGE_SIZE, kv_heads, head_dim) — view into pool
     v_view*: Tensor           # same
 
@@ -28,7 +29,8 @@ type
 # destruction handles Tensor/TorchTensor lifecycle correctly for PagePool
 #
 # For the Page, if the PagePool is not destroyed return the index to it so it can be borrowed again
-# We need to nil Tensor field to ensure their destructor is called so the TorchTensor's refcount is decremnented and they are collected
+# We need to nil the Tensor fields so their destructors run, the TorchTensor
+# refcount is decremented, and they are collected
 
 proc `=destroy`(p: var PageObj) =
   ## Auto-recycle slot index to the pool's free stack.
@@ -71,3 +73,11 @@ func pagesAvailable*(pool: PagePool): int =
 
 func pageIndex*(p: Page): int32 =
   p.index
+
+func layerView*(pool: PagePool, layer: int): tuple[kView, vView: Tensor] =
+  ## Returns the per-layer slab views (num_pages, PAGE_SIZE, kv_heads,
+  ## head_dim) of the layer-major pool, the slice that the paged
+  ## kernels consume per dispatch: data_ptr at the layer base, page
+  ## stride num_layers·PAGE_SIZE·kv_heads·head_dim.
+  (pool.k_buffer.narrow(1, layer, 1).squeeze(1),
+   pool.v_buffer.narrow(1, layer, 1).squeeze(1))

--- a/workspace/transformers/tests/kvcache/test_page_pool.nim
+++ b/workspace/transformers/tests/kvcache/test_page_pool.nim
@@ -5,9 +5,8 @@
 ##   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
 ## at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-import std/unittest
-import std/importutils
 import workspace/libtorch
+import workspace/libtorch_testutils
 import workspace/transformers/src/stateful/page_pool
 import workspace/transformers/src/stateful/kvcache
 
@@ -16,43 +15,50 @@ import workspace/transformers/src/stateful/kvcache
 # and the trie's graftPages/evict lifecycle. The pool tests need
 # libtorch linked at runtime.
 
-suite "Page + KVCache integration (P = Page, public API only)":
-  test "empty KVCache[uint32, Page] LPM":
-    var cache = KVCache[uint32, Page].new()
-    let tokens = @[1'u32, 2, 3]
-    let matched = cache.lpm(tokens)
-    check matched.totalTokenMatched == 0
-    check matched.pages.len == 0
-    cache.graftPages(tokens, newSeq[Page]())
+proc testEmptyKvCacheLpm(): bool =
+  var cache = KVCache[uint32, Page].new()
+  let tokens = @[1'u32, 2, 3]
+  let matched = cache.lpm(tokens)
+  doAssert matched.totalTokenMatched == 0
+  doAssert matched.pages.len == 0
+  cache.graftPages(tokens, newSeq[Page]())
+  result = true
 
-  test "graftPages with Page ref, then LPM retrieves":
-    var cache = KVCache[uint32, Page].new()
-    let tokens = @[1'u32, 2, 3]
-    # Pages carry a nil pool, so =destroy is a no-op
-    cache.graftPages(tokens, newSeq[Page]())
+proc testGraftPagesEmptyPageSeq(): bool =
+  var cache = KVCache[uint32, Page].new()
+  let tokens = @[1'u32, 2, 3]
+  # Pages carry a nil pool, so =destroy is a no-op
+  cache.graftPages(tokens, newSeq[Page]())
+  result = true
 
-  test "evict returns page count > 0 after graftPages":
-    var cache = KVCache[uint32, Page].new()
-    # Graft two single-token sequences, each with one "page"
-    # Note: Page here is just a token type for the trie.
-    type DummyPage = int  # int payload, no GPU pool for trie-only tests
-    var dcache = KVCache[uint32, DummyPage].new()
-    dcache.graftPages(@[1'u32], @[42])
-    dcache.graftPages(@[2'u32], @[43])
-    let freed = dcache.evict()
-    check freed > 0
+proc testEvictReturnsFreedPages(): bool =
+  # Graft two single-token sequences, each with one "page"
+  # Note: Page here is just a token type for the trie.
+  type DummyPage = int  # int payload, no GPU pool for trie-only tests
+  var dcache = KVCache[uint32, DummyPage].new()
+  dcache.graftPages(@[1'u32], @[42])
+  dcache.graftPages(@[2'u32], @[43])
+  let freed = dcache.evict()
+  doAssert freed > 0
+  result = true
 
-suite "PagePool layer views":
-  test "layerView selects the per-layer slab slice":
-    let pool = PagePool.init(4, 3, 2, 128, kFloat16, kCPU)
-    let kv = pool.layerView(1)
-    let k = kv.kView
-    let v = kv.vView
-    check k.size(0) == 4
-    check k.size(1) == TokensPerPage
-    check k.size(2) == 2
-    check k.size(3) == 128
-    check v.size(0) == 4
-    let off = cast[int](k.data_ptr()) - cast[int](pool.layerView(0).kView.data_ptr())
-    check off == 1 * TokensPerPage * 2 * 128 * k.element_size()
-    check k.strides()[0] == 3 * TokensPerPage * 2 * 128
+proc testLayerViewSlabSlice(): bool =
+  let pool = PagePool.init(4, 3, 2, 128, kFloat16, kCPU)
+  let kv = pool.layerView(1)
+  let k = kv.kView
+  let v = kv.vView
+  doAssert k.size(0) == 4
+  doAssert k.size(1) == TokensPerPage
+  doAssert k.size(2) == 2
+  doAssert k.size(3) == 128
+  doAssert v.size(0) == 4
+  let off = cast[int](k.data_ptr()) - cast[int](pool.layerView(0).kView.data_ptr())
+  doAssert off == 1 * TokensPerPage * 2 * 128 * k.element_size()
+  doAssert k.strides()[0] == 3 * TokensPerPage * 2 * 128
+  result = true
+
+when isMainModule:
+  runCppTest("empty KVCache[uint32, Page] LPM", testEmptyKvCacheLpm)
+  runCppTest("graftPages with an empty page sequence", testGraftPagesEmptyPageSeq)
+  runCppTest("evict returns page count > 0 after graftPages", testEvictReturnsFreedPages)
+  runCppTest("layerView selects the per-layer slab slice", testLayerViewSlabSlice)

--- a/workspace/transformers/tests/kvcache/test_page_pool.nim
+++ b/workspace/transformers/tests/kvcache/test_page_pool.nim
@@ -7,6 +7,7 @@
 
 import std/unittest
 import std/importutils
+import workspace/libtorch
 import workspace/transformers/src/stateful/page_pool
 import workspace/transformers/src/stateful/kvcache
 
@@ -43,3 +44,18 @@ suite "Page + KVCache integration (P = Page, public API only)":
     dcache.graftPages(@[2'u32], @[43])
     let freed = dcache.evict()
     check freed > 0
+
+suite "PagePool layer views":
+  test "layerView selects the per-layer slab slice":
+    let pool = PagePool.init(4, 3, 2, 128, kFloat16, kCPU)
+    let kv = pool.layerView(1)
+    let k = kv.kView
+    let v = kv.vView
+    check k.size(0) == 4
+    check k.size(1) == TokensPerPage
+    check k.size(2) == 2
+    check k.size(3) == 128
+    check v.size(0) == 4
+    let off = cast[int](k.data_ptr()) - cast[int](pool.layerView(0).kView.data_ptr())
+    check off == 1 * TokensPerPage * 2 * 128 * k.element_size()
+    check k.strides()[0] == 3 * TokensPerPage * 2 * 128

--- a/workspace/transformers/tests/kvcache/test_page_pool.nim
+++ b/workspace/transformers/tests/kvcache/test_page_pool.nim
@@ -11,11 +11,10 @@ import workspace/libtorch
 import workspace/transformers/src/stateful/page_pool
 import workspace/transformers/src/stateful/kvcache
 
-# These tests verify Page + KVCache lifecycle using only public APIs.
-# PageObj fields (index, pool) are private — we interact via borrow() and
-# the trie's graftPages/evict lifecycle.
-#
-# Full PagePool + tensor tests need libtorch linked at runtime (see AGENTS.md).
+# Page + KVCache lifecycle tests, public API only. PageObj fields
+# (index, pool) are private, so the tests interact via borrow()
+# and the trie's graftPages/evict lifecycle. The pool tests need
+# libtorch linked at runtime.
 
 suite "Page + KVCache integration (P = Page, public API only)":
   test "empty KVCache[uint32, Page] LPM":
@@ -28,17 +27,15 @@ suite "Page + KVCache integration (P = Page, public API only)":
 
   test "graftPages with Page ref, then LPM retrieves":
     var cache = KVCache[uint32, Page].new()
-    # Create Pages using the pool (needs tensor init — skipped if unavailable)
     let tokens = @[1'u32, 2, 3]
-    # These pages have nil pool so =destroy is a no-op
-    cache.graftPages(tokens, newSeq[Page]())  # just release lock
+    # Pages carry a nil pool, so =destroy is a no-op
+    cache.graftPages(tokens, newSeq[Page]())
 
   test "evict returns page count > 0 after graftPages":
     var cache = KVCache[uint32, Page].new()
     # Graft two single-token sequences, each with one "page"
-    # Note: Page here is just a token type for the trie; actual pool/buffer
-    # management is tested via the orchestrator integration tests.
-    type DummyPage = int  # int as page payload (no GPU pool needed for trie-only tests)
+    # Note: Page here is just a token type for the trie.
+    type DummyPage = int  # int payload, no GPU pool for trie-only tests
     var dcache = KVCache[uint32, DummyPage].new()
     dcache.graftPages(@[1'u32], @[42])
     dcache.graftPages(@[2'u32], @[43])


### PR DESCRIPTION
This adds EXL3-quantized KV-cache support to the PagedAttention kernel.

Similar to turboquant, it distributes spikes via random rotations, but Hadamard rotations instead of the Polar rotation used in Turboquant.

~~TODO: more tests~~ -> done in https://github.com/mratsim/tattletale/pull/84/commits/78937ae3c512f0cf1d364f94789e9caf478814e0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added paged KV-cache quantization and dequantization supporting 2-, 4-, and 8-bit formats with linear and LMCubic companding.
  - Added layer-aware KV-cache views and paged attention support for multi-layer cache layouts.
  - Added comprehensive validation for quantization accuracy, cache boundaries, layer separation, and round-trip behavior.

- **Refactor**
  - Renamed deterministic tile test terminology from “draws” to “cases” without changing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->