### PR TITLE
[kernel] GGUF Paged Attention support  🔥 🔥 

### DIFF
--- a/workspace/positron/src/kernels/ceramic/gguf_attn.nim
+++ b/workspace/positron/src/kernels/ceramic/gguf_attn.nim
@@ -1,0 +1,249 @@
+## Tattletale
+## Copyright (c) 2026 Mamy André-Ratsimbazafy
+## Licensed and distributed under either of
+##   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+##   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+## at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+# ############################################################
+#
+#     GGUF attention-forward composition driver (gguf_attn)
+#
+# ############################################################
+
+## GGUF attention-forward composition driver: one Metal block hosting
+## the quantized-linear, qk-norm+rope and paged-attention launchers,
+## plus the host `ggufAttnForward` forward, one `engine.run` per
+## kernel: q/k/v projections, qk-norm+rope, the host cache write
+## (write-before staging, decode rows at cache_seqlen - 1, prefill rows
+## at cache_seqlen + j), paged attention, o_proj. Requires H % 8 == 0,
+## Nkv % 8 == 0 and a power-of-two pageSize (the write's shift/mask).
+
+import std/[math, bitops]
+import workspace/crucible
+import ./gguf_linear_fwd
+import ./qk_norm_rope
+import ./paged_attn
+
+# ═════════════════════════════════════════════════════════════════════
+#  The thin {.global.} launchers, one per scheme for the quantized
+#  linear (0 = Q8_0, 1 = Q4_K, 2 = IQ4_XS) plus the qk-norm+rope and
+#  paged attention forwards at D = 128. Each launcher's first param is
+#  the output buffer: engine.run binds the separate outBuf argument to
+#  it and the args tuple to the rest.
+#  ═════════════════════════════════════════════════════════════════════
+
+const ggufAttnMsl* = metal:
+  proc ggufLinearQ8(
+      Out: ptr UncheckedArray[float16], x: ptr UncheckedArray[float16],
+      w: ptr UncheckedArray[uint8], M, K, N, rowBytes: int32) {.global.} =
+    gguf_linear_fwd(Out, x, w, M, K, N, rowBytes, 0)
+
+  proc ggufLinearQ4K(
+      Out: ptr UncheckedArray[float16], x: ptr UncheckedArray[float16],
+      w: ptr UncheckedArray[uint8], M, K, N, rowBytes: int32) {.global.} =
+    gguf_linear_fwd(Out, x, w, M, K, N, rowBytes, 1)
+
+  proc ggufLinearIQ4XS(
+      Out: ptr UncheckedArray[float16], x: ptr UncheckedArray[float16],
+      w: ptr UncheckedArray[uint8], M, K, N, rowBytes: int32) {.global.} =
+    gguf_linear_fwd(Out, x, w, M, K, N, rowBytes, 2)
+
+  proc ggufQkNormRopeD128(
+      Out: ptr UncheckedArray[float16], X, G: ptr UncheckedArray[float16],
+      Cos, Sin: ptr UncheckedArray[float32],
+      xTokenStride, cosTokenStride, headBlocks, xColBase: int32,
+      eps: float32) {.global.} =
+    qk_norm_rope_fwd(Out, X, G, Cos, Sin, xTokenStride, cosTokenStride,
+                     headBlocks, xColBase, eps)
+
+  proc ggufPagedD128(
+      o, q: ptr UncheckedArray[float16],
+      k_cache, v_cache: ptr UncheckedArray[float16],
+      block_table, cache_seqlens, cu_seqlens_q: ptr UncheckedArray[int32],
+      num_seqs, H, Nkv, max_pages, page_size: int32) {.global.} =
+    paged_attn_fwd(o, q, k_cache, v_cache, block_table, cache_seqlens,
+                   cu_seqlens_q, num_seqs, H, Nkv, max_pages, page_size, 128)
+
+# ═════════════════════════════════════════════════════════════════════
+#  The attention-forward parameters and result
+#  ═════════════════════════════════════════════════════════════════════
+
+type
+  GGufAttnParams* = object
+    ## Geometry, tables and weights of one attention-layer forward.
+    ## `x`, the token rows, is passed separately to `ggufAttnForward`.
+    ## The K/V slabs are in-out: the forward appends the batch's new
+    ## rows before attention runs.
+    hidden*: int              # x row width = the projections' K
+    H*, Nkv*: int             # query / kv head counts (GQA ratio H div Nkv)
+    D*: int                   # head dim (128 in this composition)
+    pageSize*, maxPages*: int
+    eps*, theta*: float32     # the qk-norm epsilon and the RoPE base
+    cacheSeqlens*: seq[int32]     # (num_seqs), see the module doc's staging contract
+    cuSeqlensQ*: seq[int32]       # (num_seqs+1), the cumulative q-token ranges
+    blockTable*: seq[int32]       # (num_seqs, max_pages) dense, -1 padding
+    positions*: seq[int32]        # (num_qo_tokens), the per-token positions
+    qw*, kw*, vw*, ow*: seq[byte] # the raw GGUF block streams
+    qRowBytes*, kRowBytes*, vRowBytes*, oRowBytes*: int32
+    qScheme*, kScheme*, vScheme*, oScheme*: int  # 0 = Q8_0, 1 = Q4_K, 2 = IQ4_XS
+    normGammaQ*, normGammaK*: seq[uint16]  # (D,) fp16 per-dim weights
+
+  GGufAttnResult* = object
+    ## Per-launch outputs of the driver, one buffer per kernel stage.
+    ## `outBuf`, the final buffer, is the layer output. Sizes are
+    ## token-based: num_qo_tokens = cuSeqlensQ[^1].
+    outBuf*: seq[uint16]      # (num_qo_tokens, hidden) fp16, the layer output
+    qBuf*, kBuf*, vBuf*: seq[uint16]  # the pre-norm projections
+    qRope*, kRope*: seq[uint16]       # the qk-norm+rope outputs
+    attnOut*: seq[uint16]     # (num_qo_tokens, H, D) fp16, the paged output
+
+# ═════════════════════════════════════════════════════════════════════
+#  The shared NEOX cos/sin table builder (see the module doc, the
+#  qk_norm_rope kernel's table contract)
+#  ═════════════════════════════════════════════════════════════════════
+
+proc buildRopeCosSin*(nTokens, rowsPerToken, D: int; positions: seq[int32];
+                      theta: float32): tuple[cosT, sinT: seq[float32]] =
+  ## Precomputes the NEOX fp32 cos/sin tables: one (rows, half)
+  ## row-major table per signal, rows = nTokens·rowsPerToken, half =
+  ## D div 2. Row r of token m (r = m·rowsPerToken + h) carries the
+  ## cos/sin of inv_freq[t]·pos with inv_freq[t] = theta^(−2t/D),
+  ## the pow in float64 rounded to fp32, the sin/cos in fp32.
+  ## The dims pair t and t + half share the value, so the table stores
+  ## the half once and the kernel's two half-tiles both read it.
+  let half = D shr 1
+  var invFreq = newSeq[float32](half)
+  for t in 0 ..< half:
+    invFreq[t] = float32(pow(float64(theta), -float64(2 * t) / float64(D)))
+  let rows = nTokens * rowsPerToken
+  result.cosT = newSeq[float32](rows * half)
+  result.sinT = newSeq[float32](rows * half)
+  for m in 0 ..< nTokens:
+    let pos = float32(positions[m])
+    for h in 0 ..< rowsPerToken:
+      let row = m * rowsPerToken + h
+      for t in 0 ..< half:
+        let ang = invFreq[t] * pos
+        result.cosT[row * half + t] = cos(ang)
+        result.sinT[row * half + t] = sin(ang)
+
+func ggufLinearLauncher(scheme: int): string =
+  ## Metal launcher name for the packed-stream scheme: 0 = Q8_0,
+  ## 1 = Q4_K, 2 = IQ4_XS.
+  case scheme
+  of 0: "ggufLinearQ8"
+  of 1: "ggufLinearQ4K"
+  of 2: "ggufLinearIQ4XS"
+  else: raise newException(ValueError, "unknown GGUF scheme: " & $scheme)
+
+func slabOffset(pageId, inPage, h, d: int; pageSize, Nkv, D: int): int =
+  ## K/V slab offset of (pageId, inPage, head h, dim d) in the flat
+  ## (num_pages, page_size, Nkv, D) layout, head-dim contiguous:
+  ## (pageId·pageSize + inPage)·(Nkv·D) + h·D + d.
+  (pageId * pageSize + inPage) * (Nkv * D) + h * D + d
+
+# ═════════════════════════════════════════════════════════════════════
+#  The layer driver
+#  ═════════════════════════════════════════════════════════════════════
+
+proc ggufAttnForward*(engine: var auto, p: GGufAttnParams, x: seq[uint16],
+                      kSlab, vSlab: var seq[uint16]): GGufAttnResult =
+  ## Runs one attention-layer forward, one `engine.run` per kernel in
+  ## the module doc's order: the q/k/v projections over the shared x,
+  ## the fused qk-norm+rope on the separate q and k buffers, the cache
+  ## write (the module doc's staging contract), the paged attention
+  ## over the slabs and the o_proj. `x` is (num_qo_tokens, hidden)
+  ## fp16. The slabs are mutated by the append: each seq's roped k and
+  ## plain v land at the rows the staging contract fixes. Decode
+  ## (q_len == 1) and prefill (q_len >= 2) seqs mix under one
+  ## `cu_seqlens_q`. `positions` are per token. Requires H % 8 == 0,
+  ## Nkv % 8 == 0 and a power-of-two pageSize (asserted).
+  doAssert (p.H and 7) == 0 and (p.Nkv and 7) == 0,
+    "the composed q/k views require H % 8 == 0 and Nkv % 8 == 0"
+  doAssert p.pageSize >= 1 and (p.pageSize and (p.pageSize - 1)) == 0,
+    "the cache write requires a power-of-two pageSize (shift/mask)"
+  let numSeqs = p.cuSeqlensQ.len - 1
+  let nTokens = p.cuSeqlensQ[numSeqs].int
+  doAssert nTokens >= 1, "the forward needs at least one query token"
+  let nQ = p.H * p.D
+  let nKv = p.Nkv * p.D
+
+  # the q/k/v projections (K = hidden, N = H·D / Nkv·D)
+  result.qBuf = newSeq[uint16](nTokens * nQ)
+  engine.run << (grid: (nQ div 128, (nTokens + 31) div 32, 1),
+                 blk: (32, 1)) >> (
+    ggufLinearLauncher(p.qScheme), result.qBuf,
+    (x, p.qw, int32(nTokens), int32(p.hidden), int32(nQ), p.qRowBytes))
+  result.kBuf = newSeq[uint16](nTokens * nKv)
+  engine.run << (grid: (nKv div 128, (nTokens + 31) div 32, 1),
+                 blk: (32, 1)) >> (
+    ggufLinearLauncher(p.kScheme), result.kBuf,
+    (x, p.kw, int32(nTokens), int32(p.hidden), int32(nKv), p.kRowBytes))
+  result.vBuf = newSeq[uint16](nTokens * nKv)
+  engine.run << (grid: (nKv div 128, (nTokens + 31) div 32, 1),
+                 blk: (32, 1)) >> (
+    ggufLinearLauncher(p.vScheme), result.vBuf,
+    (x, p.vw, int32(nTokens), int32(p.hidden), int32(nKv), p.vRowBytes))
+
+  # the fused qk-norm+rope over the separate q/k buffers: the composed
+  # (token, head-block) view, q's head-blocks = H div 8, k's = Nkv
+  # div 8. The x view's token stride is the buffer row width and the
+  # head-column offset is 0 (each buffer holds only its own heads)
+  let headBlocksQ = p.H div 8
+  let headBlocksK = p.Nkv div 8
+  let (cosQ, sinQ) = buildRopeCosSin(nTokens, p.H, p.D, p.positions, p.theta)
+  let (cosK, sinK) = buildRopeCosSin(nTokens, p.Nkv, p.D, p.positions, p.theta)
+  result.qRope = newSeq[uint16](nTokens * nQ)
+  engine.run << (grid: (1, nTokens, headBlocksQ), blk: (32, 1)) >> (
+    "ggufQkNormRopeD128", result.qRope,
+    (result.qBuf, p.normGammaQ, cosQ, sinQ,
+     int32(nQ), int32(p.H), int32(headBlocksQ), int32(0), p.eps))
+  result.kRope = newSeq[uint16](nTokens * nKv)
+  engine.run << (grid: (1, nTokens, headBlocksK), blk: (32, 1)) >> (
+    "ggufQkNormRopeD128", result.kRope,
+    (result.kBuf, p.normGammaK, cosK, sinK,
+     int32(nKv), int32(p.Nkv), int32(headBlocksK), int32(0), p.eps))
+
+  # the cache write (the write-before staging): each seq's roped k and
+  # plain v land at the rows the module doc's staging contract fixes.
+  # The page decomposition is shift/mask (pageSize is a power of two).
+  let lgPageSize = countTrailingZeroBits(p.pageSize)
+  let pageMask = p.pageSize - 1
+  for s in 0 ..< numSeqs:
+    let qLen = (p.cuSeqlensQ[s + 1] - p.cuSeqlensQ[s]).int
+    let q0 = p.cuSeqlensQ[s].int
+    let writeStart = p.cacheSeqlens[s].int - (if qLen == 1: 1 else: 0)
+    for j in 0 ..< qLen:
+      let row = writeStart + j
+      let pageIdx = row shr lgPageSize
+      let inPage = row and pageMask
+      let pageId = p.blockTable[s * p.maxPages + pageIdx].int
+      doAssert pageId >= 0, "cache write hit an unused block_table slot"
+      let t = q0 + j
+      for h in 0 ..< p.Nkv:
+        for d in 0 ..< p.D:
+          let i = slabOffset(pageId, inPage, h, d, p.pageSize, p.Nkv, p.D)
+          kSlab[i] = result.kRope[(t * p.Nkv + h) * p.D + d]
+          vSlab[i] = result.vBuf[(t * p.Nkv + h) * p.D + d]
+
+  # the paged attention's x extent: the batch's longest q_len in 8-row
+  # q blocks (the kernel zero-fills the blocks beyond a seq's own q_len)
+  var xBlocks = 1
+  for s in 0 ..< numSeqs:
+    let qLen = p.cuSeqlensQ[s + 1] - p.cuSeqlensQ[s]
+    xBlocks = max(xBlocks, (qLen.int + 7) div 8)
+  result.attnOut = newSeq[uint16](nTokens * nQ)
+  engine.run << (grid: (xBlocks, p.H, numSeqs), blk: (32, 1)) >> (
+    "ggufPagedD128", result.attnOut,
+    (result.qRope, kSlab, vSlab, p.blockTable, p.cacheSeqlens, p.cuSeqlensQ,
+     int32(numSeqs), int32(p.H), int32(p.Nkv),
+     int32(p.maxPages), int32(p.pageSize)))
+
+  # the o_proj over the attention output (num_qo_tokens, H·D) → hidden
+  result.outBuf = newSeq[uint16](nTokens * p.hidden)
+  engine.run << (grid: (p.hidden div 128, (nTokens + 31) div 32, 1),
+                 blk: (32, 1)) >> (
+    ggufLinearLauncher(p.oScheme), result.outBuf,
+    (result.attnOut, p.ow, int32(nTokens), int32(nQ),
+     int32(p.hidden), p.oRowBytes))

--- a/workspace/positron/src/kernels/ceramic/gguf_attn.nim
+++ b/workspace/positron/src/kernels/ceramic/gguf_attn.nim
@@ -215,6 +215,15 @@ proc ggufAttnForward*(engine: var auto, p: GGufAttnParams, x: seq[uint16],
   # The page decomposition is shift/mask (pageSize is a power of two).
   let lgPageSize = countTrailingZeroBits(p.pageSize)
   let pageMask = p.pageSize - 1
+  # the slabs hold whole pages of (page_size, Nkv, D); the per-token
+  # write moves one (Nkv, D) row into both slabs at the same offset,
+  # so the k and v slabs must share an equal whole-page capacity
+  let slabPageElems = p.pageSize * p.Nkv * p.D
+  let slabPageCount = kSlab.len div slabPageElems
+  doAssert kSlab.len == vSlab.len,
+    "the k and v slabs must hold an equal number of elements"
+  doAssert kSlab.len mod slabPageElems == 0,
+    "the k slab length must be a whole number of pages"
   for s in 0 ..< numSeqs:
     let qLen = (p.cuSeqlensQ[s + 1] - p.cuSeqlensQ[s]).int
     let q0 = p.cuSeqlensQ[s].int
@@ -227,6 +236,8 @@ proc ggufAttnForward*(engine: var auto, p: GGufAttnParams, x: seq[uint16],
       let inPage = row and pageMask
       let pageId = p.blockTable[s * p.maxPages + pageIdx].int
       doAssert pageId >= 0, "cache write hit an unused block_table slot"
+      doAssert pageId < slabPageCount,
+        "cache write hit a pageId beyond the slab's page capacity"
       # each token's Nkv·D span is one contiguous move on both sides:
       # the slab row (pageId, inPage) and the kRope/vBuf token row are
       # both head-dim-contiguous (slabOffset's h·D + d layout)

--- a/workspace/positron/src/kernels/ceramic/gguf_attn.nim
+++ b/workspace/positron/src/kernels/ceramic/gguf_attn.nim
@@ -26,11 +26,11 @@ import ./qk_norm_rope
 import ./paged_attn
 
 # ═════════════════════════════════════════════════════════════════════
-#  The thin {.global.} launchers, one per scheme for the quantized
-#  linear (0 = Q8_0, 1 = Q4_K, 2 = IQ4_XS) plus the qk-norm+rope and
-#  paged attention forwards at D = 128. Each launcher's first param is
-#  the output buffer: engine.run binds the separate outBuf argument to
-#  it and the args tuple to the rest.
+#  The thin {.global.} launchers, one per GGufScheme for the quantized
+#  linear plus the qk-norm+rope and paged attention forwards at D =
+#  128. Each launcher's first param is the output buffer: engine.run
+#  binds the separate outBuf argument to it and the args tuple to the
+#  rest.
 #  ═════════════════════════════════════════════════════════════════════
 
 const ggufAttnMsl* = metal:
@@ -70,6 +70,10 @@ const ggufAttnMsl* = metal:
 #  ═════════════════════════════════════════════════════════════════════
 
 type
+  GGufScheme* = enum
+    ## The GGUF block-quantization schemes the four projections accept.
+    gsQ8_0, gsQ4_K, gsIQ4_XS
+
   GGufAttnParams* = object
     ## Geometry, tables and weights of one attention-layer forward.
     ## `x`, the token rows, is passed separately to `ggufAttnForward`.
@@ -86,7 +90,7 @@ type
     positions*: seq[int32]        # (num_qo_tokens), the per-token positions
     qw*, kw*, vw*, ow*: seq[byte] # the raw GGUF block streams
     qRowBytes*, kRowBytes*, vRowBytes*, oRowBytes*: int32
-    qScheme*, kScheme*, vScheme*, oScheme*: int  # 0 = Q8_0, 1 = Q4_K, 2 = IQ4_XS
+    qScheme*, kScheme*, vScheme*, oScheme*: GGufScheme
     normGammaQ*, normGammaK*: seq[uint16]  # (D,) fp16 per-dim weights
 
   GGufAttnResult* = object
@@ -128,14 +132,12 @@ proc buildRopeCosSin*(nTokens, rowsPerToken, D: int; positions: seq[int32];
         result.cosT[row * half + t] = cos(ang)
         result.sinT[row * half + t] = sin(ang)
 
-func ggufLinearLauncher(scheme: int): string =
-  ## Metal launcher name for the packed-stream scheme: 0 = Q8_0,
-  ## 1 = Q4_K, 2 = IQ4_XS.
+func ggufLinearLauncher(scheme: GGufScheme): string =
+  ## Metal launcher name for the packed-stream scheme.
   case scheme
-  of 0: "ggufLinearQ8"
-  of 1: "ggufLinearQ4K"
-  of 2: "ggufLinearIQ4XS"
-  else: raise newException(ValueError, "unknown GGUF scheme: " & $scheme)
+  of gsQ8_0: "ggufLinearQ8"
+  of gsQ4_K: "ggufLinearQ4K"
+  of gsIQ4_XS: "ggufLinearIQ4XS"
 
 func slabOffset(pageId, inPage, h, d: int; pageSize, Nkv, D: int): int =
   ## K/V slab offset of (pageId, inPage, head h, dim d) in the flat
@@ -163,6 +165,9 @@ proc ggufAttnForward*(engine: var auto, p: GGufAttnParams, x: seq[uint16],
     "the composed q/k views require H % 8 == 0 and Nkv % 8 == 0"
   doAssert p.pageSize >= 1 and (p.pageSize and (p.pageSize - 1)) == 0,
     "the cache write requires a power-of-two pageSize (shift/mask)"
+  doAssert p.D == 128, "the qk-norm+rope and paged attention kernels run 128-wide"
+  doAssert p.hidden mod 128 == 0,
+    "the o_proj grid tiles hidden in 128-column blocks"
   let numSeqs = p.cuSeqlensQ.len - 1
   let nTokens = p.cuSeqlensQ[numSeqs].int
   doAssert nTokens >= 1, "the forward needs at least one query token"
@@ -216,16 +221,19 @@ proc ggufAttnForward*(engine: var auto, p: GGufAttnParams, x: seq[uint16],
     let writeStart = p.cacheSeqlens[s].int - (if qLen == 1: 1 else: 0)
     for j in 0 ..< qLen:
       let row = writeStart + j
+      doAssert row >= 0, "the cache write row must be non-negative"
       let pageIdx = row shr lgPageSize
+      doAssert pageIdx < p.maxPages, "the cache write row exceeds the block-table budget"
       let inPage = row and pageMask
       let pageId = p.blockTable[s * p.maxPages + pageIdx].int
       doAssert pageId >= 0, "cache write hit an unused block_table slot"
+      # each token's Nkv·D span is one contiguous move on both sides:
+      # the slab row (pageId, inPage) and the kRope/vBuf token row are
+      # both head-dim-contiguous (slabOffset's h·D + d layout)
       let t = q0 + j
-      for h in 0 ..< p.Nkv:
-        for d in 0 ..< p.D:
-          let i = slabOffset(pageId, inPage, h, d, p.pageSize, p.Nkv, p.D)
-          kSlab[i] = result.kRope[(t * p.Nkv + h) * p.D + d]
-          vSlab[i] = result.vBuf[(t * p.Nkv + h) * p.D + d]
+      let dstBase = slabOffset(pageId, inPage, 0, 0, p.pageSize, p.Nkv, p.D)
+      copyMem(addr kSlab[dstBase], addr result.kRope[t * nKv], nKv * 2)
+      copyMem(addr vSlab[dstBase], addr result.vBuf[t * nKv], nKv * 2)
 
   # the paged attention's x extent: the batch's longest q_len in 8-row
   # q blocks (the kernel zero-fills the blocks beyond a seq's own q_len)

--- a/workspace/positron/src/kernels/ceramic/gguf_linear_fwd.nim
+++ b/workspace/positron/src/kernels/ceramic/gguf_linear_fwd.nim
@@ -1,0 +1,73 @@
+## Tattletale
+## Copyright (c) 2026 Mamy André-Ratsimbazafy
+## Licensed and distributed under either of
+##   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+##   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+## at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+# ############################################################
+#
+#     GGUF quantized linear forward (gguf_linear_fwd)
+#
+# ############################################################
+
+## GGUF quantized linear forward: out = x @ W_dequant over the packed
+## GGUF stream. The fp16 weight tiles dequantize in registers via the
+## gguf_ops decoders into the mma-B arrangement (file row = the N axis,
+## file col = the K axis), accumulate in fp32 and round once to fp16 in
+## the epilogue. Static scheme dispatch: 0 = Q8_0, 1 = Q4_K, 2 = IQ4_XS.
+## Grid x = N div 128, grid y = (M + 31) div 32, threadgroup = 32 lanes,
+## M row-bounded. Known contract: K a multiple of 128 (Q8_0) or 256
+## (Q4_K, IQ4_XS), N a multiple of 128.
+
+import workspace/crucible
+import workspace/ceramic
+import ./gguf_ops
+import ./exl3_ops
+import ./tile_io_rows
+
+proc gguf_linear_fwd*(
+    Out: ptr UncheckedArray[float16],    # (M, N) fp16 output
+    x: ptr UncheckedArray[float16],      # (M, K) fp16 input
+    w: ptr UncheckedArray[uint8],        # the packed GGUF stream, N rows × rowBytes
+    M, K, N, rowBytes: int32,
+    scheme: static int) {.device.} =
+  ## Runs the GGUF quantized linear forward for one output block: the
+  ## 32×16 x-tile loads row-bounded at K-block `kk`, each 32-col n-tile
+  ## dequantizes its 16×32 b-tile from the packed stream and
+  ## accumulates into the 4 fp32 accumulators, the epilogue rounds each
+  ## accumulator once to fp16 and stores row-bounded. Grid x = N div
+  ## 128, grid y = (M + 31) div 32, threadgroup = 32 lanes.
+  let tgx = int32(threadgroup_position_in_grid.x)
+  let tgy = int32(threadgroup_position_in_grid.y)
+
+  # x and Out carry the natural row strides (the w stream is addressed
+  # by the decoders through the raw pointer and rowBytes)
+  let glX = x.gd(shape = (-1, -1, -1, -1), stride = (32 * K, 0, K, 1))
+  let glOut = Out.gd(shape = (-1, -1, -1, -1), stride = (32 * N, 0, N, 1))
+
+  # the output accumulators, array-resident and zeroed before the K
+  # loop (declared on the fp16 atom so the mma's three operands share
+  # one fragment layout)
+  var d: array[4, rt_l(float32, 32, 32, getTileConfig(float32, float16))]
+  for i in 0 ..< 4:
+    d[i].zero()
+
+  var a_reg: rt_l(float16, 32, 16)
+  var b_reg: rt_r(float16, 16, 32)
+
+  for kk in 0'i32 ..< K div 16:
+    a_reg.loadTileRows(glX, (0, 0, tgy, kk), M)
+    for nt in 0'i32 ..< 4:
+      when scheme == 0:
+        dequantGGUF_Q8_0(b_reg, w, kk, rowBytes, tgx, nt)
+      elif scheme == 1:
+        dequantGGUF_Q4_K(b_reg, w, kk, rowBytes, tgx, nt)
+      else:
+        dequantGGUF_IQ4_XS(b_reg, w, kk, rowBytes, tgx, nt)
+      d[nt].mma_AB(a_reg, b_reg)
+
+  var y: array[4, rt_l(float16, 32, 32)]
+  for nt in 0'i32 ..< 4:
+    y[nt].convert(d[nt])
+    glOut.storeTileRows(y[nt], (0, 0, tgy, tgx * 4 + nt), M)

--- a/workspace/positron/src/kernels/ceramic/gguf_linear_fwd.nim
+++ b/workspace/positron/src/kernels/ceramic/gguf_linear_fwd.nim
@@ -43,8 +43,8 @@ proc gguf_linear_fwd*(
 
   # x and Out carry the natural row strides (the w stream is addressed
   # by the decoders through the raw pointer and rowBytes)
-  let glX = x.gd(shape = (-1, -1, -1, -1), stride = (32 * K, 0, K, 1))
-  let glOut = Out.gd(shape = (-1, -1, -1, -1), stride = (32 * N, 0, N, 1))
+  let gdX = x.gd(shape = (-1, -1, -1, -1), stride = (32 * K, 0, K, 1))
+  let gdOut = Out.gd(shape = (-1, -1, -1, -1), stride = (32 * N, 0, N, 1))
 
   # the output accumulators, array-resident and zeroed before the K
   # loop (declared on the fp16 atom so the mma's three operands share
@@ -57,7 +57,7 @@ proc gguf_linear_fwd*(
   var b_reg: rt_r(float16, 16, 32)
 
   for kk in 0'i32 ..< K div 16:
-    a_reg.loadTileRows(glX, (0, 0, tgy, kk), M)
+    a_reg.loadTileRows(gdX, (0, 0, tgy, kk), M)
     for nt in 0'i32 ..< 4:
       when scheme == 0:
         dequantGGUF_Q8_0(b_reg, w, kk, rowBytes, tgx, nt)
@@ -70,4 +70,4 @@ proc gguf_linear_fwd*(
   var y: array[4, rt_l(float16, 32, 32)]
   for nt in 0'i32 ..< 4:
     y[nt].convert(d[nt])
-    glOut.storeTileRows(y[nt], (0, 0, tgy, tgx * 4 + nt), M)
+    gdOut.storeTileRows(y[nt], (0, 0, tgy, tgx * 4 + nt), M)

--- a/workspace/positron/src/kernels/ceramic/gguf_ops.nim
+++ b/workspace/positron/src/kernels/ceramic/gguf_ops.nim
@@ -1,0 +1,178 @@
+## Tattletale
+## Copyright (c) 2026 Mamy André-Ratsimbazafy
+## Licensed and distributed under either of
+##   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+##   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+## at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+# ############################################################
+#
+#     GGUF dequant tile ops: Q8_0 / Q4_K / IQ4_XS
+#
+# ############################################################
+
+## GGUF dequant tile ops: the Q8_0, Q4_K and IQ4_XS fp16 weight-tile
+## decoders for the quantized linear forward. Each op decodes one 16×32
+## mma-B b-tile from the packed GGUF byte stream: tile element (k, c) =
+## file element (row = (tgx·4 + nt)·32 + c, col = kk·16 + k), file
+## row-major with row = the N axis and col = the K axis. Every scheme
+## runs its fp32 decode chain in the fixed op order with one fp16 RNE
+## per element at the tile write. Known contract: K and N are
+## 128-multiples.
+
+import workspace/crucible
+import workspace/ceramic
+
+# ═════════════════════════════════════════════════════════════════════
+#  dequantGGUF_Q8_0
+#  ═════════════════════════════════════════════════════════════════════
+
+proc dequantGGUF_Q8_0*[A: static MmaAtom](
+    bReg: var RtRight[float16, 16, 32, A],
+    w: ptr UncheckedArray[uint8],
+    kk, rowBytes: int32,
+    tgx, nt: int32) {.device.} =
+  ## Decodes the 16×32 Q8_0 weight tile at K-block `kk` (file cols
+  ## kk·16 .. kk·16+15), N-tile `nt` of the 128-col output block `tgx`
+  ## (file rows (tgx·4 + nt)·32 .. +31), into the mma-B arrangement.
+  ## The tile spans one 32-col block, constant per call: block =
+  ## kk div 2, within-block col offset = 16·(kk and 1).
+  ##
+  ## File layout per 34-byte block: fp16 scale `d` at bytes 0..1, the
+  ## 32 int8 `q` at bytes 2..33. Decode chain per element, the fixed
+  ## op order: t1 = fp32(d)·q with `q` sign-extended arithmetically,
+  ## one fp16 RNE at the store. `rowBytes` is the byte span of one
+  ## file row.
+  const M = A.getM()
+  const vpt = A.getVpt()
+  let lane = int(thread_index_in_threadgroup)
+  let cell = crd2idx(A.getLayoutA(), (lane, 0)).toIntVal()
+  let row = cell mod M
+  let col = cell div M
+  let baseRow = (tgx * 4 + nt) * 32
+  let baseCol = kk * 16
+  let blockByte = (baseCol div 32) * 34
+  let withinCol = baseCol mod 32
+  for m in 0'i32 ..< 4:
+    for v in 0'i32 ..< vpt:
+      let rowByte = (baseRow + col + 8 * m + v) * rowBytes + blockByte
+      let d = uint16(uint16(w[rowByte]) or (uint16(w[rowByte + 1]) shl 8)).asFp16().to(float32)
+      for n in 0'i32 ..< 2:
+        let k = row + 8 * n
+        let qv = int32(w[rowByte + 2 + withinCol + k])
+        let qF = float32(qv) - 256.0'f32 * float32(qv shr 7)
+        bReg.frags[m][n].frag[v] = (d * qF).to(float16)
+
+# ═════════════════════════════════════════════════════════════════════
+#  dequantGGUF_Q4_K
+#  ═════════════════════════════════════════════════════════════════════
+
+proc dequantGGUF_Q4_K*[A: static MmaAtom](
+    bReg: var RtRight[float16, 16, 32, A],
+    w: ptr UncheckedArray[uint8],
+    kk, rowBytes: int32,
+    tgx, nt: int32) {.device.} =
+  ## Decodes the 16×32 Q4_K weight tile at K-block `kk`, N-tile `nt`
+  ## of `tgx`, into the mma-B arrangement. The tile spans one 32-col
+  ## sub-block, constant per call: super-block = kk div 16, sub-block
+  ## = (kk div 2) and 7, within-sub-block col offset = 16·(kk and 1).
+  ##
+  ## File layout per 144-byte super-block: fp16 `d` at bytes 0..1,
+  ## fp16 `dmin` at bytes 2..3, the 12 scale bytes at bytes 4..15, the
+  ## 128 nibble bytes at bytes 16..143. For sub-block nt (0..7), the
+  ## 6-bit scale and min unpack (llama.cpp get_scale_min_k4):
+  ##
+  ## - nt < 4:  sc = scales[nt] & 0x3F, m = scales[nt+4] & 0x3F
+  ## - nt ≥ 4:  sc = (scales[nt+4] & 0xF) | ((scales[nt-4] shr 6) shl 4)
+  ##            m  = (scales[nt+4] shr 4) | ((scales[nt] shr 6) shl 4)
+  ##
+  ## Nibble at within-sub-block col c: (qs[32·(nt shr 1) + c] shr
+  ## (4·(nt and 1))) and 0xF. Decode chain per element: t1 = fp32(d)·sc,
+  ## t2 = t1·nibble, t3 = t2 − fp32(dmin)·m, one fp16 RNE at the store.
+  const M = A.getM()
+  const vpt = A.getVpt()
+  let lane = int(thread_index_in_threadgroup)
+  let cell = crd2idx(A.getLayoutA(), (lane, 0)).toIntVal()
+  let row = cell mod M
+  let col = cell div M
+  let baseRow = (tgx * 4 + nt) * 32
+  let baseCol = kk * 16
+  let blockByte = (baseCol div 256) * 144
+  let sb = (baseCol div 32) and 7
+  let withinCol = baseCol mod 32
+  for m in 0'i32 ..< 4:
+    for v in 0'i32 ..< vpt:
+      let rowByte = (baseRow + col + 8 * m + v) * rowBytes + blockByte
+      let d = uint16(uint16(w[rowByte]) or (uint16(w[rowByte + 1]) shl 8)).asFp16().to(float32)
+      let dmin = uint16(uint16(w[rowByte + 2]) or (uint16(w[rowByte + 3]) shl 8)).asFp16().to(float32)
+      var scv: int32
+      var mv: int32
+      if sb < 4:
+        scv = int32(w[rowByte + 4 + sb]) and 63
+        mv = int32(w[rowByte + 8 + sb]) and 63
+      else:
+        scv = (int32(w[rowByte + 8 + sb]) and 0xF) or
+              ((int32(w[rowByte + sb]) shr 6) shl 4)
+        mv = (int32(w[rowByte + 8 + sb]) shr 4) or
+             ((int32(w[rowByte + 4 + sb]) shr 6) shl 4)
+      let dl = d * float32(scv)
+      let ml = dmin * float32(mv)
+      for n in 0'i32 ..< 2:
+        let k = row + 8 * n
+        let nib = (int32(w[rowByte + 16 + (sb shr 1) * 32 + withinCol + k]) shr
+                   (4 * (sb and 1))) and 0xF
+        let prod = dl * float32(nib)
+        let wv = prod - ml
+        bReg.frags[m][n].frag[v] = wv.to(float16)
+
+# ═════════════════════════════════════════════════════════════════════
+#  dequantGGUF_IQ4_XS
+#  ═════════════════════════════════════════════════════════════════════
+
+proc dequantGGUF_IQ4_XS*[A: static MmaAtom](
+    bReg: var RtRight[float16, 16, 32, A],
+    w: ptr UncheckedArray[uint8],
+    kk, rowBytes: int32,
+    tgx, nt: int32) {.device.} =
+  ## Decodes the 16×32 IQ4_XS weight tile at K-block `kk`, N-tile `nt`
+  ## of `tgx`, into the mma-B arrangement. The tile spans one 32-col
+  ## sub-block, constant per call: super-block = kk div 16, sub-block
+  ## = (kk div 2) and 7, within-sub-block col offset = 16·(kk and 1).
+  ##
+  ## File layout per 136-byte super-block: fp16 `d` at bytes 0..1, the
+  ## uint16 `sc_h` at bytes 2..3, the 4 scale-low bytes at bytes 4..7,
+  ## the 128 nibble bytes at bytes 8..135. For sub-block j (0..7):
+  ## scale6' = ((scales_l[j shr 1] shr (4·(j and 1))) and 0xF) or
+  ## (((sc_h shr (2·j)) and 0x3) shl 4) − 32. Nibble at within-sub-block
+  ## col p: (qs[16·j + (p mod 16)] shr (4·(p div 16))) and 0xF, with
+  ## the 16-entry kvaluesIQ4NL codebook. Decode chain per element:
+  ## t1 = fp32(d)·scale6', t2 = t1·kvaluesIQ4NL[nibble], one fp16 RNE
+  ## at the store.
+  const M = A.getM()
+  const vpt = A.getVpt()
+  const kvaluesIQ4NL = [int32(-127), -104, -83, -65, -49, -35, -22, -10,
+                         1, 13, 25, 38, 53, 69, 89, 113]
+  let lane = int(thread_index_in_threadgroup)
+  let cell = crd2idx(A.getLayoutA(), (lane, 0)).toIntVal()
+  let row = cell mod M
+  let col = cell div M
+  let baseRow = (tgx * 4 + nt) * 32
+  let baseCol = kk * 16
+  let blockByte = (baseCol div 256) * 136
+  let j = (baseCol div 32) and 7
+  let withinCol = baseCol mod 32
+  for m in 0'i32 ..< 4:
+    for v in 0'i32 ..< vpt:
+      let rowByte = (baseRow + col + 8 * m + v) * rowBytes + blockByte
+      let d = uint16(uint16(w[rowByte]) or (uint16(w[rowByte + 1]) shl 8)).asFp16().to(float32)
+      let scH = uint16(uint16(w[rowByte + 2]) or (uint16(w[rowByte + 3]) shl 8))
+      let low4 = (int32(w[rowByte + 4 + (j shr 1)]) shr (4 * (j and 1))) and 0xF
+      let high2 = (int32(scH) shr (2 * j)) and 0x3
+      let scale6v = (low4 or (high2 shl 4)) - 32
+      let dl = d * float32(scale6v)
+      for n in 0'i32 ..< 2:
+        let p = withinCol + row + 8 * n
+        let nib = (int32(w[rowByte + 8 + 16 * j + (p mod 16)]) shr
+                   (4 * (p div 16))) and 0xF
+        let prod = dl * float32(kvaluesIQ4NL[nib])
+        bReg.frags[m][n].frag[v] = prod.to(float16)

--- a/workspace/positron/tests/gguf_test_utils.nim
+++ b/workspace/positron/tests/gguf_test_utils.nim
@@ -49,7 +49,8 @@ func fp16sToF32*(hs: seq[uint16]): seq[float32] =
 proc genQ8_0*(K, N, seed: int): seq[uint8] =
   ## Deterministic packed Q8_0 stream: N rows × (K div 32) blocks of
   ## 34 bytes. d = fp16-exact per (row, block), q = int8 spanning the
-  ## signed range.
+  ## signed range. Requires K a 32-multiple.
+  doAssert K mod 32 == 0, "Q8_0 packs 32 columns per block, K must be a 32-multiple"
   let blocks = K div 32
   let rowBytes = blocks * 34
   result = newSeq[uint8](N * rowBytes)
@@ -77,7 +78,9 @@ proc genQ4_K*(K, N, seed: int): seq[uint8] =
   ## Deterministic packed Q4_K stream: N rows × (K div 256)
   ## super-blocks of 144 bytes. d, dmin, the 12 scale bytes and the
   ## nibble bytes are per-index mixes. The scale bytes exercise both
-  ## the nt < 4 and the nt ≥ 4 unpack branches.
+  ## the nt < 4 and the nt ≥ 4 unpack branches. Requires K a
+  ## 256-multiple.
+  doAssert K mod 256 == 0, "Q4_K packs 256 columns per super-block, K must be a 256-multiple"
   let sbs = K div 256
   let rowBytes = sbs * 144
   result = newSeq[uint8](N * rowBytes)
@@ -114,7 +117,8 @@ proc genQ4_K*(K, N, seed: int): seq[uint8] =
 proc genIQ4_XS*(K, N, seed: int): seq[uint8] =
   ## Deterministic packed IQ4_XS stream: N rows × (K div 256)
   ## super-blocks of 136 bytes. d, sc_h, the 4 scale-low bytes and the
-  ## nibble bytes are per-index mixes.
+  ## nibble bytes are per-index mixes. Requires K a 256-multiple.
+  doAssert K mod 256 == 0, "IQ4_XS packs 256 columns per super-block, K must be a 256-multiple"
   let sbs = K div 256
   let rowBytes = sbs * 136
   result = newSeq[uint8](N * rowBytes)
@@ -161,7 +165,8 @@ func decodeWeightsQ8_0*(packed: seq[uint8], K, N: int): seq[uint16] =
   ## order: element (row r over N, col c over K) at index r·K + c. Per
   ## (row, block) a 256-entry table holds fp32(d)·q for every int8 q,
   ## the gather rounds once with fp32ToFp16 (RNE), the kernel's exact
-  ## chain.
+  ## chain. Requires K a 32-multiple.
+  doAssert K mod 32 == 0, "Q8_0 packs 32 columns per block, K must be a 32-multiple"
   let blocks = K div 32
   let rowBytes = blocks * 34
   result = newSeq[uint16](N * K)
@@ -182,7 +187,8 @@ func decodeWeightsQ4_K*(packed: seq[uint8], K, N: int): seq[uint16] =
   ## (row, super-block, sub-block) a 16-entry table holds
   ## t2 = (fp32(d)·sc)·nibble − fp32(dmin)·m for every nibble, the
   ## gather rounds once with fp32ToFp16 (RNE), the kernel's exact
-  ## chain order.
+  ## chain order. Requires K a 256-multiple.
+  doAssert K mod 256 == 0, "Q4_K packs 256 columns per super-block, K must be a 256-multiple"
   let sbs = K div 256
   let rowBytes = sbs * 144
   result = newSeq[uint16](N * K)
@@ -218,7 +224,9 @@ func decodeWeightsIQ4_XS*(packed: seq[uint8], K, N: int): seq[uint16] =
   ## file order: element (row r over N, col c over K) at index r·K + c.
   ## Per (row, super-block, sub-block) a 16-entry table holds
   ## fp32(d)·scale6'·kvaluesIQ4NL[nibble], the gather rounds once with
-  ## fp32ToFp16 (RNE), the kernel's exact chain order.
+  ## fp32ToFp16 (RNE), the kernel's exact chain order. Requires K a
+  ## 256-multiple.
+  doAssert K mod 256 == 0, "IQ4_XS packs 256 columns per super-block, K must be a 256-multiple"
   let sbs = K div 256
   let rowBytes = sbs * 136
   result = newSeq[uint16](N * K)

--- a/workspace/positron/tests/gguf_test_utils.nim
+++ b/workspace/positron/tests/gguf_test_utils.nim
@@ -1,0 +1,241 @@
+## Tattletale
+## Copyright (c) 2026 Mamy André-Ratsimbazafy
+## Licensed and distributed under either of
+##   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+##   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+## at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+## Shared GGUF test support: the deterministic packed block-stream
+## generators (one per scheme), the decode-table fp16 weight
+## reconstruction that rebuilds the weight matrix from the packed bytes
+## in file order, and the fp16 value helpers the linear and attn tests
+## share. The single home of the reconstruction, imported by later
+## GGUF tests instead of re-derived. The reconstruction is an
+## independent reference and never imports the kernel ops.
+
+import ../../ceramic/tests/tile_test_utils
+
+# ═════════════════════════════════════════════════════════════════════
+#  Deterministic values
+#  ═════════════════════════════════════════════════════════════════════
+
+func ggufMix(r, c, seed: int): int =
+  ## Deterministic 0..31 mix of the seed and the (row, col) index. The
+  ## (c div 32) and (r div 32) terms keep the pattern off the 32-col
+  ## block and the 32-row tile (the exl3Val pattern).
+  (seed * (r + 1) + 7 * c + 11 * seed + 13 * (c div 32) +
+   17 * (r div 32)) mod 32
+
+func ggufFp16(r, c, seed: int): uint16 =
+  ## Deterministic fp16-exact value: an fp16 grid point in [-4.0, 3.75]
+  ## at 0.25 steps (0.25·k is exactly representable in fp16, so
+  ## fp32ToFp16 is exact).
+  fp32ToFp16(0.25'f32 * float32(ggufMix(r, c, seed) - 16))
+
+func buildX*(M, K, seed: int, scale: float32): seq[uint16] =
+  ## Deterministic fp16-exact x buffer, row-major M×K: 0.25-grid points scaled by `scale`.
+  for r in 0 ..< M:
+    for c in 0 ..< K:
+      result.add fp32ToFp16(scale * 0.25'f32 * float32(ggufMix(r, c, seed) - 16))
+
+func fp16sToF32*(hs: seq[uint16]): seq[float32] =
+  ## Widens an fp16 bit buffer to fp32 values, one fp16ToFp32 per element.
+  for h in hs: result.add fp16ToFp32(h)
+
+# ═════════════════════════════════════════════════════════════════════
+#  Packed stream generators (file order: N rows × rowBytes)
+#  ═════════════════════════════════════════════════════════════════════
+
+proc genQ8_0*(K, N, seed: int): seq[uint8] =
+  ## Deterministic packed Q8_0 stream: N rows × (K div 32) blocks of
+  ## 34 bytes. d = fp16-exact per (row, block), q = int8 spanning the
+  ## signed range.
+  let blocks = K div 32
+  let rowBytes = blocks * 34
+  result = newSeq[uint8](N * rowBytes)
+  for r in 0 ..< N:
+    for b in 0 ..< blocks:
+      let base = r * rowBytes + b * 34
+      let d16 = ggufFp16(r, b * 32, seed)
+      result[base] = uint8(d16 and 0xFF)
+      result[base + 1] = uint8(d16 shr 8)
+      for i in 0 ..< 32:
+        let c = b * 32 + i
+        let g = r * K + c
+        if g mod 7 == 0:
+          # every 7th element takes one of the int8 boundaries so the
+          # 0x80 / 0x7F / 0x00 byte handling cannot silently drift
+          let e = (g div 7) mod 3
+          result[base + 2 + i] = if e == 0: 0x80'u8
+                                 elif e == 1: 0x7F'u8
+                                 else: 0x00'u8
+        else:
+          let qv = ggufMix(r, c, seed + 1) * 8 - 127
+          result[base + 2 + i] = uint8(qv and 0xFF)
+
+proc genQ4_K*(K, N, seed: int): seq[uint8] =
+  ## Deterministic packed Q4_K stream: N rows × (K div 256)
+  ## super-blocks of 144 bytes. d, dmin, the 12 scale bytes and the
+  ## nibble bytes are per-index mixes. The scale bytes exercise both
+  ## the nt < 4 and the nt ≥ 4 unpack branches.
+  let sbs = K div 256
+  let rowBytes = sbs * 144
+  result = newSeq[uint8](N * rowBytes)
+  for r in 0 ..< N:
+    for sb in 0 ..< sbs:
+      let base = r * rowBytes + sb * 144
+      let d16 = ggufFp16(r, sb * 256, seed)
+      let dm16 = ggufFp16(r, sb * 256 + 8, seed + 2)
+      result[base] = uint8(d16 and 0xFF)
+      result[base + 1] = uint8(d16 shr 8)
+      result[base + 2] = uint8(dm16 and 0xFF)
+      result[base + 3] = uint8(dm16 shr 8)
+      # the 12 scale bytes: 0..3 sc low-6 of sub-blocks 0..3, 4..7 m
+      # low-6 of sub-blocks 0..3, 8..11 the sc low-4 and m high-4 of
+      # sub-blocks 4..7. Bits 6..7 of bytes 0..3 and 4..7 also carry
+      # the cross-byte high-2 sc and m terms of the nt ≥ 4 unpack
+      # (scales[nt-4] shr 6, scales[nt] shr 6). The low-3 bits of
+      # bytes 8..11 vary the sc low-4 field beyond {0, 8}.
+      for t in 0 ..< 4:
+        let mixSc = ggufMix(r, sb * 256 + t, seed + 3)
+        let mixM = ggufMix(r, sb * 256 + 16 + t, seed + 4)
+        let mixSc4 = ggufMix(r, sb * 256 + 32 + t, seed + 5)
+        result[base + 4 + t] = uint8(mixSc * 2 + 64 * (mixSc mod 4))
+        result[base + 8 + t] = uint8(mixM * 2 + 1 + 64 * (mixM mod 4))
+        result[base + 12 + t] = uint8(mixSc4 * 8 + (mixSc4 mod 8))
+      # the 128 nibble bytes: byte 32·j + c holds sub-block 2j col c
+      # in the low nibble and sub-block 2j+1 col c in the high nibble
+      for j in 0 ..< 4:
+        for c in 0 ..< 32:
+          let lo = ggufMix(r, sb * 256 + j * 64 + c, seed + 6) mod 16
+          let hi = ggufMix(r, sb * 256 + j * 64 + 32 + c, seed + 7) mod 16
+          result[base + 16 + 32 * j + c] = uint8(lo or (hi shl 4))
+
+proc genIQ4_XS*(K, N, seed: int): seq[uint8] =
+  ## Deterministic packed IQ4_XS stream: N rows × (K div 256)
+  ## super-blocks of 136 bytes. d, sc_h, the 4 scale-low bytes and the
+  ## nibble bytes are per-index mixes.
+  let sbs = K div 256
+  let rowBytes = sbs * 136
+  result = newSeq[uint8](N * rowBytes)
+  for r in 0 ..< N:
+    for sb in 0 ..< sbs:
+      let base = r * rowBytes + sb * 136
+      let d16 = ggufFp16(r, sb * 256, seed)
+      result[base] = uint8(d16 and 0xFF)
+      result[base + 1] = uint8(d16 shr 8)
+      # sc_h: 8 two-bit fields, field j is the high-2 scale bits of
+      # sub-block j
+      var scH: uint16 = 0
+      for j in 0 ..< 8:
+        scH = scH or uint16((ggufMix(r, sb * 256 + 32 + j, seed + 7) mod 4) shl (2 * j))
+      result[base + 2] = uint8(scH and 0xFF)
+      result[base + 3] = uint8(scH shr 8)
+      # the 4 scale-low bytes: byte t holds the low nibble of sub-block
+      # 2t and the high nibble of sub-block 2t+1
+      for t in 0 ..< 4:
+        let loN = ggufMix(r, sb * 256 + 8 + t, seed + 5) mod 16
+        let hiN = ggufMix(r, sb * 256 + 16 + t, seed + 6) mod 16
+        result[base + 4 + t] = uint8(loN or (hiN shl 4))
+      # the 128 nibble bytes: byte 16·j + (p mod 16) holds sub-block j
+      # col p's nibble at shift 4·(p div 16)
+      var qs = newSeq[uint8](128)
+      for j in 0 ..< 8:
+        for p in 0 ..< 32:
+          let nib = ggufMix(r, sb * 256 + 64 + j * 32 + p, seed + 8) mod 16
+          qs[16 * j + (p mod 16)] =
+            uint8(int(qs[16 * j + (p mod 16)]) or (nib shl (4 * (p div 16))))
+      for i in 0 ..< 128:
+        result[base + 8 + i] = qs[i]
+
+# ═════════════════════════════════════════════════════════════════════
+#  The decode-table reconstruction (file order, one fp16 RNE per element)
+#  ═════════════════════════════════════════════════════════════════════
+
+const kvaluesIQ4NL = [-127, -104, -83, -65, -49, -35, -22, -10,
+                       1, 13, 25, 38, 53, 69, 89, 113]
+  ## 16-entry IQ4_NL codebook: the fp32 multiply factor of nibble v.
+
+func decodeWeightsQ8_0*(packed: seq[uint8], K, N: int): seq[uint16] =
+  ## Rebuilds the fp16 weight matrix from a packed Q8_0 stream in file
+  ## order: element (row r over N, col c over K) at index r·K + c. Per
+  ## (row, block) a 256-entry table holds fp32(d)·q for every int8 q,
+  ## the gather rounds once with fp32ToFp16 (RNE), the kernel's exact
+  ## chain.
+  let blocks = K div 32
+  let rowBytes = blocks * 34
+  result = newSeq[uint16](N * K)
+  for r in 0 ..< N:
+    for b in 0 ..< blocks:
+      let base = r * rowBytes + b * 34
+      let d = fp16ToFp32(uint16(packed[base]) or (uint16(packed[base + 1]) shl 8))
+      var table: array[256, float32]
+      for qi in 0 ..< 256:
+        let qv = int32(qi)
+        table[qi] = d * (float32(qv) - 256.0'f32 * float32(qv shr 7))
+      for i in 0 ..< 32:
+        result[r * K + b * 32 + i] = fp32ToFp16(table[int(packed[base + 2 + i])])
+
+func decodeWeightsQ4_K*(packed: seq[uint8], K, N: int): seq[uint16] =
+  ## Rebuilds the fp16 weight matrix from a packed Q4_K stream in file
+  ## order: element (row r over N, col c over K) at index r·K + c. Per
+  ## (row, super-block, sub-block) a 16-entry table holds
+  ## t2 = (fp32(d)·sc)·nibble − fp32(dmin)·m for every nibble, the
+  ## gather rounds once with fp32ToFp16 (RNE), the kernel's exact
+  ## chain order.
+  let sbs = K div 256
+  let rowBytes = sbs * 144
+  result = newSeq[uint16](N * K)
+  for r in 0 ..< N:
+    for sb in 0 ..< sbs:
+      let base = r * rowBytes + sb * 144
+      let d = fp16ToFp32(uint16(packed[base]) or (uint16(packed[base + 1]) shl 8))
+      let dmin = fp16ToFp32(uint16(packed[base + 2]) or (uint16(packed[base + 3]) shl 8))
+      for nt in 0 ..< 8:
+        var scv: int
+        var mv: int
+        if nt < 4:
+          scv = int(packed[base + 4 + nt]) and 63
+          mv = int(packed[base + 8 + nt]) and 63
+        else:
+          scv = (int(packed[base + 8 + nt]) and 0xF) or
+                ((int(packed[base + nt]) shr 6) shl 4)
+          mv = (int(packed[base + 8 + nt]) shr 4) or
+               ((int(packed[base + 4 + nt]) shr 6) shl 4)
+        let dl = d * float32(scv)
+        let ml = dmin * float32(mv)
+        var table: array[16, float32]
+        for nib in 0 ..< 16:
+          let prod = dl * float32(nib)
+          table[nib] = prod - ml
+        for c in 0 ..< 32:
+          let nib = (int(packed[base + 16 + (nt shr 1) * 32 + c]) shr
+                     (4 * (nt and 1))) and 0xF
+          result[r * K + sb * 256 + nt * 32 + c] = fp32ToFp16(table[nib])
+
+func decodeWeightsIQ4_XS*(packed: seq[uint8], K, N: int): seq[uint16] =
+  ## Rebuilds the fp16 weight matrix from a packed IQ4_XS stream in
+  ## file order: element (row r over N, col c over K) at index r·K + c.
+  ## Per (row, super-block, sub-block) a 16-entry table holds
+  ## fp32(d)·scale6'·kvaluesIQ4NL[nibble], the gather rounds once with
+  ## fp32ToFp16 (RNE), the kernel's exact chain order.
+  let sbs = K div 256
+  let rowBytes = sbs * 136
+  result = newSeq[uint16](N * K)
+  for r in 0 ..< N:
+    for sb in 0 ..< sbs:
+      let base = r * rowBytes + sb * 136
+      let d = fp16ToFp32(uint16(packed[base]) or (uint16(packed[base + 1]) shl 8))
+      let scH = uint16(packed[base + 2]) or (uint16(packed[base + 3]) shl 8)
+      for j in 0 ..< 8:
+        let low4 = (int(packed[base + 4 + (j shr 1)]) shr (4 * (j and 1))) and 0xF
+        let high2 = (int(scH) shr (2 * j)) and 0x3
+        let scale6v = (low4 or (high2 shl 4)) - 32
+        let dl = d * float32(scale6v)
+        var table: array[16, float32]
+        for nib in 0 ..< 16:
+          table[nib] = dl * float32(kvaluesIQ4NL[nib])
+        for p in 0 ..< 32:
+          let nib = (int(packed[base + 8 + 16 * j + (p mod 16)]) shr
+                     (4 * (p div 16))) and 0xF
+          result[r * K + sb * 256 + j * 32 + p] = fp32ToFp16(table[nib])

--- a/workspace/positron/tests/manual_gguf_attn_fp16.nim
+++ b/workspace/positron/tests/manual_gguf_attn_fp16.nim
@@ -1,0 +1,272 @@
+## Tattletale
+## Copyright (c) 2026 Mamy André-Ratsimbazafy
+## Licensed and distributed under either of
+##   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+##   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+## at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+##
+## Run: nim cpp -r --hints:off --warnings:off \
+##   --outdir:build/wip \
+##   --nimcache:nimcache/wip \
+##   workspace/positron/tests/manual_gguf_attn_fp16.nim
+
+import std/[strformat, options, math, bitops]
+import workspace/crucible
+import workspace/libtorch
+import workspace/libtorch as F
+import workspace/libtorch_testutils
+import ../../ceramic/tests/tile_test_utils
+import ../src/kernels/ceramic/gguf_attn
+import ./gguf_test_utils
+
+type
+  AttnTensors = object
+    ## Per-stage fp16 outputs widened to fp32 tensors.
+    qBuf, kBuf, vBuf, qRope, kRope, attnOut, outBuf: F.Tensor
+
+proc gammaVal(c, seed: int): float32 =
+  ## Deterministic fp16-exact norm weight in [0.5, 1.5).
+  let k = (7 * c + 11 * seed + 13 * (c div 32)) mod 16
+  0.5'f32 + float32(k) / 16.0'f32
+
+proc scaleQ4K(stream: seq[uint8], shift: int): seq[uint8] =
+  ## Scales the d and dmin fp16 fields of every 144-byte Q4_K
+  ## super-block by 2^-shift (exact in fp16). The test applies it to
+  ## the o stream: the native Q4_K scale over the o_proj's K = 2048
+  ## yields ~1e3 outputs, where the fp16 output ulp (1.0) alone
+  ## exceeds the 5e-3 absolute tolerance. The 2^-12 shift brings the
+  ## layer output to O(1). The reference decodes the same packed bytes.
+  result = stream
+  let sbs = stream.len div 144
+  for sb in 0 ..< sbs:
+    let base = sb * 144
+    for off in [0, 2]:
+      let d16 = uint16(result[base + off]) or (uint16(result[base + off + 1]) shl 8)
+      let scaled = fp32ToFp16(fp16ToFp32(d16) / float32(1 shl shift))
+      result[base + off] = uint8(scaled and 0xFF)
+      result[base + off + 1] = uint8(scaled shr 8)
+
+proc worstAbsDiff(a, b: F.Tensor): float32 =
+  ## Largest |a[i] - b[i]| over all elements.
+  doAssert a.numel() == b.numel(), "worstAbsDiff needs equal element counts"
+  let ap = a.contiguous().data_ptr(float32)
+  let bp = b.contiguous().data_ptr(float32)
+  result = 0.0'f32
+  for i in 0 ..< a.numel():
+    let d = abs(ap[i] - bp[i])
+    if d > result: result = d
+
+proc decodeWeights(scheme: int, packed: seq[uint8], K, N: int): seq[uint16] =
+  ## (N, K) file-order fp16 reconstruction for the packed scheme.
+  case scheme
+  of 0: decodeWeightsQ8_0(packed, K, N)
+  of 1: decodeWeightsQ4_K(packed, K, N)
+  of 2: decodeWeightsIQ4_XS(packed, K, N)
+  else: raise newException(ValueError, "unknown scheme: " & $scheme)
+
+proc tensorFromFp16(hs: seq[uint16], rows, cols: int): F.Tensor =
+  ## fp16 bit buffer widened to a (rows, cols) fp32 tensor.
+  var f = newSeq[float32](hs.len)
+  for i in 0 ..< hs.len: f[i] = fp16ToFp32(hs[i])
+  toTensor(f).reshape(rows, cols)
+
+proc kernelUnderTest(p: GGufAttnParams, x: seq[uint16],
+                     kSlab, vSlab: var seq[uint16]): AttnTensors =
+  ## Runs `ggufAttnForward` and widens each fp16 stage to fp32 tensors.
+  var engine = bkMetal.init()
+  engine.ingest(ggufAttnMsl)
+  let r = ggufAttnForward(engine, p, x, kSlab, vSlab)
+  let nTokens = p.cuSeqlensQ[^1].int
+  result.qBuf = tensorFromFp16(r.qBuf, nTokens, p.H * p.D)
+  result.kBuf = tensorFromFp16(r.kBuf, nTokens, p.Nkv * p.D)
+  result.vBuf = tensorFromFp16(r.vBuf, nTokens, p.Nkv * p.D)
+  result.qRope = tensorFromFp16(r.qRope, nTokens, p.H * p.D)
+  result.kRope = tensorFromFp16(r.kRope, nTokens, p.Nkv * p.D)
+  result.attnOut = tensorFromFp16(r.attnOut, nTokens, p.H * p.D)
+  result.outBuf = tensorFromFp16(r.outBuf, nTokens, p.hidden)
+
+proc qkNormRopeRef(qT: F.Tensor, gamma: seq[uint16], cosT, sinT: seq[float32],
+                   rowsPerToken, D: int, eps: float32): F.Tensor =
+  ## Torch qk-norm+rope: rms_norm per (nTokens·rowsPerToken, D)
+  ## row, the fp16 two-rounding, the fp32 NEOX rotation with the
+  ## (nTokens·rowsPerToken, 64) tables, reshaped to the 3D layout.
+  let rows = qT.size(0) * rowsPerToken
+  let flat = qT.reshape(rows, D)
+  let normed = rms_norm(flat, D, F.ones(D, kFloat32), float64(eps))
+  let xr = normed.to(kFloat16)
+  let gT = toTensor(fp16sToF32(gamma)).reshape(1, D).to(kFloat16)
+  let xg = (xr.to(kFloat32) * gT.to(kFloat32)).to(kFloat16).to(kFloat32)
+  let cosTns = toTensor(cosT).reshape(rows, D div 2)
+  let sinTns = toTensor(sinT).reshape(rows, D div 2)
+  let t1 = (xg.narrow(1, 0, D div 2) * cosTns -
+            xg.narrow(1, D div 2, D div 2) * sinTns).to(kFloat16)
+  let t2 = (xg.narrow(1, D div 2, D div 2) * cosTns +
+            xg.narrow(1, 0, D div 2) * sinTns).to(kFloat16)
+  F.cat([t1, t2], 1).reshape(qT.size(0), rowsPerToken, D).to(kFloat32)
+
+proc writeRefSlab(dst: var seq[float32], src: F.Tensor, p: GGufAttnParams,
+                  rowsPerToken: int) =
+  ## Fills the flat (num_pages·page_size·Nkv·D) fp32 slab from the
+  ## reference's own kRope/v with the driver's write-band addressing
+  ## (rows outside the bands stay zero).
+  let lgPageSize = countTrailingZeroBits(p.pageSize)
+  let pageMask = p.pageSize - 1
+  let sp = src.contiguous().data_ptr(float32)
+  for s in 0 ..< p.cuSeqlensQ.len - 1:
+    let qLen = (p.cuSeqlensQ[s + 1] - p.cuSeqlensQ[s]).int
+    let q0 = p.cuSeqlensQ[s].int
+    let writeStart = p.cacheSeqlens[s].int - (if qLen == 1: 1 else: 0)
+    for j in 0 ..< qLen:
+      let row = writeStart + j
+      let pageIdx = row shr lgPageSize
+      let inPage = row and pageMask
+      let pageId = p.blockTable[s * p.maxPages + pageIdx].int
+      let t = q0 + j
+      for h in 0 ..< p.Nkv:
+        for d in 0 ..< p.D:
+          let i = (pageId * p.pageSize + inPage) * (p.Nkv * p.D) + h * p.D + d
+          dst[i] = sp[(t * rowsPerToken + h) * p.D + d]
+
+proc gatherKv(src: F.Tensor, blockTable: seq[int32], maxPages, pageSize,
+              covered, s: int): F.Tensor =
+  ## Seq's K or V rows from the slab via the kernel's fetch math:
+  ## block_table[s, t div page_size]·page_size + t mod page_size.
+  var idx = newSeq[int64](covered)
+  for t in 0 ..< covered:
+    let pageIdx = t div pageSize
+    let inPage = t mod pageSize
+    idx[t] = int64(blockTable[s * maxPages + pageIdx] * pageSize + inPage)
+  src.index_select(0, toTensor(idx))
+
+proc sdpaDecode(qt, kt, vt: F.Tensor, H, Nkv: int): F.Tensor =
+  ## q (1, H, 1, D), k/v (covered, Nkv, D), causal off, GQA on.
+  let k2 = kt.reshape(1, kt.size(0), Nkv, kt.size(2)).transpose(1, 2)
+  let v2 = vt.reshape(1, vt.size(0), Nkv, vt.size(2)).transpose(1, 2)
+  scaled_dot_product_attention(qt, k2, v2, enable_gqa = H > Nkv)
+
+proc sdpaPrefill(qt, kt, vt: F.Tensor, cacheSeqlen, qLen, H, Nkv: int): F.Tensor =
+  ## q (1, H, qLen, D), k/v (covered, Nkv, D), banded causal mask over
+  ## [0, cache_seqlen + q_len), GQA on.
+  let covered = cacheSeqlen + qLen
+  var maskF = newSeq[float32](qLen * covered)
+  for j in 0 ..< qLen:
+    for k in 0 ..< covered:
+      maskF[j * covered + k] = if k <= cacheSeqlen + j: 0.0'f32 else: float32(NegInf)
+  let k2 = kt.reshape(1, covered, Nkv, kt.size(2)).transpose(1, 2)
+  let v2 = vt.reshape(1, covered, Nkv, vt.size(2)).transpose(1, 2)
+  let mt = toTensor(maskF).reshape(1, qLen, covered)
+  scaled_dot_product_attention(qt, k2, v2, attn_mask = some(mt), enable_gqa = H > Nkv)
+
+proc reference(p: GGufAttnParams, x: seq[uint16], numPages: int): AttnTensors =
+  ## Torch composition: F.linear projections, rms_norm + rope with
+  ## the driver's cos/sin tables, the reference's own slab writes,
+  ## per-seq SDPA with GQA, then the o_proj. Every fp16 round mirrors
+  ## the kernel's fp16 buffers. The slabs never come from the kernel.
+  let nTokens = p.cuSeqlensQ[^1].int
+  let nQ = p.H * p.D
+  let nKv = p.Nkv * p.D
+  let xT = toTensor(fp16sToF32(x)).reshape(nTokens, p.hidden).to(kFloat16).to(kFloat32)
+  let wq = toTensor(fp16sToF32(decodeWeights(p.qScheme, p.qw, p.hidden, nQ))).reshape(nQ, p.hidden).to(kFloat16).to(kFloat32)
+  let wk = toTensor(fp16sToF32(decodeWeights(p.kScheme, p.kw, p.hidden, nKv))).reshape(nKv, p.hidden).to(kFloat16).to(kFloat32)
+  let wv = toTensor(fp16sToF32(decodeWeights(p.vScheme, p.vw, p.hidden, nKv))).reshape(nKv, p.hidden).to(kFloat16).to(kFloat32)
+  let wo = toTensor(fp16sToF32(decodeWeights(p.oScheme, p.ow, nQ, p.hidden))).reshape(p.hidden, nQ).to(kFloat16).to(kFloat32)
+  result.qBuf = F.linear(xT, wq).to(kFloat16).to(kFloat32)
+  result.kBuf = F.linear(xT, wk).to(kFloat16).to(kFloat32)
+  result.vBuf = F.linear(xT, wv).to(kFloat16).to(kFloat32)
+  let (cosQ, sinQ) = buildRopeCosSin(nTokens, p.H, p.D, p.positions, p.theta)
+  let (cosK, sinK) = buildRopeCosSin(nTokens, p.Nkv, p.D, p.positions, p.theta)
+  result.qRope = qkNormRopeRef(result.qBuf, p.normGammaQ, cosQ, sinQ, p.H, p.D, p.eps)
+  result.kRope = qkNormRopeRef(result.kBuf, p.normGammaK, cosK, sinK, p.Nkv, p.D, p.eps)
+  var kSlab = newSeq[float32](numPages * p.pageSize * p.Nkv * p.D)
+  var vSlab = newSeq[float32](numPages * p.pageSize * p.Nkv * p.D)
+  writeRefSlab(kSlab, result.kRope, p, p.Nkv)
+  writeRefSlab(vSlab, result.vBuf, p, p.Nkv)
+  let kT = toTensor(kSlab).reshape(numPages * p.pageSize, p.Nkv, p.D).to(kFloat16).to(kFloat32)
+  let vT = toTensor(vSlab).reshape(numPages * p.pageSize, p.Nkv, p.D).to(kFloat16).to(kFloat32)
+  var attnOutRef = newSeq[float32](nTokens * nQ)
+  let qp = result.qRope.contiguous().data_ptr(float32)
+  for s in 0 ..< p.cuSeqlensQ.len - 1:
+    let qLen = (p.cuSeqlensQ[s + 1] - p.cuSeqlensQ[s]).int
+    let q0 = p.cuSeqlensQ[s].int
+    let covered = p.cacheSeqlens[s].int + qLen - (if qLen == 1: 1 else: 0)
+    let kt = gatherKv(kT, p.blockTable, p.maxPages, p.pageSize, covered, s)
+    let vt = gatherKv(vT, p.blockTable, p.maxPages, p.pageSize, covered, s)
+    let qt = if qLen == 1:
+               result.qRope.narrow(0, q0, 1).reshape(1, p.H, 1, p.D)
+             else:
+               var qf2 = newSeq[float32](qLen * p.H * p.D)
+               for h in 0 ..< p.H:
+                 for j in 0 ..< qLen:
+                   for dd in 0 ..< p.D:
+                     qf2[(h * qLen + j) * p.D + dd] = qp[((q0 + j) * p.H + h) * p.D + dd]
+               toTensor(qf2).reshape(1, p.H, qLen, p.D)
+    let ot = if qLen == 1: sdpaDecode(qt, kt, vt, p.H, p.Nkv)
+             else: sdpaPrefill(qt, kt, vt, p.cacheSeqlens[s].int, qLen, p.H, p.Nkv)
+    let pT = ot.contiguous().data_ptr(float32)
+    for h in 0 ..< p.H:
+      for j in 0 ..< qLen:
+        for dd in 0 ..< p.D:
+          attnOutRef[((q0 + j) * p.H + h) * p.D + dd] = pT[(h * qLen + j) * p.D + dd]
+  result.attnOut = toTensor(attnOutRef).reshape(nTokens, nQ).to(kFloat16).to(kFloat32)
+  result.outBuf = F.linear(result.attnOut, wo).to(kFloat16).to(kFloat32)
+
+proc checkGGUFAttn(): bool =
+  ## One mixed decode/prefill batch with all three schemes across the
+  ## four projections: per-stage kernel output vs the torch reference.
+  let hidden = 256
+  let H = 16
+  let Nkv = 8
+  let D = 128
+  let nQ = H * D
+  let nKv = Nkv * D
+  let numPages = 4
+  let pageSize = 16
+  let maxPages = 3
+  let nTokens = 4
+  let qw = genQ4_K(hidden, nQ, 1)
+  let kw = genIQ4_XS(hidden, nKv, 2)
+  let vw = genQ8_0(hidden, nKv, 3)
+  let ow = scaleQ4K(genQ4_K(nQ, hidden, 4), 12)
+  var gammaQ = newSeq[uint16](D)
+  var gammaK = newSeq[uint16](D)
+  for c in 0 ..< D:
+    gammaQ[c] = fp32ToFp16(gammaVal(c, 5))
+    gammaK[c] = fp32ToFp16(gammaVal(c, 7))
+  var p = GGufAttnParams(
+    hidden: hidden, H: H, Nkv: Nkv, D: D,
+    pageSize: pageSize, maxPages: maxPages,
+    eps: 1e-6'f32, theta: 1e6'f32,
+    cacheSeqlens: @[20'i32, 0],
+    cuSeqlensQ: @[0'i32, 1, 4],
+    blockTable: @[0'i32, 1, -1, 2, 3, -1],
+    positions: @[19'i32, 0, 1, 2],
+    qw: qw, kw: kw, vw: vw, ow: ow,
+    qRowBytes: int32(qw.len div nQ),
+    kRowBytes: int32(kw.len div nKv),
+    vRowBytes: int32(vw.len div nKv),
+    oRowBytes: int32(ow.len div hidden),
+    qScheme: 1, kScheme: 2, vScheme: 0, oScheme: 1,
+    normGammaQ: gammaQ, normGammaK: gammaK)
+  let x = buildX(nTokens, hidden, 11, 1.0'f32 / 65536.0'f32)
+  var kSlab = newSeq[uint16](numPages * pageSize * Nkv * D)
+  var vSlab = newSeq[uint16](numPages * pageSize * Nkv * D)
+  let actual = kernelUnderTest(p, x, kSlab, vSlab)
+  let expected = reference(p, x, numPages)
+  var worstAll = 0.0'f32
+  for stage in [("qBuf", actual.qBuf, expected.qBuf),
+                ("kBuf", actual.kBuf, expected.kBuf),
+                ("vBuf", actual.vBuf, expected.vBuf),
+                ("qRope", actual.qRope, expected.qRope),
+                ("kRope", actual.kRope, expected.kRope),
+                ("attnOut", actual.attnOut, expected.attnOut),
+                ("outBuf", actual.outBuf, expected.outBuf)]:
+    let w = worstAbsDiff(stage[1], stage[2])
+    worstAll = max(worstAll, w)
+    echo &"  {stage[0]}: worst |Δ| = {w}, {stage[1].numel()} elements"
+  echo &"  worst |Δ| across stages = {worstAll} (per-stage evidence, only outBuf is asserted at 5e-3)"
+  assertAllClose(actual.outBuf, expected.outBuf, rtol = 0.0'f64, abstol = 5e-3'f64)
+  result = true
+
+when isMainModule:
+  runCppTest("GGUF attention composition vs the torch SDPA reference", checkGGUFAttn)

--- a/workspace/positron/tests/manual_gguf_attn_fp16.nim
+++ b/workspace/positron/tests/manual_gguf_attn_fp16.nim
@@ -57,13 +57,12 @@ proc worstAbsDiff(a, b: F.Tensor): float32 =
     let d = abs(ap[i] - bp[i])
     if d > result: result = d
 
-proc decodeWeights(scheme: int, packed: seq[uint8], K, N: int): seq[uint16] =
+proc decodeWeights(scheme: GGufScheme, packed: seq[uint8], K, N: int): seq[uint16] =
   ## (N, K) file-order fp16 reconstruction for the packed scheme.
   case scheme
-  of 0: decodeWeightsQ8_0(packed, K, N)
-  of 1: decodeWeightsQ4_K(packed, K, N)
-  of 2: decodeWeightsIQ4_XS(packed, K, N)
-  else: raise newException(ValueError, "unknown scheme: " & $scheme)
+  of gsQ8_0: decodeWeightsQ8_0(packed, K, N)
+  of gsQ4_K: decodeWeightsQ4_K(packed, K, N)
+  of gsIQ4_XS: decodeWeightsIQ4_XS(packed, K, N)
 
 proc tensorFromFp16(hs: seq[uint16], rows, cols: int): F.Tensor =
   ## fp16 bit buffer widened to a (rows, cols) fp32 tensor.
@@ -109,7 +108,7 @@ proc writeRefSlab(dst: var seq[float32], src: F.Tensor, p: GGufAttnParams,
                   rowsPerToken: int) =
   ## Fills the flat (num_pages·page_size·Nkv·D) fp32 slab from the
   ## reference's own kRope/v with the driver's write-band addressing
-  ## (rows outside the bands stay zero).
+  ## (rows outside the bands keep the seeded history).
   let lgPageSize = countTrailingZeroBits(p.pageSize)
   let pageMask = p.pageSize - 1
   let sp = src.contiguous().data_ptr(float32)
@@ -158,11 +157,15 @@ proc sdpaPrefill(qt, kt, vt: F.Tensor, cacheSeqlen, qLen, H, Nkv: int): F.Tensor
   let mt = toTensor(maskF).reshape(1, qLen, covered)
   scaled_dot_product_attention(qt, k2, v2, attn_mask = some(mt), enable_gqa = H > Nkv)
 
-proc reference(p: GGufAttnParams, x: seq[uint16], numPages: int): AttnTensors =
+proc reference(p: GGufAttnParams, x: seq[uint16], numPages: int,
+               kSeed, vSeed: int): AttnTensors =
   ## Torch composition: F.linear projections, rms_norm + rope with
   ## the driver's cos/sin tables, the reference's own slab writes,
   ## per-seq SDPA with GQA, then the o_proj. Every fp16 round mirrors
   ## the kernel's fp16 buffers. The slabs never come from the kernel.
+  ## The k/v history starts from the same fp16 buildX seeds as the
+  ## kernel's slabs, so the fetched history rows are non-zero on both
+  ## sides.
   let nTokens = p.cuSeqlensQ[^1].int
   let nQ = p.H * p.D
   let nKv = p.Nkv * p.D
@@ -180,6 +183,10 @@ proc reference(p: GGufAttnParams, x: seq[uint16], numPages: int): AttnTensors =
   result.kRope = qkNormRopeRef(result.kBuf, p.normGammaK, cosK, sinK, p.Nkv, p.D, p.eps)
   var kSlab = newSeq[float32](numPages * p.pageSize * p.Nkv * p.D)
   var vSlab = newSeq[float32](numPages * p.pageSize * p.Nkv * p.D)
+  let kHist = buildX(numPages * p.pageSize * p.Nkv, p.D, kSeed, 1.0'f32)
+  let vHist = buildX(numPages * p.pageSize * p.Nkv, p.D, vSeed, 1.0'f32)
+  for i in 0 ..< kHist.len: kSlab[i] = fp16ToFp32(kHist[i])
+  for i in 0 ..< vHist.len: vSlab[i] = fp16ToFp32(vHist[i])
   writeRefSlab(kSlab, result.kRope, p, p.Nkv)
   writeRefSlab(vSlab, result.vBuf, p, p.Nkv)
   let kT = toTensor(kSlab).reshape(numPages * p.pageSize, p.Nkv, p.D).to(kFloat16).to(kFloat32)
@@ -246,13 +253,18 @@ proc checkGGUFAttn(): bool =
     kRowBytes: int32(kw.len div nKv),
     vRowBytes: int32(vw.len div nKv),
     oRowBytes: int32(ow.len div hidden),
-    qScheme: 1, kScheme: 2, vScheme: 0, oScheme: 1,
+    qScheme: gsQ4_K, kScheme: gsIQ4_XS, vScheme: gsQ8_0, oScheme: gsQ4_K,
     normGammaQ: gammaQ, normGammaK: gammaK)
   let x = buildX(nTokens, hidden, 11, 1.0'f32 / 65536.0'f32)
-  var kSlab = newSeq[uint16](numPages * pageSize * Nkv * D)
-  var vSlab = newSeq[uint16](numPages * pageSize * Nkv * D)
+  let kSeed = 13
+  let vSeed = 17
+  # the slabs start non-zero so the fetched history rows carry real
+  # values on both sides (a wrong history-page fetch no longer
+  # returns zeros and passes)
+  var kSlab = buildX(numPages * pageSize * Nkv, D, kSeed, 1.0'f32)
+  var vSlab = buildX(numPages * pageSize * Nkv, D, vSeed, 1.0'f32)
   let actual = kernelUnderTest(p, x, kSlab, vSlab)
-  let expected = reference(p, x, numPages)
+  let expected = reference(p, x, numPages, kSeed, vSeed)
   var worstAll = 0.0'f32
   for stage in [("qBuf", actual.qBuf, expected.qBuf),
                 ("kBuf", actual.kBuf, expected.kBuf),
@@ -264,8 +276,13 @@ proc checkGGUFAttn(): bool =
     let w = worstAbsDiff(stage[1], stage[2])
     worstAll = max(worstAll, w)
     echo &"  {stage[0]}: worst |Δ| = {w}, {stage[1].numel()} elements"
-  echo &"  worst |Δ| across stages = {worstAll} (per-stage evidence, only outBuf is asserted at 5e-3)"
-  assertAllClose(actual.outBuf, expected.outBuf, rtol = 0.0'f64, abstol = 5e-3'f64)
+  echo &"  worst |Δ| across stages = {worstAll} (per-stage evidence, only outBuf is asserted at 6.25e-2)"
+  # outBuf tolerance: the seeded k/v history lifts the layer output to
+  # O(10-30), where the fp16 output ulp (0.03125 at |31.3|) alone
+  # exceeds the 5e-3 bound that suits O(1) outputs. Measured worst
+  # |Δ| = 0.03125, one ulp at the largest output. The 0.0625 bound is
+  # two ulp at that magnitude, a 2x margin over the measurement.
+  assertAllClose(actual.outBuf, expected.outBuf, rtol = 0.0'f64, abstol = 6.25e-2'f64)
   result = true
 
 when isMainModule:

--- a/workspace/positron/tests/manual_gguf_dequant_fp16.nim
+++ b/workspace/positron/tests/manual_gguf_dequant_fp16.nim
@@ -1,0 +1,83 @@
+## Tattletale
+## Copyright (c) 2026 Mamy André-Ratsimbazafy
+## Licensed and distributed under either of
+##   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+##   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+## at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+##
+## Run: nim cpp -r --hints:off --warnings:off \
+##   --outdir:build/wip \
+##   --nimcache:nimcache/wip \
+##   workspace/positron/tests/manual_gguf_dequant_fp16.nim
+
+import std/strformat, workspace/crucible, workspace/ceramic, workspace/libtorch_testutils
+import ../../ceramic/tests/tile_test_utils, ../src/kernels/ceramic/gguf_ops, ./gguf_test_utils
+
+const ggufDequantMsl = metal:
+  proc dequantTile[A: static MmaAtom](bReg: var RtRight[float16, 16, 32, A],
+      Out: ptr UncheckedArray[float16], w: ptr UncheckedArray[uint8], K, rowBytes, scheme: int32) {.device.} =
+    let kk = int32(threadgroup_position_in_grid.x)
+    let tile = int32(threadgroup_position_in_grid.y)
+    if scheme == 0:
+      dequantGGUF_Q8_0(bReg, w, kk, rowBytes, tile div 4, tile mod 4)
+    else:
+      if scheme == 1:
+        dequantGGUF_Q4_K(bReg, w, kk, rowBytes, tile div 4, tile mod 4)
+      else:
+        dequantGGUF_IQ4_XS(bReg, w, kk, rowBytes, tile div 4, tile mod 4)
+    let cell = crd2idx(A.getLayoutA(), (int(thread_index_in_threadgroup), 0)).toIntVal()
+    for n in 0'i32 ..< 2:
+      for m in 0'i32 ..< 4:
+        for v in 0'i32 ..< 2:
+          Out[(tile * 32 + (cell div 8) + 8 * m + v) * K + kk * 16 + (cell mod 8) + 8 * n] =
+            bReg.frags[m][n].frag[v]
+  proc dequantQ8_0(Out: ptr UncheckedArray[float16], w: ptr UncheckedArray[uint8], K, rowBytes: int32) {.global.} =
+    var bReg: rt_r(float16, 16, 32)
+    dequantTile(bReg, Out, w, K, rowBytes, 0)
+  proc dequantQ4_K(Out: ptr UncheckedArray[float16], w: ptr UncheckedArray[uint8], K, rowBytes: int32) {.global.} =
+    var bReg: rt_r(float16, 16, 32)
+    dequantTile(bReg, Out, w, K, rowBytes, 1)
+  proc dequantIQ4_XS(Out: ptr UncheckedArray[float16], w: ptr UncheckedArray[uint8], K, rowBytes: int32) {.global.} =
+    var bReg: rt_r(float16, 16, 32)
+    dequantTile(bReg, Out, w, K, rowBytes, 2)
+
+proc dequantKernel(engine: var auto, launcher: string, packed: seq[uint8],
+    K, N, rowBytes: int): seq[uint16] =
+  var outO = newSeq[uint16](N * K)
+  engine.run << (grid: (K div 16, N div 32, 1), blk: (32, 1)) >> (
+    launcher, outO, (packed, int32(K), int32(rowBytes)))
+  result = outO
+
+func worstAbsDiff(a, b: seq[uint16]): float32 =
+  result = 0.0'f32
+  for i in 0 ..< a.len:
+    let d = abs(fp16ToFp32(a[i]) - fp16ToFp32(b[i]))
+    if d > result: result = d
+
+proc checkGGUFDequant(): bool =
+  var engine = bkMetal.init()
+  engine.ingest(ggufDequantMsl)
+  let cases = [
+    ("dequantQ8_0", 128, 128, genQ8_0, decodeWeightsQ8_0),
+    ("dequantQ8_0", 256, 256, genQ8_0, decodeWeightsQ8_0),
+    ("dequantQ4_K", 256, 256, genQ4_K, decodeWeightsQ4_K),
+    ("dequantQ4_K", 512, 128, genQ4_K, decodeWeightsQ4_K),
+    ("dequantIQ4_XS", 256, 256, genIQ4_XS, decodeWeightsIQ4_XS),
+    ("dequantIQ4_XS", 512, 128, genIQ4_XS, decodeWeightsIQ4_XS),
+  ]
+  var worstAll = 0.0'f32
+  for d in 0 ..< cases.len:
+    let (launcher, K, N, gen, decode) = cases[d]
+    let packed = gen(K, N, 100 + d)
+    let actual = dequantKernel(engine, launcher, packed, K, N, packed.len div N)
+    let expected = decode(packed, K, N)
+    let w = worstAbsDiff(actual, expected)
+    if w > worstAll: worstAll = w
+    echo &"  {launcher} K={K} N={N}: worst |Δ| = {w}, {actual.len} elements"
+    doAssert actual == expected, &"{launcher} K={K} N={N}: bit mismatch"
+  echo &"  worst |Δ| across {cases.len} cases = {worstAll} (bit-exact)"
+  result = true
+
+when isMainModule:
+  runCppTest("GGUF dequant Q8_0/Q4_K/IQ4_XS vs the shared reconstruction", checkGGUFDequant)

--- a/workspace/positron/tests/manual_gguf_linear_fp16.nim
+++ b/workspace/positron/tests/manual_gguf_linear_fp16.nim
@@ -1,0 +1,78 @@
+## Tattletale
+## Copyright (c) 2026 Mamy André-Ratsimbazafy
+## Licensed and distributed under either of
+##   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+##   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+## at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+##
+## Run: nim cpp -r --hints:off --warnings:off \
+##   --outdir:build/wip \
+##   --nimcache:nimcache/wip \
+##   workspace/positron/tests/manual_gguf_linear_fp16.nim
+
+import std/strformat, workspace/crucible, workspace/ceramic
+import workspace/libtorch, workspace/libtorch as F
+import workspace/libtorch_testutils
+import ../../ceramic/tests/tile_test_utils
+import ../src/kernels/ceramic/gguf_linear_fwd
+import ./gguf_test_utils
+
+const ggufLinearMsl = metal:
+  proc ggufLinearQ8(Out: ptr UncheckedArray[float16], x: ptr UncheckedArray[float16],
+      w: ptr UncheckedArray[uint8], M, K, N, rowBytes: int32) {.global.} =
+    gguf_linear_fwd(Out, x, w, M, K, N, rowBytes, 0)
+  proc ggufLinearQ4K(Out: ptr UncheckedArray[float16], x: ptr UncheckedArray[float16],
+      w: ptr UncheckedArray[uint8], M, K, N, rowBytes: int32) {.global.} =
+    gguf_linear_fwd(Out, x, w, M, K, N, rowBytes, 1)
+  proc ggufLinearIQ4XS(Out: ptr UncheckedArray[float16], x: ptr UncheckedArray[float16],
+      w: ptr UncheckedArray[uint8], M, K, N, rowBytes: int32) {.global.} =
+    gguf_linear_fwd(Out, x, w, M, K, N, rowBytes, 2)
+
+proc ggufLinearKernel(engine: var auto, launcher: string, xBits: seq[uint16],
+    packed: seq[uint8], M, K, N, rowBytes: int): F.Tensor =
+  var outO = newSeq[uint16](M * N)
+  engine.run << (grid: (N div 128, (M + 31) div 32, 1), blk: (32, 1)) >> (
+    launcher, outO, (xBits, packed, int32(M), int32(K), int32(N), int32(rowBytes)))
+  var outF = newSeq[float32](M * N)
+  for i in 0 ..< M * N: outF[i] = fp16ToFp32(outO[i])
+  toTensor(outF).reshape(M, N)
+
+proc ggufLinearReference(xBits, wBits: seq[uint16], M, K, N: int): F.Tensor =
+  ## Torch reference: fp32 F.linear over the fp16-rounded inputs, weight in (N, K) file order, one fp16 round.
+  F.linear(toTensor(fp16sToF32(xBits)).reshape(M, K),
+           toTensor(fp16sToF32(wBits)).reshape(N, K)).to(kFloat16).to(kFloat32)
+
+proc worstAbsDiff(a, b: F.Tensor): float32 =
+  let ap = a.contiguous().data_ptr(float32)
+  let bp = b.contiguous().data_ptr(float32)
+  for i in 0 ..< a.numel():
+    if abs(ap[i] - bp[i]) > result: result = abs(ap[i] - bp[i])
+proc checkGGUFLinear(): bool =
+  # per-scheme x scale keeps the output O(1) (weight RMS ~2e2..3e3)
+  var engine = bkMetal.init()
+  engine.ingest(ggufLinearMsl)
+  let cases = [
+    (0, 32, 128, 128, 200, 1.0'f32 / 16384.0'f32, "ggufLinearQ8", genQ8_0, decodeWeightsQ8_0),
+    (0, 64, 256, 256, 201, 1.0'f32 / 16384.0'f32, "ggufLinearQ8", genQ8_0, decodeWeightsQ8_0),
+    (1, 17, 256, 128, 202, 1.0'f32 / 65536.0'f32, "ggufLinearQ4K", genQ4_K, decodeWeightsQ4_K),
+    (1, 64, 512, 256, 203, 1.0'f32 / 65536.0'f32, "ggufLinearQ4K", genQ4_K, decodeWeightsQ4_K),
+    (2, 64, 256, 128, 204, 1.0'f32 / 262144.0'f32, "ggufLinearIQ4XS", genIQ4_XS, decodeWeightsIQ4_XS),
+    (2, 8, 512, 256, 205, 1.0'f32 / 262144.0'f32, "ggufLinearIQ4XS", genIQ4_XS, decodeWeightsIQ4_XS),
+  ]
+  var worstAll = 0.0'f32
+  for d in 0 ..< cases.len:
+    let (scheme, M, K, N, seed, xScale, launcher, gen, decode) = cases[d]
+    let packed = gen(K, N, seed)
+    let xBits = buildX(M, K, seed, xScale)
+    let actual = ggufLinearKernel(engine, launcher, xBits, packed, M, K, N, packed.len div N)
+    let expected = ggufLinearReference(xBits, decode(packed, K, N), M, K, N)
+    let w = worstAbsDiff(actual, expected)
+    if w > worstAll: worstAll = w
+    echo &"  scheme {scheme} M={M} K={K} N={N}: worst |Δ| = {w}, {M * N} elements"
+    assertAllClose(actual, expected, rtol = 0.0'f64, abstol = 5e-3'f64)
+  echo &"  worst |Δ| across {cases.len} cases = {worstAll} (tolerance 5e-3)"
+  result = true
+
+when isMainModule:
+  runCppTest("GGUF quantized linear fwd vs the torch F.linear reference", checkGGUFLinear)


### PR DESCRIPTION
This adds preliminary support for GGUF including GGUF Paged Attention to allow scalable concurrency even with GGUF quants.

For now we support Q8_0/Q4_K/IQ4_XS.

See https://developers.redhat.com/articles/2026/06/15/llamacpp-vs-vllm-choosing-right-local-llm-inference-engine, most of the latency/perf woes of llama.cpp are due to their attention architecture that requires a contiguous slab of memory while vLLM / SGLang, ... can compute attention on arbitrary pointers of memory.

In practice:
- llama.cpp needs to prereserve slots via -n / --parallel
- each slot divides the max context available for a model. For example a 262K context model, if launched with parallel = 2 cannot ever handled more than 131K in llama.cpp

With PagedAttention, any query can be 262K, it's all dynamic. There is no need to move memory around with interleaved users queries, with contiguous slots users query will evict each others from the KV cache.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GPU-accelerated GGUF quantized linear operations for Q8_0, Q4_K, and IQ4_XS formats.
  * Added complete attention processing with projections, normalization, rotary embeddings, paged key/value caching, and grouped-query attention.
  * Added rotary embedding table generation for attention workloads.

* **Tests**
  * Added validation for quantized weight decoding, linear operations, and mixed decode/prefill attention against reference results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->