### PR TITLE
[Metal Perf] avoid copying when we have unified memory -> 95~97% of MLX perf on GEMM.

### DIFF
--- a/workspace/ceramic/benchmark/bench_matmul_apple_gpu.nim
+++ b/workspace/ceramic/benchmark/bench_matmul_apple_gpu.nim
@@ -13,10 +13,11 @@
 ## time, and bit-exactness vs the fp32 host reference on sampled output
 ## positions (tolerance 0.0).
 ##
-## Timing is host-side end-to-end (buffer upload, encode, dispatch, wait,
-## readback) — the harness's run contract. A K=16 overhead probe with the
-## same buffers separates the per-run copy/dispatch cost from the kernel
-## compute (est. compute = full run − overhead).
+## Timing is host-side end-to-end: the timed region is one full `engine.run` call
+## (bind, encode, dispatch, wait). Device args live in page-aligned host buffers
+## that the runtime binds no-copy, so the timed region holds no upload and no
+## readback copy. A K=16 overhead probe on the same buffers separates the per-run
+## dispatch cost from the kernel compute, giving est. compute = full run − overhead.
 ##
 ## Usage:
 ##   nim cpp -r --hints:off --warnings:off \
@@ -33,6 +34,26 @@ import ./bench_utils
 import ../tests/tile_test_utils
 import ../src/kernels/k_tile_gemm
 
+proc posix_memalign(memptr: ptr pointer, alignment: csize_t, size: csize_t): cint
+  {.importc: "posix_memalign", header: "<stdlib.h>".}
+
+proc getpagesize(): cint {.importc: "getpagesize", header: "<unistd.h>".}
+
+func roundPages(nbytes: int, ps = getpagesize()): int =
+  ## Byte length rounded up to a host-page multiple, 16 KiB on Apple Silicon.
+  ## The device-visible length must be a page multiple for a no-copy binding.
+  (nbytes + ps - 1) div ps * ps
+
+proc allocAligned(nbytes: int): pointer =
+  ## Allocation that is page-aligned and has a byte length that is a page multiple,
+  ## the two requirements of no-copy binding. Any other length gets an allocated
+  ## buffer and a copy.
+  let ps = getpagesize()
+  var p: pointer = nil
+  doAssert posix_memalign(addr p, csize_t(ps), csize_t(roundPages(nbytes, ps))) == 0,
+    "posix_memalign failed for " & $nbytes & " bytes"
+  p
+
 # ═════════════════════════════════════════════════════════════════════════
 #  Config
 # ═════════════════════════════════════════════════════════════════════════
@@ -44,11 +65,26 @@ const
   SamplePositions = 1024
 
 const gemmKernel = "fusedGemm"
+const linearKernel = "fusedLinear"
+const gemmStridedKernel = "fusedGemmStrided"
 
+# One metal block = one library: ingest replaces the previous artifact,
+# so this single source holds every bench kernel.
 const gemmMsl = metal:
   proc fusedGemm(D: ptr UncheckedArray[float32], A, B: ptr UncheckedArray[float16],
                  N, K, M: int32) {.global.} =
     matmul(D, A, B, N, K, M)
+
+  proc fusedLinear(D: ptr UncheckedArray[float32], A, B: ptr UncheckedArray[float16],
+                   Bias: ptr UncheckedArray[float32], N, K, M: int32) {.global.} =
+    linear(D, A, B, Bias, N, K, M)
+
+  proc fusedGemmStrided(D: ptr UncheckedArray[float32], A, B: ptr UncheckedArray[float16],
+                        C: ptr UncheckedArray[float32],
+                        M, N, K: int32, alpha: float32,
+                        rsa, csa, rsb, csb: int32, beta: float32,
+                        rsc, csc: int32) {.global.} =
+    gemm(D, M, N, K, alpha, A, rsa, csa, B, rsb, csb, beta, C, rsc, csc)
 
 # ═════════════════════════════════════════════════════════════════════════
 #  Theoretical peak (Apple GPU)
@@ -132,7 +168,55 @@ proc bench(run: proc(); ops: float64): tuple[gflops, medianUs: float64] =
   let med = median(times)
   ((ops / 1e9) / med, med * 1e6)
 
-proc checkBitExact(M, N, K, Mp, Np, Kp: int; Ah, Bh: seq[uint16]; C: seq[float32]): tuple[maxAbs, maxRel: float32] =
+func biasVal(n: int): float32 =
+  ## Deterministic per-column bias mix, negative on every third column.
+  (if n mod 3 == 0: -float32(1 + 2 * n) else: float32(1 + 2 * n))
+
+proc checkBitExactBias(M, N, K, Mp, Np, Kp: int, Ah, Bh: ptr UncheckedArray[uint16],
+                       Bias: ptr UncheckedArray[float32],
+                       C: ptr UncheckedArray[float32]): tuple[maxAbs, maxRel: float32] =
+  ## Bit-exactness on SamplePositions sampled (m, n) outputs, D = A·B + bias.
+  ## Reference: fp32 k-sum plus the fp32 bias add, exact in fp32,
+  ## which the kernel's k-ordered accumulation must match.
+  var rng = initRand(0xC0FFEE)
+  result = (0.0'f32, 0.0'f32)
+  for s in 0 ..< SamplePositions:
+    let m = rng.rand(M - 1)
+    let n = rng.rand(N - 1)
+    var acc = 0.0'f32
+    for k in 0 ..< K:
+      acc += fp16ToFp32(Ah[m * Kp + k]) * fp16ToFp32(Bh[k * Np + n])
+    let got = C[m * Np + n]
+    let d = abs(got - (acc + Bias[n]))
+    if d > result.maxAbs: result.maxAbs = d
+    let rel = d / max(abs(got), max(abs(acc + Bias[n]), 1e-12'f32))
+    if rel > result.maxRel: result.maxRel = rel
+  doAssert result.maxAbs == 0.0'f32,
+    &"not bit-exact: worst |Δ| = {result.maxAbs}"
+
+proc checkBitExactAxpy(M, N, K, Mp, Np, Kp: int, Ah, Bh: ptr UncheckedArray[uint16],
+                       Ch: ptr UncheckedArray[float32],
+                       C: ptr UncheckedArray[float32]): tuple[maxAbs, maxRel: float32] =
+  ## Bit-exactness on SamplePositions sampled (m, n) outputs, D = A·B + C.
+  ## Reference: fp32 k-sum plus the fp32 C add (α = β = 1, exact in fp32).
+  var rng = initRand(0xC0FFEE)
+  result = (0.0'f32, 0.0'f32)
+  for s in 0 ..< SamplePositions:
+    let m = rng.rand(M - 1)
+    let n = rng.rand(N - 1)
+    var acc = 0.0'f32
+    for k in 0 ..< K:
+      acc += fp16ToFp32(Ah[m * Kp + k]) * fp16ToFp32(Bh[k * Np + n])
+    let got = C[m * Np + n]
+    let d = abs(got - (acc + Ch[m * Np + n]))
+    if d > result.maxAbs: result.maxAbs = d
+    let rel = d / max(abs(got), max(abs(acc + Ch[m * Np + n]), 1e-12'f32))
+    if rel > result.maxRel: result.maxRel = rel
+  doAssert result.maxAbs == 0.0'f32,
+    &"not bit-exact: worst |Δ| = {result.maxAbs}"
+
+proc checkBitExact(M, N, K, Mp, Np, Kp: int, Ah, Bh: ptr UncheckedArray[uint16],
+                   C: ptr UncheckedArray[float32]): tuple[maxAbs, maxRel: float32] =
   ## Bit-exactness on SamplePositions sampled (m, n) outputs.
   ## The reference is the sequential fp32 k-sum: fp16→fp32 is exact and
   ## fp16 products are exact in fp32, so it is the exact-in-fp32 result,
@@ -168,7 +252,7 @@ proc runBench() =   # engines are RAII, so keep them function-local
   echo &"  GEMM benchmark — Apple GPU tile layer (fp16 in, fp32 acc)"
   echo &"  Device: {engine.deviceName()}"
   echo &"  Tiles: 32×32 output per threadgroup (32 lanes), K-block 16"
-  echo &"  Timing: host-side end-to-end; K=16 probe separates copy overhead"
+  echo &"  Timing: host-side end-to-end, no-copy args, K=16 probe separates dispatch overhead"
   echo "=".repeat(72)
   echo ""
   printPeakTable(cores)
@@ -185,18 +269,18 @@ proc runBench() =   # engines are RAII, so keep them function-local
       Kp = N
       ops = float64(2 * N * N * N)
 
-    var Ah = newSeq[uint16](Mp * Kp)
-    var Bh = newSeq[uint16](Kp * Np)
-    for i in 0 ..< Ah.len: Ah[i] = fp32ToFp16(rand(1.0'f32))
-    for i in 0 ..< Bh.len: Bh[i] = fp32ToFp16(rand(1.0'f32))
-    var C = newSeq[float32](Mp * Np)
+    var Ah = cast[ptr UncheckedArray[uint16]](allocAligned(Mp * Kp * sizeof(uint16)))
+    var Bh = cast[ptr UncheckedArray[uint16]](allocAligned(Kp * Np * sizeof(uint16)))
+    for i in 0 ..< Mp * Kp: Ah[i] = fp32ToFp16(rand(1.0'f32))
+    for i in 0 ..< Kp * Np: Bh[i] = fp32ToFp16(rand(1.0'f32))
+    var C = cast[ptr UncheckedArray[float32]](allocAligned(Mp * Np * sizeof(float32)))
 
-    # Raw-pointer views into the host buffers (the pointer API, no
-    # seq/array marshalling). Ah/Bh/C live until the next size, so
-    # the views stay valid for the whole size iteration.
-    var aArg = PtrArg[uint16](buf: cast[ptr UncheckedArray[uint16]](addr Ah[0]), len: Ah.len, off: 0)
-    var bArg = PtrArg[uint16](buf: cast[ptr UncheckedArray[uint16]](addr Bh[0]), len: Bh.len, off: 0)
-    var cArg = PtrArg[float32](buf: cast[ptr UncheckedArray[float32]](addr C[0]), len: C.len, off: 0)
+    # Raw-pointer views into the page-aligned host buffers, the pointer API with no
+    # seq/array marshalling. Ah/Bh/C live until the next size, so the views stay
+    # valid for the whole size iteration.
+    var aArg = PtrArg[uint16](buf: Ah, len: Mp * Kp, off: 0)
+    var bArg = PtrArg[uint16](buf: Bh, len: Kp * Np, off: 0)
+    var cArg = PtrArg[float32](buf: C, len: Mp * Np, off: 0)
 
     # Correctness on a fresh run, then warmup + timed samples on the same buffers.
     engine.run << (grid: (Np div 32, Mp div 32), blk: (32, 1)) >>
@@ -222,9 +306,9 @@ proc runBench() =   # engines are RAII, so keep them function-local
       echo &"         grid ({Np div 32},{Mp div 32}), K-loop {Kp div 16} iters, " &
            &"AI {ops / float64((Mp * Kp + Kp * Np) * 2):.1f} FLOP/B"
 
-      # Harness overhead probe: same buffers, K = 16 (one k-block, ~zero
-      # compute). The per-run upload + readback + dispatch cost at identical
-      # buffer sizes, so est. compute = full run − overhead.
+      # K=16 overhead probe: same buffers at K = 16, one k-block and ~zero compute.
+      # Measures the per-run bind + encode/commit/wait + dispatch cost, giving est.
+      # compute = full run − overhead.
       proc runOverhead() =
         engine.run << (grid: (Np div 32, Mp div 32), blk: (32, 1)) >>
           (gemmKernel, cArg, (aArg, bArg, int32(Mp), int32(16), int32(Np)))
@@ -232,6 +316,92 @@ proc runBench() =   # engines are RAII, so keep them function-local
       let computeUs = r.medianUs - o.medianUs
       echo &"         est. compute {computeUs:.1f} μs (full {r.medianUs:.0f} − " &
            &"overhead {o.medianUs:.0f}) → {ops / (computeUs * 1e6):.1f} TFLOPS"
+    echo ""
+
+  # ── Linear (bias fused) and strided-C gemm paths ──
+  # Same fused core with the bias / α·A·B+β·C epilogues. The strided kernel
+  # takes runtime row/col strides for C (row-major here).
+  echo "=".repeat(72)
+  echo "  Linear (bias fused) and strided-C gemm — same fused core"
+  echo "=".repeat(72)
+  echo ""
+
+  for N in ProblemSizes:
+    let
+      Mp = N
+      Np = N
+      Kp = N
+      ops = float64(2 * N * N * N)
+
+    var Ah = cast[ptr UncheckedArray[uint16]](allocAligned(Mp * Kp * sizeof(uint16)))
+    var Bh = cast[ptr UncheckedArray[uint16]](allocAligned(Kp * Np * sizeof(uint16)))
+    for i in 0 ..< Mp * Kp: Ah[i] = fp32ToFp16(rand(1.0'f32))
+    for i in 0 ..< Kp * Np: Bh[i] = fp32ToFp16(rand(1.0'f32))
+    var Ch = cast[ptr UncheckedArray[float32]](allocAligned(Mp * Np * sizeof(float32)))
+    for i in 0 ..< Mp * Np: Ch[i] = rand(1.0'f32)
+    var Bias = cast[ptr UncheckedArray[float32]](allocAligned(Np * sizeof(float32)))
+    for n in 0 ..< Np: Bias[n] = biasVal(n)
+    var D = cast[ptr UncheckedArray[float32]](allocAligned(Mp * Np * sizeof(float32)))
+
+    var aArg = PtrArg[uint16](buf: Ah, len: Mp * Kp, off: 0)
+    var bArg = PtrArg[uint16](buf: Bh, len: Kp * Np, off: 0)
+    var dArg = PtrArg[float32](buf: D, len: Mp * Np, off: 0)
+    var cArg = PtrArg[float32](buf: Ch, len: Mp * Np, off: 0)
+    # Bias is the only arg whose byte length can land inside a single page
+    # (16 KiB = 4096 fp32 lanes). A length that is not a page multiple would take
+    # the allocate-and-copy path on every dispatch, so `len` is the page-rounded
+    # length, in-bounds because allocAligned rounds the allocation up too. Kernel
+    # code reads the `Np` named lanes, never the padding.
+    var biasArg = PtrArg[float32](
+      buf: Bias, len: roundPages(Np * sizeof(float32)) div sizeof(float32), off: 0)
+
+    # ── linear (D = A·B + bias) ──
+    engine.run << (grid: (Np div 32, Mp div 32), blk: (32, 1)) >>
+      (linearKernel, dArg, (aArg, bArg, biasArg, int32(Mp), int32(Kp), int32(Np)))
+    block:
+      let chk = checkBitExactBias(N, N, N, Mp, Np, Kp, Ah, Bh, Bias, D)
+      proc run() =
+        engine.run << (grid: (Np div 32, Mp div 32), blk: (32, 1)) >>
+          (linearKernel, dArg, (aArg, bArg, biasArg, int32(Mp), int32(Kp), int32(Np)))
+      let r = bench(run, ops)
+      let label = &"{N}³"
+      echo &"  linear  {label:<21} {r.gflops:>8.2f}  {int(r.medianUs):>6d} μs  " &
+           &"{formatFloat(chk.maxAbs, ffScientific, 1):>9} {formatFloat(chk.maxRel, ffScientific, 1):>9}"
+
+    # ── gemm strided-C (D = α·A·B + β·C, row-major C) ──
+    engine.run << (grid: (Np div 32, Mp div 32), blk: (32, 1)) >>
+      (gemmStridedKernel, dArg,
+       (aArg, bArg, cArg, int32(Mp), int32(Np), int32(Kp), 1.0'f32,
+        int32(Kp), int32(1), int32(Np), int32(1), 0.0'f32, int32(Np), int32(1)))
+    block:
+      # β = 0 probe: the epilogue skips the C read (EpiAXPBYStrided),
+      # D = A·B, isolating the C-read cost vs the plain matmul core.
+      let chk = checkBitExact(N, N, N, Mp, Np, Kp, Ah, Bh, D)
+      proc run() =
+        engine.run << (grid: (Np div 32, Mp div 32), blk: (32, 1)) >>
+          (gemmStridedKernel, dArg,
+           (aArg, bArg, cArg, int32(Mp), int32(Np), int32(Kp), 1.0'f32,
+            int32(Kp), int32(1), int32(Np), int32(1), 0.0'f32, int32(Np), int32(1)))
+      let r = bench(run, ops)
+      let label = &"{N}³"
+      echo &"  strided-β0 {label:<18} {r.gflops:>8.2f}  {int(r.medianUs):>6d} μs  " &
+           &"{formatFloat(chk.maxAbs, ffScientific, 1):>9} {formatFloat(chk.maxRel, ffScientific, 1):>9}"
+
+    engine.run << (grid: (Np div 32, Mp div 32), blk: (32, 1)) >>
+      (gemmStridedKernel, dArg,
+       (aArg, bArg, cArg, int32(Mp), int32(Np), int32(Kp), 1.0'f32,
+        int32(Kp), int32(1), int32(Np), int32(1), 1.0'f32, int32(Np), int32(1)))
+    block:
+      let chk = checkBitExactAxpy(N, N, N, Mp, Np, Kp, Ah, Bh, Ch, D)
+      proc run() =
+        engine.run << (grid: (Np div 32, Mp div 32), blk: (32, 1)) >>
+          (gemmStridedKernel, dArg,
+           (aArg, bArg, cArg, int32(Mp), int32(Np), int32(Kp), 1.0'f32,
+            int32(Kp), int32(1), int32(Np), int32(1), 1.0'f32, int32(Np), int32(1)))
+      let r = bench(run, ops)
+      let label = &"{N}³"
+      echo &"  strided {label:<21} {r.gflops:>8.2f}  {int(r.medianUs):>6d} μs  " &
+           &"{formatFloat(chk.maxAbs, ffScientific, 1):>9} {formatFloat(chk.maxRel, ffScientific, 1):>9}"
     echo ""
 
   echo "Done."

--- a/workspace/ceramic/benchmark/bench_metal_overhead_apple_gpu.nim
+++ b/workspace/ceramic/benchmark/bench_metal_overhead_apple_gpu.nim
@@ -1,0 +1,233 @@
+## Tattletale
+## Copyright (c) 2026 Mamy André-Ratsimbazafy
+## Licensed and distributed under either of
+##   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT.)
+##   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0.)
+## at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+## Benchmark: Metal dispatch-path overhead decomposition (Apple GPU)
+##
+## Splits the per-call cost of the MetalEngine run contract into allocation, host
+## memcpy, and encode/commit/wait, at tile-GEMM buffer sizes: fp32 output, fp16
+## inputs. bench_matmul_apple_gpu's K=16 probe measures the same total, this file
+## attributes it to components.
+##
+## Probes, per shape (median of `NbSamples` samples after `WarmupSamples` warmups):
+##   alloc/free      4 fresh MTLBuffers (out + 2 inputs + scalars), no copies, no kernel
+##   alloc+memcpy    same buffers + copyMem in and back, no kernel
+##   trivial kernel  full run contract, signature-identical kernel writing one element
+##   K=16 gemm       real fusedGemm, one k-block, cross-check
+##
+## Kernel probes bind every device arg page-aligned with a page-multiple byte
+## length, so all of them wrap no-copy exactly like bench_matmul_apple_gpu. A copied
+## arg would bill the run a transfer the GEMM bench never pays.
+##
+## Usage:
+##   nim cpp -r --hints:off --warnings:off \
+##     --outdir:build/bench_metal_overhead_apple_gpu \
+##     --nimcache:nimcache/bench_metal_overhead_apple_gpu \
+##     workspace/ceramic/benchmark/bench_metal_overhead_apple_gpu.nim
+
+import std/[monotimes, times, algorithm, strutils, strformat]
+
+import workspace/crucible
+# initMetal/allocBuffer/releaseBuffer come from `exec/metal_runtime`,
+# which the engine module re-exports. The {.all.} adds the engine's private symbols,
+# which nothing here uses.
+import workspace/crucible/src/runtime/engines/metal {.all.}
+import ../src/kernels/k_tile_gemm
+
+# ═════════════════════════════════════════════════════════════════════════
+#  Config
+# ═════════════════════════════════════════════════════════════════════════
+
+const
+  ProblemSizes = [2048, 4096]
+  NbSamples = 10
+  WarmupSamples = 3
+  ProbeK = 16            # K of the k-block probes: one k-block, so their A/B
+                         # are N×ProbeK strips, not full squares
+
+const touchKernel = "touch"
+const gemmKernel = "fusedGemm"
+
+# One metal block = one library: ingest replaces the previous artifact,
+# so this single source holds both probe kernels.
+const probeMsl = metal:
+  # Dispatch probe kernel: every invoke stores the identical value and D[0] is never
+  # read back. The concurrent same-value store is deliberate, a per-invoke guard
+  # would bill the measurement its own serialization.
+  proc touch(D: ptr UncheckedArray[float32], A, B: ptr UncheckedArray[float16],
+             N, K, M: int32) {.global.} =
+    D[0] = float32(A[0]) + float32(B[0])
+
+  proc fusedGemm(D: ptr UncheckedArray[float32], A, B: ptr UncheckedArray[float16],
+                 N, K, M: int32) {.global.} =
+    matmul(D, A, B, N, K, M)
+
+proc getpagesize(): cint {.importc: "getpagesize", header: "<unistd.h>".}
+
+proc posix_memalign(memptr: ptr pointer, alignment: csize_t, size: csize_t): cint
+  {.importc: "posix_memalign", header: "<stdlib.h>".}
+
+func roundPages(nbytes: int, ps = getpagesize()): int =
+  ## Byte length rounded up to a host-page multiple, 16 KiB on Apple Silicon.
+  ## The device-visible length must be a page multiple for a no-copy binding.
+  (nbytes + ps - 1) div ps * ps
+
+proc allocPages(nbytes: int): pointer =
+  ## Allocation that is page-aligned and has a byte length that is a page multiple,
+  ## the two requirements of no-copy binding. Any other length gets an allocated
+  ## buffer and a copy.
+  let ps = getpagesize()
+  var p: pointer = nil
+  doAssert posix_memalign(addr p, csize_t(ps), csize_t(roundPages(nbytes, ps))) == 0,
+    "posix_memalign failed for " & $nbytes & " bytes"
+  p
+
+# ═════════════════════════════════════════════════════════════════════════
+#  Benchmark helpers
+# ═════════════════════════════════════════════════════════════════════════
+
+func median(xs: seq[float64]): float64 =
+  ## Middle element of the sorted samples: index len div 2, which for an even length
+  ## is the upper of the two middle values.
+  let s = sorted(xs)
+  s[s.len div 2]
+
+proc bench(run: proc(), ops: float64): tuple[gflops, medianUs: float64] =
+  ## Warmup runs (discarded) then timed samples, median of the samples. `ops`
+  ## is the FLOP count of one timed unit and reaches `gflops` only, which is why
+  ## the cost-measuring probes pass 1.0 and read `medianUs`.
+  for _ in 0 ..< WarmupSamples:
+    run()
+
+  var times = newSeq[float64](NbSamples)
+  for s in 0 ..< NbSamples:
+    let t0 = getMonoTime()
+    run()
+    let t1 = getMonoTime()
+    times[s] = float64((t1 - t0).inNanoseconds) / 1e9
+
+  let med = median(times)
+  ((ops / 1e9) / med, med * 1e6)
+
+func mb(nbytes: int): string =
+  &"{nbytes.float64 / (1024.0 * 1024.0):.0f} MB"
+
+# ═════════════════════════════════════════════════════════════════════════
+#  Main
+# ═════════════════════════════════════════════════════════════════════════
+
+proc runBench() =   # engines are RAII, so keep them function-local
+  var engine = bkMetal.init()
+  engine.ingest(probeMsl)
+
+  echo "=".repeat(72)
+  echo "  Metal dispatch-path overhead decomposition — Apple GPU"
+  echo &"  Device: {engine.deviceName()}"
+  echo "=".repeat(72)
+  echo ""
+
+  for N in ProblemSizes:
+    let
+      outSize = 4 * N * N      # fp32 C/D bytes
+      inSize = 2 * N * N       # fp16 A/B bytes per matrix
+      scalarSize = 3 * 16      # 3 int32 args at 16-byte constant slots
+      probeOps = float64(2 * N * N * ProbeK)  # K=16 probe: one k-block only
+
+    # Output arg: page-aligned with a page-multiple byte length, like the K=16 probe
+    # inputs. Seq storage gives no page-alignment guarantee, so a run
+    # could alloc+copy+readback the output while the inputs wrap no-copy, an asymmetric
+    # measurement. Kernel-visible length stays N×N.
+    var hostOut = cast[ptr UncheckedArray[float32]](allocPages(outSize))
+    var hostA = newSeq[uint16](N * N)
+    var hostB = newSeq[uint16](N * N)
+    for i in 0 ..< hostA.len:
+      hostA[i] = uint16(0x3C00 + (i and 3))   # fp16 1.0..1.003, valid operands
+      hostB[i] = uint16(0x3C00 + ((i + 1) and 3))
+    var scalarPack = newSeq[byte](scalarSize)
+
+    var dArg = PtrArg[float32](buf: hostOut, len: N * N, off: 0)
+
+    echo &"  {N}³ buffers: out {mb(outSize)} fp32, in {mb(inSize)} fp16 ×2, scalars {scalarSize} B"
+
+    # K=16 probes read an N×ProbeK strip of each input, so the arg length names
+    # the operand the kernel reads, not a full square. Page alignment and a length
+    # that is a page multiple keep the strips on the no-copy path.
+    let
+      probeElems = N * ProbeK
+      probeBytes = probeElems * sizeof(uint16)
+      probeLen = roundPages(probeBytes) div sizeof(uint16)
+    var probeA = cast[ptr UncheckedArray[uint16]](allocPages(probeBytes))
+    var probeB = cast[ptr UncheckedArray[uint16]](allocPages(probeBytes))
+    for i in 0 ..< probeElems:
+      probeA[i] = uint16(0x3C00 + (i and 3))    # fp16 1.0..1.003
+      probeB[i] = uint16(0x3C00 + ((i + 1) and 3))
+    var aKArg = PtrArg[uint16](buf: probeA, len: probeLen, off: 0)
+    var bKArg = PtrArg[uint16](buf: probeB, len: probeLen, off: 0)
+
+    echo &"  K=16 probe inputs: {probeElems} fp16 ×2 = {probeBytes div 1024} KiB each"
+
+    # ── Probe 1: allocation/free cycle. allocBuffer/releaseBuffer only, 4
+    # fresh MTLBuffers per iteration on a bare device, no copies, no kernel.
+    block:
+      let dev = initMetal().device
+      proc runAlloc() =
+        var outBuf = allocBuffer(dev, outSize)
+        var aBuf = allocBuffer(dev, inSize)
+        var bBuf = allocBuffer(dev, inSize)
+        var sBuf = allocBuffer(dev, scalarSize)
+        releaseBuffer(outBuf)
+        releaseBuffer(aBuf)
+        releaseBuffer(bBuf)
+        releaseBuffer(sBuf)
+      let r = bench(runAlloc, 1.0)
+      echo &"    alloc/free      {int(r.medianUs):>6d} μs   (4 fresh MTLBuffers per call)"
+
+    # ── Probe 2: allocation + host memcpy. Same 4 buffers per iteration,
+    # copyMem in (out + 2 inputs + scalars) + copyMem back (out), no kernel.
+    block:
+      let dev = initMetal().device
+      proc runCopy() =
+        var outBuf = allocBuffer(dev, outSize)
+        var aBuf = allocBuffer(dev, inSize)
+        var bBuf = allocBuffer(dev, inSize)
+        var sBuf = allocBuffer(dev, scalarSize)
+        copyMem(outBuf.data, addr hostOut[0], outSize)
+        copyMem(aBuf.data, addr hostA[0], inSize)
+        copyMem(bBuf.data, addr hostB[0], inSize)
+        let dst = cast[ptr UncheckedArray[byte]](sBuf.data)
+        copyMem(addr dst[0], addr scalarPack[0], scalarSize)
+        copyMem(addr hostOut[0], outBuf.data, outSize)
+        releaseBuffer(outBuf)
+        releaseBuffer(aBuf)
+        releaseBuffer(bBuf)
+        releaseBuffer(sBuf)
+      let r = bench(runCopy, 1.0)
+      echo &"    alloc+memcpy    {int(r.medianUs):>6d} μs   (+ copyMem in/out, no kernel)"
+
+    # ── Probe 3: trivial kernel. Full run contract
+    # (no-copy binds, scalar pack, encode/commit/wait) with a kernel
+    # of the GEMM's exact signature writing one element, same grid/blk as the GEMM.
+    block:
+      proc runTouch() =
+        engine.run << (grid: (N div 32, N div 32), blk: (32, 1)) >>
+          (touchKernel, dArg, (aKArg, bKArg, int32(N), int32(ProbeK), int32(N)))
+      let r = bench(runTouch, 1.0)
+      echo &"    trivial kernel  {int(r.medianUs):>6d} μs   (full run contract, ~zero compute)"
+
+    # ── Probe 4: K=16 gemm. Real fusedGemm at one k-block, cross-checks
+    # the trivial-kernel total against bench_matmul_apple_gpu's K=16 overhead probe.
+    block:
+      proc runK16() =
+        engine.run << (grid: (N div 32, N div 32), blk: (32, 1)) >>
+          (gemmKernel, dArg, (aKArg, bKArg, int32(N), int32(ProbeK), int32(N)))
+      let r = bench(runK16, probeOps)
+      echo &"    K=16 gemm       {int(r.medianUs):>6d} μs   (cross-check)"
+    echo ""
+
+  echo "Done."
+
+when isMainModule:
+  runBench()

--- a/workspace/crucible/src/abis/objc_abi.nim
+++ b/workspace/crucible/src/abis/objc_abi.nim
@@ -119,6 +119,7 @@ when defined(macosx):
     MsgSendIDIDPtr = proc (self: ID; op: SEL; a: ID; b: ID; c: ptr ID): ID {.cdecl.}
     MsgSendUInt2 = proc (self: ID; op: SEL; a: NSUInteger; b: NSUInteger): ID {.cdecl.}
     MsgSendIDUInt2 = proc (self: ID; op: SEL; a: ID; b: NSUInteger; c: NSUInteger): ID {.cdecl.}
+    MsgSendPtrUInt2ID = proc (self: ID, op: SEL, a: pointer, b: NSUInteger, c: NSUInteger, d: ID): ID {.cdecl.}
     MsgSendSize2 = proc (self: ID; op: SEL; a: MTLSize; b: MTLSize): ID {.cdecl.}
     MsgSendBOOL = proc (self: ID; op: SEL; a: BOOL): ID {.cdecl.}
     MsgSendUInt1 = proc (self: ID; op: SEL; a: NSUInteger): ID {.cdecl.}
@@ -156,6 +157,11 @@ when defined(macosx):
   ## setBuffer:offset:atIndex:.
   template msgSend*(self: ID; op: SEL; a: ID; b: NSUInteger; c: NSUInteger): ID =
     cast[MsgSendIDUInt2](objc_msgSend)(self, op, a, b, c)
+
+  ## Selectors with one pointer, two NSUInteger and one object argument:
+  ## newBufferWithBytesNoCopy:length:options:deallocator: (nil deallocator).
+  template msgSend*(self: ID, op: SEL, a: pointer, b: NSUInteger, c: NSUInteger, d: ID): ID =
+    cast[MsgSendPtrUInt2ID](objc_msgSend)(self, op, a, b, c, d)
 
   ## Selectors with two MTLSize arguments:
   ## dispatchThreadgroups:threadsPerThreadgroup:.

--- a/workspace/crucible/src/runtime/engines/metal.nim
+++ b/workspace/crucible/src/runtime/engines/metal.nim
@@ -14,8 +14,16 @@
 ## blk is dispatch-time, so run validates it against the Apple Silicon 1024-thread limit.
 ## Scalars (ArgBlob size < 0) pack into one shared constant buffer at 16-byte slots,
 ## bound per index via `setBuffer:offset:atIndex:`.
-## The output reads back directly from `contents()` after `waitUntilCompleted`.
-## No staging buffer exists in the code path.
+## No-copy binding: page-aligned host memory with a byte length that is a multiple
+## of the page size yields a wrapper over the caller's bytes, cached
+## per (pointer, size), so binding allocates nothing and copies nothing.
+## Any other length gets a shared buffer, copied in before launch and copied back
+## after the wait.
+## A wrap the driver refuses is a hard error rather than a slower run, there is no
+## fallback to the copied path.
+## Output reads back in place for a no-copy binding, or through `contents()` once
+## `waitUntilCompleted` returns for an allocated buffer. No staging buffer exists
+## in the code path.
 ##
 ## The device context (`initMetal`) lives in `exec/metal_runtime`
 ## (imported below). This module owns the engine and its RAII `=destroy` hook.
@@ -50,15 +58,24 @@ type
     ctx: MetalCtx
 
   MetalCache = object
-    ## Two-level cache: the compiled library (level 1, keyed by the source it was built from)
-    ## and per-kernel-name compute pipeline states (level 2).
-    ## Re-ingest replaces the library and clears the pipeline states.
+    ## Four per-engine caches: the compiled library, the compute pipeline states,
+    ## the no-copy wrapper table, the packed-scalar buffer.
+    ## The library is keyed by the source it was built from, the pipeline states
+    ## by kernel name, the wrapper table by (host pointer, byte length). Re-ingest
+    ## replaces the library and clears the pipeline states.
+    ## A wrapper hit is revalidated against the VM map before reuse, see
+    ## `cachedWrap`. `scalarBuf` holds the packed scalar args, contents memcpy'd
+    ## in per run, capacity grown on demand.
     library: objc.ID
     psos: Table[string, objc.ID]
+    bufs: Table[(pointer, int), objc.ID]
+    scalarBuf: MetalBuffer
+    scalarCap: int
 
   MetalEngine* = ref object
-    ## `source` plus the RAII value fields `ctx` (device + queue) and `cache` (library + PSOs),
-    ## which release their +1 Objective-C objects when the engine ref is destroyed.
+    ## `source` plus the RAII value fields `ctx` (device + queue) and `cache`
+    ## (library, pipeline states, wrapper table, scalar buffer), which release
+    ## their +1 Objective-C objects when the engine ref is destroyed.
     source: string
     ctx: MetalDeviceCtx
     cache: MetalCache   # after ctx: released before ctx shutdown
@@ -95,23 +112,37 @@ when defined(macosx):
       objc.release(ctx.ctx.queue)
       objc.release(ctx.ctx.device)
 
+  proc dropBufferCache(cache: var MetalCache) =
+    ## Release and empty all cached wrappers. Sound only between runs: each run ends
+    ## with waitUntilCompleted, so no in-flight command still holds a binding.
+    ## Release drops GPU mappings, never host pages.
+    for buf in cache.bufs.values:
+      var b = MetalBuffer(buffer: buf, data: nil)
+      objc.release(b.buffer)
+    cache.bufs.clear()
+
   proc `=destroy`(cache: var MetalCache) =
-    ## Releases the library and cached pipeline states while the device is still alive:
-    ## this field is declared after `ctx`,
-    ## so reverse-order field destruction runs it before `ctx`'s `=destroy` releases the device.
-    ## Runs inside a pool for the same reason as `MetalDeviceCtx`.
+    ## Frees the library, pipeline states, wrapper cache and scalar buffer
+    ## while the device is still alive: declared after `ctx`, so reverse-order
+    ## field destruction runs it first. Pooled, same reason as `MetalDeviceCtx`.
     objc.withMemPool:
       objc.release(cache.library)
       for pso in cache.psos.values:
         objc.release(pso)
       cache.psos.clear()
+      dropBufferCache(cache)
+      var sb = cache.scalarBuf
+      releaseBuffer(sb)
+      cache.scalarBuf = MetalBuffer(buffer: objc.ID(nil), data: nil)
+      cache.scalarCap = 0
 
   proc newMetalEngine*(): MetalEngine =
     ## Factory reached by engines.nim via `import {.all.}`.
     objc.withMemPool:
       result = MetalEngine(
         ctx: MetalDeviceCtx(ctx: initMetal()),
-        cache: MetalCache(psos: initTable[string, objc.ID]())
+        cache: MetalCache(psos: initTable[string, objc.ID](),
+                          bufs: initTable[(pointer, int), objc.ID]())
       )
 
   # ─────────────────────────────────────────────────────────────────────────
@@ -143,6 +174,60 @@ when defined(macosx):
     objc.withMemPool:
       result = objc.nsStringToNimString(objc.msgSend(engine.ctx.ctx.device, objc.`$$`("name")))
 
+  const BufCacheMax = 64
+
+  func eligibleNoCopy(data: pointer, size: int): bool {.inline.} =
+    ## Page-aligned `data` and a `size` that is a multiple of the host page size:
+    ## the two newBufferWithBytesNoCopy requirements. The predicate reports whether
+    ## a binding would be legal for the length given, it cannot tell whether
+    ## the caller's memory covers that length.
+    size > 0 and data != nil and
+      (cast[uint](data) mod hostPageSize().uint) == 0'u and
+      (size mod hostPageSize()) == 0
+
+  proc cachedWrap(engine: MetalEngine, data: pointer, size: int): MetalBuffer =
+    ## No-copy view cache: one MTLBuffer wrapper per (pointer, size), reused
+    ## across runs, avoiding the per-dispatch create+release cost.
+    ##
+    ## Dataflow: caller-owned host memory → no-copy wrapper over shared storage →
+    ## GPU reads and writes alias the caller's bytes directly. The cache holds
+    ## wrappers only, memory ownership never transfers.
+    ##
+    ## Liveness, one syscall per hit (`hostRangeLive`), never an allocation:
+    ## - memory still mapped under the same (pointer, size): hit and rewrap give
+    ##   the same view of the same bytes, return the cached wrapper.
+    ## - memory unmapped, or remapped so the old range is only partly live:
+    ##   the wrapper no longer describes what the caller named, drop it
+    ##   (release, then rewrap).
+    ## - memory remapped at the same address with the same byte length, entirely:
+    ##   indistinguishable from a hit, the one hole in a VM-map check. See TODO.
+    ##
+    ## Preconditions: `data` page-aligned, `size` a multiple of the page size and no
+    ## larger than the caller's allocation behind it, and that memory outliving
+    ## every wrapper on it.
+    ## `wrapBufferNoCopy` inherits Apple's nil-deallocator obligation.
+    ## Capacity is bounded at run entry (`runImpl`) only. Releasing an entry
+    ## the current run already bound would drop its last reference mid-encode.
+    ##
+    ## TODO: close the same-address remap hole before long-lived or foreign callers
+    ## bind through this cache. Tag entries with an allocator epoch or generation
+    ## (register/unregister at alloc/free) so a recycled (pointer, size) key misses
+    ## the cache and rewraps.
+    let key = (data, size)
+    if engine.cache.bufs.hasKey(key):
+      if hostRangeLive(data, size):
+        result = MetalBuffer(buffer: engine.cache.bufs[key], data: data)
+        return
+      # Unmapped or remapped in pieces: the wrapper no longer describes the memory
+      # the caller named, so release it and wrap the current bytes.
+      var stale = MetalBuffer(buffer: engine.cache.bufs[key], data: nil)
+      objc.release(stale.buffer)
+      engine.cache.bufs.del(key)
+      when defined(debug):
+        echo "[INFO]: metal no-copy cache: extent not mapped, re-wrapping"
+    result = wrapBufferNoCopy(engine.ctx.ctx.device, data, size)
+    engine.cache.bufs[key] = result.buffer
+
   # ─────────────────────────────────────────────────────────────────────────
   # ▸ PRIVATE run path
   # ─────────────────────────────────────────────────────────────────────────
@@ -153,8 +238,10 @@ when defined(macosx):
     ## The output is the kernel's first parameter (binding 0), then the input args in order:
     ##   device buffers for size ≥ 0,
     ##   constant-buffer slots for size < 0.
-    ## The output's current bytes are uploaded before launch (in-place β·C)
-    ## and read back after waitUntilCompleted.
+    ## Page-aligned memory with a byte length that is a page multiple binds no-copy,
+    ## and the GPU aliases the caller's bytes, see `cachedWrap`. Any other length
+    ## allocates a shared buffer, memcpy in before launch (in-place β·C) and memcpy
+    ## back after waitUntilCompleted.
     objc.withMemPool:
       # blk is dispatch-time, so run validates the launch geometry.
       if cfg.grid.x < 1 or cfg.grid.y < 1 or cfg.grid.z < 1:
@@ -187,30 +274,62 @@ when defined(macosx):
                                    engine.cache.library, kernel)
         engine.cache.psos[kernel] = pso
 
-      # Buffers: output + size ≥ 0 inputs (shared storage, memcpy in).
-      # The size < 0 scalars pack into one shared constant buffer at 16-byte slots.
+      # Buffers: the output plus every input with size ≥ 0. Eligible ones wrap host
+      # memory no-copy, so the kernel reads and writes the bytes the caller passed,
+      # in place. Any other length allocates a fresh shared buffer and copies
+      # in/out.
+      # Per-call buffers (fresh allocations) release at scope exit, and no-copy
+      # wrappers stay in the cache.
+      # Wrapper-cache capacity, bounded between runs. At run entry no wrapper bound
+      # by this run exists yet, so eviction cannot drop one the encoder still
+      # references. One run may take the table past the bound through its own
+      # distinct (pointer, size) keys.
+      if engine.cache.bufs.len >= BufCacheMax:
+        dropBufferCache(engine.cache)
       let outSize = output.size
-      var outBuf = allocBuffer(engine.ctx.ctx.device, outSize)
+      var outBuf: MetalBuffer
+      var outWrapped = false
+      if eligibleNoCopy(output.data, outSize):
+        outBuf = cachedWrap(engine, output.data, outSize)
+        outWrapped = true
+      else:
+        outBuf = allocBuffer(engine.ctx.ctx.device, outSize)
+        if outSize > 0:
+          copyMem(outBuf.data, output.data, outSize)
+      # Body-level defer: a defer inside the else block would fire at the end
+      # of that block, before the encode.
       defer:
-        releaseBuffer(outBuf)
-      if outSize > 0:
-        copyMem(outBuf.data, output.data, outSize)
+        if not outWrapped:
+          releaseBuffer(outBuf)
 
       var inputBuffers = newSeq[MetalBuffer](blobs.len)
+      var perCallBuffers = newSeq[MetalBuffer]()
       var scalarCount = 0
       for i in 0 ..< blobs.len:
         if blobs[i].size >= 0:
-          inputBuffers[i] = allocBuffer(engine.ctx.ctx.device, blobs[i].size)
-          copyMem(inputBuffers[i].data, blobs[i].data, blobs[i].size)
+          if eligibleNoCopy(blobs[i].data, blobs[i].size):
+            inputBuffers[i] = cachedWrap(engine, blobs[i].data, blobs[i].size)
+          else:
+            inputBuffers[i] = allocBuffer(engine.ctx.ctx.device, blobs[i].size)
+            perCallBuffers.add inputBuffers[i]
+            copyMem(inputBuffers[i].data, blobs[i].data, blobs[i].size)
         else:
           inc scalarCount
       defer:
-        for b in mitems(inputBuffers):
+        for b in mitems(perCallBuffers):
           releaseBuffer(b)
 
+      # The size < 0 scalars pack into one persistent shared constant buffer
+      # at 16-byte slots (capacity grown on demand, contents memcpy'd in per run).
       var scalarBuf: MetalBuffer
       if scalarCount > 0:
-        scalarBuf = allocBuffer(engine.ctx.ctx.device, scalarCount * ScalarSlotStride)
+        let needed = scalarCount * ScalarSlotStride
+        if needed > engine.cache.scalarCap:
+          var old = engine.cache.scalarBuf
+          releaseBuffer(old)
+          engine.cache.scalarBuf = allocBuffer(engine.ctx.ctx.device, needed)
+          engine.cache.scalarCap = needed
+        scalarBuf = engine.cache.scalarBuf
         let dst = cast[ptr UncheckedArray[byte]](scalarBuf.data)
         var slot = 0
         for i in 0 ..< blobs.len:
@@ -222,8 +341,6 @@ when defined(macosx):
                        "-byte constant-buffer slot")
             copyMem(addr dst[slot * ScalarSlotStride], blobs[i].data, sz)
             inc slot
-      defer:
-        releaseBuffer(scalarBuf)
 
       # Encode: pipeline, buffers, dispatch, commit, wait.
       let cmdBuf = objc.msgSend(engine.ctx.ctx.queue, objc.`$$`("commandBuffer"))
@@ -264,9 +381,11 @@ when defined(macosx):
         failLoud("Metal run: command buffer failed (status " & $status &
                  " [" & $MTLCommandBufferStatusError & "=error]): " & detail)
 
-      # Direct readback: contents() is CPU-visible after waitUntilCompleted on shared-storage buffers.
+      # Readback: a no-copy output already holds its result in the memory the caller
+      # passed, because for shared-storage buffers contents() is CPU-visible once
+      # waitUntilCompleted returns. Allocated buffers copy back.
       # No staging buffer exists here.
-      if outSize > 0:
+      if outSize > 0 and not outWrapped:
         copyMem(output.data, outBuf.data, outSize)
 
 # ═════════════════════════════════════════════════

--- a/workspace/crucible/src/runtime/exec/metal_runtime.nim
+++ b/workspace/crucible/src/runtime/exec/metal_runtime.nim
@@ -197,3 +197,52 @@ when defined(macosx):
       objc.release(buffer.buffer)
       buffer.buffer = objc.ID(nil)
       buffer.data = nil
+
+  proc getpagesize(): cint {.importc: "getpagesize", header: "<unistd.h>".}
+
+  proc madvise(data: pointer, length: csize_t, advice: cint): cint
+    {.importc: "madvise", header: "<sys/mman.h>", sideEffect.}
+
+  const MadvNormal = 0                # MADV_NORMAL: default page reclamation
+
+  proc hostRangeLive*(data: pointer, size: int): bool =
+    ## Mapping check: true when every byte of [data, data+size) is mapped.
+    ## madvise(MADV_NORMAL) walks the VM map without touching pages
+    ## and without changing any byte or permission. Its defined effect is resetting
+    ## the range's paging advice to the machine default, so an advisory hint the caller had set
+    ## on that memory comes back cleared.
+    ## - ENOMEM (unmapped) or EINVAL (hole, advice-refusing mapping): false means
+    ##   "not proven mapped", never "proven freed".
+    ## - Mapped is not owned: the caller keeps ownership of the memory.
+    ##   The same-address remap hole is documented at `cachedWrap`.
+    ## Precondition: page-aligned data and a byte length that is a page multiple.
+    madvise(data, csize_t(size), MadvNormal) == 0
+
+  proc hostPageSize*(): int =
+    ## Host page size (16 KiB on Apple Silicon). NoCopy binding requires it
+    ## for both the pointer and the length.
+    int(getpagesize())
+
+  proc wrapBufferNoCopy*(device: objc.ID, data: pointer, size: int): MetalBuffer =
+    ## Shared no-copy view over page-aligned host memory: no allocation, no copy,
+    ## the GPU aliases the caller's bytes in place.
+    ## Contract: `data` page-aligned, `size` a page-size multiple and no larger
+    ## than the caller's allocation behind it, and that memory outliving the buffer,
+    ## which holds no reference to it (nil deallocator). Release tears down
+    ## the mapping only, never touching host pages.
+    ## Quits loudly on non-positive `size`, an unaligned `data`, a `size`
+    ## that is not a page multiple, or a nil buffer from the driver.
+    ## Returns +1, released via `releaseBuffer`.
+    if size <= 0:
+      failLoud("wrapBufferNoCopy: size must be positive, got " & $size)
+    if (cast[uint](data) mod hostPageSize().uint) != 0'u:
+      failLoud("wrapBufferNoCopy: data pointer is not page-aligned " &
+               "(page size " & $hostPageSize() & ")")
+    if (size mod hostPageSize()) != 0:
+      failLoud("wrapBufferNoCopy: size " & $size & " is not a page-size " &
+               "multiple (page size " & $hostPageSize() & ")")
+    result.buffer = objc.msgSend(device, objc.`$$`("newBufferWithBytesNoCopy:length:options:deallocator:"),
+                                data, objc.NSUInteger(size), SharedUntrackedOptions, objc.ID(nil))
+    if objc.isNil(result.buffer):
+      failLoud("newBufferWithBytesNoCopy returned nil (length " & $size & ")")
+    result.data = data


### PR DESCRIPTION
GEMM on Apple GPU was stuck at 7TFlops despite MLX reaching 15TFlops on a M4 Max.

The issue was that when initiating Metal buffers we were copying, which is unnecessary on an unified memory device.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved Apple GPU execution for eligible page-aligned buffers by avoiding unnecessary memory copies.
  * Reused scalar storage across runs to reduce repeated allocation overhead.
  * Added benchmark coverage for linear, matrix multiplication, strided operations, and dispatch overhead.

* **Validation**
  * Added bit-exactness checks for bias and AXPY operations.
  * Added safeguards to detect invalid or stale no-copy buffer configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->